### PR TITLE
fix(ui): enforce minimum particle speed

### DIFF
--- a/packages/ui/src/components/MinSpeedUpdater.test.ts
+++ b/packages/ui/src/components/MinSpeedUpdater.test.ts
@@ -1,0 +1,69 @@
+import type { Particle } from '@tsparticles/engine';
+import { describe, expect, it } from 'vitest';
+import { MIN_SPEED, MinSpeedUpdater } from './MinSpeedUpdater';
+
+interface MockVelocity {
+  x: number;
+  y: number;
+  length: number;
+}
+
+function mockParticle(vx: number, vy: number) {
+  const velocity: MockVelocity = {
+    x: vx,
+    y: vy,
+    get length() {
+      return Math.sqrt(this.x ** 2 + this.y ** 2);
+    },
+    set length(len: number) {
+      const angle = Math.atan2(this.y, this.x);
+      this.x = Math.cos(angle) * len;
+      this.y = Math.sin(angle) * len;
+    },
+  };
+  return { velocity };
+}
+
+describe('MinSpeedUpdater', () => {
+  const updater = new MinSpeedUpdater();
+
+  it('preserves speed at or above minimum', () => {
+    const p = mockParticle(0.8, 0);
+    updater.update(p as unknown as Particle);
+    expect(p.velocity.length).toBeCloseTo(0.8);
+  });
+
+  it('boosts speed below minimum while preserving direction', () => {
+    const p = mockParticle(0.1, 0);
+    updater.update(p as unknown as Particle);
+    expect(p.velocity.length).toBeCloseTo(MIN_SPEED);
+    expect(p.velocity.x).toBeGreaterThan(0);
+    expect(p.velocity.y).toBeCloseTo(0);
+  });
+
+  it('boosts diagonal velocity while preserving direction', () => {
+    const p = mockParticle(0.05, 0.05);
+    const angleBefore = Math.atan2(p.velocity.y, p.velocity.x);
+    updater.update(p as unknown as Particle);
+    const angleAfter = Math.atan2(p.velocity.y, p.velocity.x);
+    expect(p.velocity.length).toBeCloseTo(MIN_SPEED);
+    expect(angleAfter).toBeCloseTo(angleBefore);
+  });
+
+  it('assigns random direction when velocity is exactly zero', () => {
+    const p = mockParticle(0, 0);
+    updater.update(p as unknown as Particle);
+    expect(p.velocity.length).toBeCloseTo(MIN_SPEED);
+  });
+
+  it('does not cap speed above minimum', () => {
+    const p = mockParticle(2, 0);
+    updater.update(p as unknown as Particle);
+    expect(p.velocity.length).toBeCloseTo(2);
+  });
+
+  it('is always enabled', () => {
+    const p = mockParticle(0, 0);
+    expect(updater.isEnabled(p as unknown as Particle)).toBe(true);
+  });
+});

--- a/packages/ui/src/components/MinSpeedUpdater.ts
+++ b/packages/ui/src/components/MinSpeedUpdater.ts
@@ -1,0 +1,22 @@
+import type { IParticleUpdater, Particle } from '@tsparticles/engine';
+
+export const MIN_SPEED = 0.5;
+
+export class MinSpeedUpdater implements IParticleUpdater {
+  init(_particle: Particle) {}
+
+  isEnabled(_particle: Particle) {
+    return true;
+  }
+
+  update(particle: Particle) {
+    const speed = particle.velocity.length;
+    if (speed === 0) {
+      const angle = Math.random() * Math.PI * 2;
+      particle.velocity.x = Math.cos(angle) * MIN_SPEED;
+      particle.velocity.y = Math.sin(angle) * MIN_SPEED;
+    } else if (speed < MIN_SPEED) {
+      particle.velocity.length = MIN_SPEED;
+    }
+  }
+}

--- a/packages/ui/src/components/ParticlesBackground.tsx
+++ b/packages/ui/src/components/ParticlesBackground.tsx
@@ -1,9 +1,26 @@
-import type { Container } from '@tsparticles/engine';
+import type { Container, IParticleUpdater, Particle } from '@tsparticles/engine';
 import Particles, { initParticlesEngine } from '@tsparticles/react';
 import { loadSlim } from '@tsparticles/slim';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { colors } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
+
+const MIN_SPEED = 0.5;
+
+class MinSpeedUpdater implements IParticleUpdater {
+  init(_particle: Particle) {}
+
+  isEnabled(_particle: Particle) {
+    return true;
+  }
+
+  update(particle: Particle) {
+    const speed = particle.velocity.length;
+    if (speed > 0 && speed < MIN_SPEED) {
+      particle.velocity.length = MIN_SPEED;
+    }
+  }
+}
 
 export const ParticlesBackground = memo(function ParticlesBackground() {
   const [engineReady, setEngineReady] = useState(false);
@@ -12,6 +29,7 @@ export const ParticlesBackground = memo(function ParticlesBackground() {
   useEffect(() => {
     initParticlesEngine(async (engine) => {
       await loadSlim(engine);
+      await engine.addParticleUpdater('minSpeed', async () => new MinSpeedUpdater());
     }).then(() => setEngineReady(true));
   }, []);
 

--- a/packages/ui/src/components/ParticlesBackground.tsx
+++ b/packages/ui/src/components/ParticlesBackground.tsx
@@ -11,10 +11,16 @@ export const ParticlesBackground = memo(function ParticlesBackground() {
   const { accent } = useAccentColors();
 
   useEffect(() => {
+    let cancelled = false;
     initParticlesEngine(async (engine) => {
       await loadSlim(engine);
       await engine.addParticleUpdater('minSpeed', async () => new MinSpeedUpdater());
-    }).then(() => setEngineReady(true));
+    }).then(() => {
+      if (!cancelled) setEngineReady(true);
+    });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // canvas.windowResize() is called by the tsparticles window resize event listener.

--- a/packages/ui/src/components/ParticlesBackground.tsx
+++ b/packages/ui/src/components/ParticlesBackground.tsx
@@ -1,26 +1,10 @@
-import type { Container, IParticleUpdater, Particle } from '@tsparticles/engine';
+import type { Container } from '@tsparticles/engine';
 import Particles, { initParticlesEngine } from '@tsparticles/react';
 import { loadSlim } from '@tsparticles/slim';
 import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { colors } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
-
-const MIN_SPEED = 0.5;
-
-class MinSpeedUpdater implements IParticleUpdater {
-  init(_particle: Particle) {}
-
-  isEnabled(_particle: Particle) {
-    return true;
-  }
-
-  update(particle: Particle) {
-    const speed = particle.velocity.length;
-    if (speed > 0 && speed < MIN_SPEED) {
-      particle.velocity.length = MIN_SPEED;
-    }
-  }
-}
+import { MinSpeedUpdater } from './MinSpeedUpdater';
 
 export const ParticlesBackground = memo(function ParticlesBackground() {
   const [engineReady, setEngineReady] = useState(false);


### PR DESCRIPTION
## Summary

- Register a custom tsparticles `IParticleUpdater` that checks each particle's velocity magnitude every frame and rescales it to 0.5 if it drops below that threshold (preserving direction)
- Fixes the issue where particles gradually stop after long sessions due to energy loss from inelastic bounce collisions

## Test plan

- [ ] Open the UI and let it run for an extended period (30+ min); verify particles never stop moving
- [ ] Hover to trigger attract interaction and confirm particles recover speed after release
- [ ] Verify no visual artifacts from the speed floor (collisions should still look natural)