### PR TITLE
style(ui): lower context usage color thresholds

### DIFF
--- a/docs/packages/ui.md
+++ b/docs/packages/ui.md
@@ -73,7 +73,7 @@ Each assistant message shows its turn events (thinking -> tool calls -> response
 
 ### MessageInput
 
-Auto-growing textarea (1-10 lines, then scrolls). Shows the current LLM provider name and context window usage percentage (turns red above 80%) in the status bar, plus queued message count. Toggles between Send and Stop buttons based on streaming state. Provider changes on failover trigger a system message in the chat timeline.
+Auto-growing textarea (1-10 lines, then scrolls). Shows the current LLM provider name and context window usage percentage (teal below 50%, accent 50-69%, coral at 70%+) in the status bar, plus queued message count. Toggles between Send and Stop buttons based on streaming state. Provider changes on failover trigger a system message in the chat timeline.
 
 ### ArtifactViewer
 

--- a/packages/ui/src/components/AgentPane.tsx
+++ b/packages/ui/src/components/AgentPane.tsx
@@ -9,7 +9,7 @@ import { ChevronDownIcon, ChevronRightIcon } from '@primer/octicons-react';
 import { Box, Text } from '@primer/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { POLL_ERROR_BACKOFF_MS, POLL_INTERVAL_MS } from '../constants';
-import { colors } from '../theme/colors';
+import { colors, contextColor } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
 
 interface AgentInfo {
@@ -48,12 +48,6 @@ function TableHeaders() {
       ))}
     </Box>
   );
-}
-
-function contextColor(percent: number, accent: string): string {
-  if (percent >= 90) return colors.coral;
-  if (percent >= 60) return accent;
-  return colors.teal;
 }
 
 export function AgentPane() {

--- a/packages/ui/src/components/MessageInput.tsx
+++ b/packages/ui/src/components/MessageInput.tsx
@@ -10,7 +10,7 @@ import { ArrowUpIcon, SquareFillIcon } from '@primer/octicons-react';
 import { Box } from '@primer/react';
 import { useRef, useState } from 'react';
 import { useChatStore } from '../stores/chat';
-import { colors } from '../theme/colors';
+import { colors, contextColor } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
 
 const LINE_HEIGHT = 20; // px per line
@@ -68,7 +68,7 @@ export function MessageInput({ onSend, onQueue, onAbort }: MessageInputProps) {
     textarea.style.overflowY = textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
   };
 
-  const contextColor = contextPercent !== null && contextPercent > 80 ? colors.coral : accent;
+  const ctxColor = contextPercent !== null ? contextColor(contextPercent, accent) : colors.teal;
 
   return (
     <Box
@@ -207,7 +207,7 @@ export function MessageInput({ onSend, onQueue, onAbort }: MessageInputProps) {
                   cy="8"
                   r="7"
                   fill="none"
-                  stroke={contextColor}
+                  stroke={ctxColor}
                   strokeWidth="2"
                   strokeDasharray={`${(contextPercent / 100) * 44} 44`}
                   strokeLinecap="round"

--- a/packages/ui/src/theme/colors.test.ts
+++ b/packages/ui/src/theme/colors.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { colors, contextColor } from './colors';
+
+describe('contextColor', () => {
+  const accent = '#ffb444';
+
+  it('returns teal below 50%', () => {
+    expect(contextColor(0, accent)).toBe(colors.teal);
+    expect(contextColor(49, accent)).toBe(colors.teal);
+    expect(contextColor(49.9, accent)).toBe(colors.teal);
+  });
+
+  it('returns accent from 50% to 69%', () => {
+    expect(contextColor(50, accent)).toBe(accent);
+    expect(contextColor(60, accent)).toBe(accent);
+    expect(contextColor(69.9, accent)).toBe(accent);
+  });
+
+  it('returns coral at 70% and above', () => {
+    expect(contextColor(70, accent)).toBe(colors.coral);
+    expect(contextColor(85, accent)).toBe(colors.coral);
+    expect(contextColor(100, accent)).toBe(colors.coral);
+  });
+});

--- a/packages/ui/src/theme/colors.ts
+++ b/packages/ui/src/theme/colors.ts
@@ -53,3 +53,10 @@ export const palettes = {
     accentText: '#ffffff',
   },
 } as const satisfies Record<string, ThemePalette>;
+
+/** Map a context-usage percentage to a severity color. */
+export function contextColor(percent: number, accent: string): string {
+  if (percent >= 70) return colors.coral;
+  if (percent >= 50) return accent;
+  return colors.teal;
+}


### PR DESCRIPTION
## Summary

- Lower context color thresholds: teal < 50%, theme accent 50-69%, coral >= 70% (was 60/90 in AgentPane, 80 in MessageInput)
- Extract `contextColor()` into `colors.ts` so both components share a single source of truth
- Add unit tests for `contextColor()` boundary values

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (239 tests, 22 files)
- [ ] Visual: verify Narrator at ~53% now shows accent color in both agent pane and message input gauge