### PR TITLE
ci: split into lint and cross-platform test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - uses: actions/setup-node@v4
         with:
@@ -43,8 +41,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 8
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build shared types
-        run: pnpm --filter @system2/shared build
+      - name: Build
+        run: pnpm build
 
       - name: Lint & format
         run: pnpm check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ on:
     branches: [main]
 
 jobs:
-  check:
-    name: Build, Lint & Test
+  lint-and-format:
+    name: Code Quality Checks
     runs-on: ubuntu-latest
 
     steps:
@@ -30,6 +30,28 @@ jobs:
 
       - name: Type check
         run: pnpm typecheck
+
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Build shared types
+        run: pnpm --filter @system2/shared build
+
       - name: Lint & format
         run: pnpm check
 

--- a/packages/server/src/agents/tools/bash.test.ts
+++ b/packages/server/src/agents/tools/bash.test.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { existsSync, mkdirSync, rmSync } from 'node:fs';
+import { platform, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AgentToolUpdateCallback } from '@mariozechner/pi-agent-core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createBashTool } from './bash.js';
+
+const isWindows = platform() === 'win32';
 
 function makeTmpDir(): string {
   const dir = join(tmpdir(), `system2-test-bash-${randomUUID().slice(0, 8)}`);
@@ -61,9 +63,11 @@ describe('bash tool', () => {
 
     it('uses custom cwd', async () => {
       const dir = trackDir(makeTmpDir());
-      const result = await exec({ command: 'pwd', cwd: dir });
+      const marker = `marker-${randomUUID().slice(0, 8)}`;
+      const cmd = isWindows ? `New-Item -Name ${marker} -ItemType File` : `touch ${marker}`;
+      await exec({ command: cmd, cwd: dir });
 
-      expect((result.content[0] as { text: string }).text.trim()).toContain(dir);
+      expect(existsSync(join(dir, marker))).toBe(true);
     });
 
     it('returns error when signal is already aborted', async () => {

--- a/packages/ui/src/components/MessageList.tsx
+++ b/packages/ui/src/components/MessageList.tsx
@@ -433,7 +433,7 @@ function AssistantMessageBlock({ message, isLast }: { message: Message; isLast: 
     <Fragment>
       {/* Turn events in chronological order (thinking blocks and tool calls) */}
       {hasTurnEvents &&
-        message.turnEvents?.map((event) => (
+        message.turnEvents?.map((event: TurnEvent) => (
           <TurnEventItem
             key={event.type === 'thinking' ? event.data.id : event.data.id}
             event={event}


### PR DESCRIPTION
## Summary
- Split the single CI job into two: **Code Quality Checks** (lint, format, typecheck on Ubuntu) and **test** (build + test)
- Test job runs on a matrix of Ubuntu, macOS, and Windows with `fail-fast: false`
- Validates native dependencies (better-sqlite3) build correctly across platforms

## Test plan
- [x] Verify all 4 CI jobs pass (Code Quality Checks, test ubuntu/macos/windows)
- [x] Confirm job names match what's needed for branch protection rules