### PR TITLE
docs: update ring buffer default, add message delivery overview

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -103,6 +103,11 @@ The `/api/agents` endpoint combines DB agent records with in-memory runtime stat
 
 ## Message Delivery
 
+Messages flow through two paths depending on whether the sender is the user or another agent:
+
+- **User → Guide → User**: the UI sends a `user_message` over WebSocket. The `WebSocketHandler` calls `agentHost.prompt()`, which blocks while the agent processes. As the agent thinks, generates text, and executes tools, session events stream back through the WebSocket as typed `ServerMessage` chunks. Chat history is captured in a server-side ring buffer (default 1000 messages) and replayed on reconnect, so the UI is stateless. See [WebSocket Protocol](websocket-protocol.md) for the full message format, queuing, multi-tab broadcast, and history capture.
+- **Agent → Agent**: agents communicate via `deliverMessage()`, which wraps the Pi SDK's `sendCustomMessage()`. Messages appear as `custom_message` entries in the recipient's session. The Guide relays relevant agent updates to the user as part of its normal response stream.
+
 Two methods for sending messages, chosen based on the sender:
 
 | Method | Creates | Used By | Behavior |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,7 +74,7 @@ max_archives = 5            # Max rotated log files
 daily_summary_interval_minutes = 30  # Narrator summary frequency
 
 [chat]
-max_history_messages = 100  # Max messages in chat history ring buffer
+max_history_messages = 1000  # Max messages in chat history ring buffer
 ```
 
 ## Sections
@@ -135,7 +135,7 @@ See [Agents](agents.md#authresolver-auth-resolverts) for implementation details.
 ├── .git/                  # Version control for text files
 ├── config.toml            # Settings and credentials (0600)
 ├── app.db                 # SQLite database
-├── chat-history.json      # Chat message ring buffer (max 100)
+├── chat-history.json      # Chat message ring buffer (max 1000)
 ├── server.pid             # PID file when server is running
 ├── knowledge/
 │   ├── infrastructure.md  # Data stack details (Guide)

--- a/docs/packages/server.md
+++ b/docs/packages/server.md
@@ -49,7 +49,7 @@ The `Server` class is the main entry point. It accepts a `ServerConfig` and orch
 3. Create `AgentRegistry`
 4. Create Guide agent (singleton via `db.getOrCreateGuideAgent()`)
 5. Create Narrator agent (singleton via `db.getOrCreateNarratorAgent()`)
-6. Create `MessageHistory` (ring buffer, default 100 messages)
+6. Create `MessageHistory` (ring buffer, default 1000 messages)
 7. Subscribe once to Guide agent events for assistant message history capture (prevents duplicates with multiple tabs)
 8. Create `Scheduler`
 9. Set up Express routes

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -11,7 +11,7 @@ The UI communicates with the server over a single WebSocket connection. The serv
 
 WebSocket connects to the server port (default 3000). In development, Vite proxies `ws://localhost:3001/ws` to the backend.
 
-On connect, the server sends a `chat_history` message with recent messages from `MessageHistory` (ring buffer, default 100 messages). The server is the single source of truth for chat history: the UI does not persist messages.
+On connect, the server sends a `chat_history` message with recent messages from `MessageHistory` (ring buffer, default 1000 messages). The server is the single source of truth for chat history: the UI does not persist messages.
 
 ## Client -> Server
 


### PR DESCRIPTION
## Summary
- Update chat history ring buffer default references from 100 to 1000 across configuration, server, and WebSocket docs
- Add high-level message delivery overview to agents.md explaining user-to-Guide and agent-to-agent communication paths