### PR TITLE
feat(agents): resurrect_agent tool for project restart

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -22,7 +22,7 @@ System2's agents are built on the [pi-coding-agent](https://github.com/badlogic/
 
 **Conductor and Reviewer** are project-scoped, spawned by Guide for every project and archived when done. The Guide uses the `spawn_agent` tool to create both simultaneously at project creation time. Spawned agents receive the same spawner callback, so Conductors can spawn additional specialist data agents within their own project. On server restart, all non-archived project-scoped agents are restored automatically. If an agent fails to restore, its status remains `active` in the database, the error is logged, and the Guide is notified so it can investigate.
 
-**Agent status** has two values in the database: `active` (alive, should be restored on restart) and `archived` (terminated, will not be restored). Whether an agent is currently processing work is tracked in memory via `AgentHost.isBusy()`, not in the database.
+**Agent status** has two values in the database: `active` (alive, should be restored on restart) and `archived` (terminated, will not be restored). Archived agents can be resurrected by the Guide via the `resurrect_agent` tool, which flips the status back to `active` and resumes the session from persisted JSONL. Whether an agent is currently processing work is tracked in memory via `AgentHost.isBusy()`, not in the database.
 
 ## Agent Identity and System Instructions
 
@@ -216,6 +216,26 @@ The `terminate_agent` tool archives an agent when its work is done:
 
 Permission model mirrors spawning. Singleton agents (Guide, Narrator) cannot be terminated.
 
+### Resurrection
+
+The `resurrect_agent` tool brings back an archived agent. Only the Guide may use it. Internally, the server:
+
+1. Validates the target is archived and not a singleton
+2. Calls `db.updateAgentStatus(id, 'active')`
+3. Creates a new `AgentHost` via `initializeAgentHost()`, which resumes the agent's session from its persisted JSONL history
+4. Registers the agent in `AgentRegistry`
+5. Delivers the Guide's context message via `deliverMessage()`
+
+If initialization fails, the DB status is rolled back to `archived`.
+
+**Session continuity:** since JSONL session files are preserved through termination (only the in-memory `AgentHost` is torn down), a resurrected agent retains its full conversation history. The Guide's context message should orient the agent about the time gap and the new objectives.
+
+**Project record cleanup:** after resurrection, the Guide must update the project record via `write_system2_db`: clear `end_at` and set status back to `in progress`.
+
+**Project log resumption:** the scheduler determines active projects by checking for non-archived conductors. Once a conductor is resurrected, the next scheduled run automatically resumes project log updates.
+
+**Project story on re-completion:** if `trigger_project_story` is called for a project that already has a `project_story.md`, the Narrator receives a note about the existing story and decides whether to edit or rewrite it.
+
 ### Project Lifecycle
 
 ```text
@@ -240,6 +260,15 @@ User request → Guide creates project in app.db
              → Conductor reports to Guide
              → Guide terminates Conductor + Reviewer
              → Guide updates project status to "done"
+
+--- Optional: Project Restart ---
+User request → Guide confirms resurrection is the right approach
+             → Guide queries archived agents for the project (read_system2_db)
+             → Guide resurrects Conductor (resurrect_agent)
+             → Guide resurrects Reviewer (resurrect_agent)
+             → Guide updates project: clear end_at, status → "in progress"
+             → Resurrected agents resume from persisted session history
+             → Normal project lifecycle continues from execution phase
 ```
 
 ---
@@ -409,7 +438,7 @@ DataAgent-Extract, DataAgent-Analyze, and Reviewer work through their tasks in d
 
 ## See Also
 
-- [Tools](tools.md): all tools available to agents, including spawn_agent and terminate_agent
+- [Tools](tools.md): all tools available to agents, including spawn_agent, terminate_agent, and resurrect_agent
 - [Knowledge System](knowledge-system.md): knowledge files injected into system prompts
 - [Database](database.md): app.db schema (projects, tasks, agents, task_links, task_comments)
 - [Scheduler](scheduler.md): how scheduled jobs deliver messages to Narrator

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -9,6 +9,7 @@ Tools are built in `AgentHost.buildTools()` (`packages/server/src/agents/host.ts
 - Eight tools are always included: `bash`, `read`, `edit`, `write`, `read_system2_db`, `write_system2_db`, `message_agent`, `web_fetch`
 - `show_artifact` is Guide-only: the Guide is the only agent that interacts with the user via the UI
 - `spawn_agent`, `terminate_agent`, and `trigger_project_story` are conditional: only agents that receive a spawner callback (Guide and Conductors) get these tools
+- `resurrect_agent` is Guide-only: only the Guide receives a resurrector callback
 - `web_search` is conditional on a Brave Search API key being configured
 
 ## Tool Reference
@@ -211,9 +212,27 @@ Archive an active agent: abort its session, unregister from `AgentRegistry`, and
 - Only Guide and Conductor roles may terminate agents
 - Conductors can only terminate agents in their own project
 
+### `resurrect_agent`
+
+Resurrect an archived agent: restore its session from persisted JSONL history, re-register it in `AgentRegistry`, and deliver a context message.
+
+| Parameter  | Type   | Description                                                                                                        |
+|------------|--------|--------------------------------------------------------------------------------------------------------------------|
+| `agent_id` | number | Database ID of the archived agent to resurrect                                                                     |
+| `message`  | string | Context message orienting the agent about the time gap, why it is being resurrected, and what work is now expected |
+
+**Permission model:**
+
+- Only the Guide may resurrect agents
+- Singleton agents (Guide, Narrator) cannot be resurrected
+- Already-active agents cannot be resurrected
+- On failure, the DB status is rolled back to `archived`
+
+**Conditional:** only registered when the `AgentHost` is created with a `resurrector` callback (Guide only).
+
 ## See Also
 
-- [Agents](agents.md): agent roles, lifecycle, spawn/terminate, work management
+- [Agents](agents.md): agent roles, lifecycle, spawn/terminate/resurrect, work management
 - [Database](database.md): schema for `read_system2_db` and `write_system2_db`
 - [Configuration](configuration.md): web search configuration
 - [UI](packages/ui.md): artifact display and postMessage bridge

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -36,12 +36,13 @@ You are a professional data expert. Accuracy is non-negotiable.
 
 **Only the Guide talks to the human user.** All other agents communicate exclusively with other agents via `message_agent` and task comments. If you are not the Guide, you never address the user directly.
 
-### Spawn and Terminate Permissions
+### Spawn, Terminate, and Resurrect Permissions
 
 | Action | Guide | Conductor | Narrator | Reviewer |
 |--------|-------|-----------|----------|----------|
 | Spawn agents | Any project | Own project only | No | No |
 | Terminate agents | Any non-singleton | Own project only | No | No |
+| Resurrect agents | Any archived non-singleton | No | No | No |
 | Be terminated | No (singleton) | Yes | No (singleton) | Yes |
 
 ## Your Tools
@@ -59,6 +60,7 @@ You are a professional data expert. Accuracy is non-negotiable.
 | `web_fetch` | Fetch a URL and extract readable text content | All agents |
 | `spawn_agent` | Spawn a new Conductor or Reviewer for a project | Guide, Conductors |
 | `terminate_agent` | Archive an agent — abort its session, unregister, mark archived | Guide, Conductors |
+| `resurrect_agent` | Bring back an archived agent — resume its session from persisted JSONL, re-register | Guide only |
 | `trigger_project_story` | Signal project completion: server creates story task, collects data, delivers to Narrator | Guide, Conductors |
 | `web_search` | Search the web via Brave Search API | All agents (when configured) |
 
@@ -66,6 +68,7 @@ You are a professional data expert. Accuracy is non-negotiable.
 - For modifying existing files, prefer `edit` (exact string replacement) over `write` (full overwrite). For bulk operations where neither is convenient, use `bash` with `sed`, `awk`, `>>`, or similar.
 - `bash` streams output as the command runs. Set `run_in_background` to true for long-running commands — you will receive the result as a follow-up message when the command finishes.
 - `spawn_agent`, `terminate_agent`, and `trigger_project_story` are only available to agents that receive a spawner callback (Guide and Conductors). Narrator and Reviewer cannot spawn, terminate, or trigger project stories.
+- `resurrect_agent` is Guide-only. The Guide receives a resurrector callback; no other agent can resurrect.
 - `web_search` is only available when a Brave Search API key is configured.
 - `show_artifact` is Guide-only (the Guide is the only agent that interacts with the user via the UI). Accepts an absolute path (or `~/`-prefixed). If the artifact is registered in the database, its title is used for the tab label; otherwise the filename is used. Only one artifact is watched at a time (for live reload).
 
@@ -125,7 +128,7 @@ Reference these tables when writing queries.
 | id | INTEGER PK | Auto-incrementing identifier |
 | role | TEXT | `guide`, `conductor`, `narrator`, `reviewer` |
 | project | INTEGER FK | Assigned project (NULL for Guide and Narrator) |
-| status | TEXT | `idle`, `active`, `archived` |
+| status | TEXT | `active`, `archived` |
 | created_at | TEXT | Row creation timestamp |
 | updated_at | TEXT | Last modification timestamp |
 

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -30,6 +30,7 @@ import { createEditTool } from './tools/edit.js';
 import { createMessageAgentTool } from './tools/message-agent.js';
 import { createReadTool } from './tools/read.js';
 import { createReadSystem2DbTool } from './tools/read-system2-db.js';
+import { type AgentResurrector, createResurrectAgentTool } from './tools/resurrect-agent.js';
 import { createShowArtifactTool } from './tools/show-artifact.js';
 import { type AgentSpawner, createSpawnAgentTool } from './tools/spawn-agent.js';
 import { createTerminateAgentTool } from './tools/terminate-agent.js';
@@ -74,6 +75,7 @@ export interface AgentHostConfig {
   servicesConfig?: ServicesConfig;
   toolsConfig?: ToolsConfig;
   spawner?: AgentSpawner;
+  resurrector?: AgentResurrector;
 }
 
 export class AgentHost {
@@ -84,6 +86,7 @@ export class AgentHost {
   private servicesConfig?: ServicesConfig;
   private toolsConfig?: ToolsConfig;
   private spawner?: AgentSpawner;
+  private resurrector?: AgentResurrector;
   private llmConfig: LlmConfig;
   private authResolver: AuthResolver;
   private modelRegistry: ModelRegistry;
@@ -109,6 +112,7 @@ export class AgentHost {
     this.servicesConfig = config.servicesConfig;
     this.toolsConfig = config.toolsConfig;
     this.spawner = config.spawner;
+    this.resurrector = config.resurrector;
 
     // Store LLM config for openai-compatible provider registration
     this.llmConfig = config.llmConfig;
@@ -552,6 +556,11 @@ export class AgentHost {
       tools.push(createSpawnAgentTool(this.db, this.agentId, this.spawner));
       tools.push(createTerminateAgentTool(this.db, this.agentId, this.registry));
       tools.push(createTriggerProjectStoryTool(this.db, this.agentId, this.registry));
+    }
+
+    // resurrect_agent is Guide-only (resurrector callback only provided to Guide)
+    if (this.resurrector) {
+      tools.push(createResurrectAgentTool(this.db, this.agentId, this.resurrector));
     }
 
     return tools;

--- a/packages/server/src/agents/library/guide.md
+++ b/packages/server/src/agents/library/guide.md
@@ -156,6 +156,33 @@ When the Conductor reports project work is complete:
 
 **Important:** Never terminate agents or finalize a project without explicit user confirmation.
 
+## Project Restart Flow
+
+When the user wants to revisit or continue work on a completed project:
+
+1. **Help the user think through alternatives.** Resurrection is not always the right choice. Consider:
+   - **New project**: if the scope has changed significantly, a fresh project with new agents may be cleaner
+   - **Bespoke task**: if the user just needs a quick query or explanation, handle it directly without restarting the project
+   - **Resurrection**: if the user wants to continue the same line of work with the original agents' context intact
+
+2. **Get explicit user confirmation** that resurrection is the right approach before proceeding.
+
+3. **Query archived agents** for the project:
+
+   ```sql
+   SELECT id, role, status FROM agent WHERE project = <project_id> AND status = 'archived'
+   ```
+
+4. **Resurrect agents** via `resurrect_agent`:
+   - Resurrect the Conductor first, then the Reviewer
+   - The `message` parameter must orient each agent about the time gap, why it is being resurrected, and what work is now expected. Be specific about any changes since the agent was last active.
+
+5. **Update the project record** via `write_system2_db`:
+   - Clear `end_at` (set to null)
+   - Set status to `"in progress"`
+
+6. **Inform the user**: "Project #N has been restarted. The Conductor and Reviewer have been resurrected with their original context. [Brief summary of what happens next]."
+
 ## Artifact Management
 
 You are responsible for keeping the `artifact` table in `app.db` accurate and up to date. Artifacts are files (HTML reports, dashboards, PDFs, etc.) displayed to users via the UI.
@@ -210,6 +237,7 @@ After every update, ask yourself whether the document structure is still optimal
 - `message_agent`: Send a message to another agent by database ID
 - `spawn_agent`: Spawn a new Conductor or Reviewer for a project
 - `terminate_agent`: Archive an agent (Conductor or Reviewer) when their project work is done
+- `resurrect_agent`: Bring back an archived agent, resuming its session from persisted history. Use for project restarts.
 - `show_artifact`: Display HTML artifacts in the UI panel
 - `web_fetch`: Fetch a URL and extract readable text content
 - `web_search`: Search the web via Brave Search (only if a Brave Search API key is configured)

--- a/packages/server/src/agents/tools/resurrect-agent.test.ts
+++ b/packages/server/src/agents/tools/resurrect-agent.test.ts
@@ -1,0 +1,148 @@
+import type { Agent } from '@system2/shared';
+import { describe, expect, it, vi } from 'vitest';
+import type { DatabaseClient } from '../../db/client.js';
+import { createResurrectAgentTool } from './resurrect-agent.js';
+
+function makeAgent(id: number, role: string, project: number | null, status = 'active'): Agent {
+  return { id, role, project, status, created_at: 'now', updated_at: 'now' } as Agent;
+}
+
+function setup(agentId: number, agents: Agent[]) {
+  const resurrector = vi.fn().mockResolvedValue(undefined);
+  const updateAgentStatus = vi.fn();
+  const db = {
+    getAgent: (id: number) => agents.find((a) => a.id === id) ?? null,
+    updateAgentStatus,
+  } as unknown as DatabaseClient;
+  const tool = createResurrectAgentTool(db, agentId, resurrector);
+  return { tool, resurrector, updateAgentStatus };
+}
+
+// Derive types from the tool so tests stay in sync with implementation
+const { tool: _refTool } = setup(1, []);
+type ResurrectParams = Parameters<typeof _refTool.execute>[1];
+type ResurrectResult = Awaited<ReturnType<typeof _refTool.execute>>;
+
+describe('resurrect_agent tool', () => {
+  const exec = (tool: typeof _refTool, params: Record<string, unknown>): Promise<ResurrectResult> =>
+    tool.execute('test', params as ResurrectParams);
+
+  it('Guide resurrects archived agent successfully', async () => {
+    const { tool, resurrector, updateAgentStatus } = setup(1, [
+      makeAgent(1, 'guide', null),
+      makeAgent(5, 'conductor', 10, 'archived'),
+    ]);
+
+    const result = await exec(tool, {
+      agent_id: 5,
+      message: 'Project restarted, resume work on data extraction.',
+    });
+
+    expect((result.content[0] as { text: string }).text).toContain('has been resurrected');
+    expect(updateAgentStatus).toHaveBeenCalledWith(5, 'active');
+    expect(resurrector).toHaveBeenCalledWith(
+      5,
+      1,
+      'Project restarted, resume work on data extraction.'
+    );
+  });
+
+  it('cannot resurrect already-active agent', async () => {
+    const { tool } = setup(1, [
+      makeAgent(1, 'guide', null),
+      makeAgent(5, 'conductor', 10, 'active'),
+    ]);
+
+    const result = await exec(tool, {
+      agent_id: 5,
+      message: 'Resume work.',
+    });
+
+    expect((result.content[0] as { text: string }).text).toContain('already active');
+  });
+
+  it('cannot resurrect singleton guide', async () => {
+    const { tool } = setup(1, [
+      makeAgent(1, 'guide', null),
+      makeAgent(2, 'guide', null, 'archived'),
+    ]);
+
+    const result = await exec(tool, {
+      agent_id: 2,
+      message: 'Resume.',
+    });
+
+    expect((result.content[0] as { text: string }).text).toContain('Cannot resurrect singleton');
+  });
+
+  it('cannot resurrect singleton narrator', async () => {
+    const { tool } = setup(1, [
+      makeAgent(1, 'guide', null),
+      makeAgent(2, 'narrator', null, 'archived'),
+    ]);
+
+    const result = await exec(tool, {
+      agent_id: 2,
+      message: 'Resume.',
+    });
+
+    expect((result.content[0] as { text: string }).text).toContain('Cannot resurrect singleton');
+  });
+
+  it('Conductor cannot resurrect', async () => {
+    const { tool } = setup(3, [
+      makeAgent(3, 'conductor', 10),
+      makeAgent(5, 'reviewer', 10, 'archived'),
+    ]);
+
+    const result = await exec(tool, {
+      agent_id: 5,
+      message: 'Resume.',
+    });
+
+    expect((result.content[0] as { text: string }).text).toContain('Only the Guide');
+  });
+
+  it('Reviewer cannot resurrect', async () => {
+    const { tool } = setup(4, [
+      makeAgent(4, 'reviewer', 10),
+      makeAgent(5, 'conductor', 10, 'archived'),
+    ]);
+
+    const result = await exec(tool, {
+      agent_id: 5,
+      message: 'Resume.',
+    });
+
+    expect((result.content[0] as { text: string }).text).toContain('Only the Guide');
+  });
+
+  it('errors when agent not found', async () => {
+    const { tool } = setup(1, [makeAgent(1, 'guide', null)]);
+
+    const result = await exec(tool, {
+      agent_id: 999,
+      message: 'Resume.',
+    });
+
+    expect((result.content[0] as { text: string }).text).toContain('not found');
+  });
+
+  it('rolls back DB status on resurrector failure', async () => {
+    const { tool, resurrector, updateAgentStatus } = setup(1, [
+      makeAgent(1, 'guide', null),
+      makeAgent(5, 'conductor', 10, 'archived'),
+    ]);
+    resurrector.mockRejectedValue(new Error('session init failed'));
+
+    const result = await exec(tool, {
+      agent_id: 5,
+      message: 'Resume.',
+    });
+
+    expect((result.content[0] as { text: string }).text).toContain('session init failed');
+    // First call sets active, second call rolls back to archived
+    expect(updateAgentStatus).toHaveBeenCalledWith(5, 'active');
+    expect(updateAgentStatus).toHaveBeenCalledWith(5, 'archived');
+  });
+});

--- a/packages/server/src/agents/tools/resurrect-agent.ts
+++ b/packages/server/src/agents/tools/resurrect-agent.ts
@@ -1,0 +1,146 @@
+/**
+ * Resurrect Agent Tool
+ *
+ * Re-activates an archived agent: updates its status in the database,
+ * re-initializes its AgentHost (resuming from its persisted JSONL session),
+ * registers it in the AgentRegistry, and delivers a context message.
+ *
+ * Permission model:
+ *   - Only the Guide may resurrect agents.
+ *   - Singleton agents (guide, narrator) cannot be resurrected.
+ *   - Already-active agents cannot be resurrected.
+ */
+
+import type { AgentTool } from '@mariozechner/pi-agent-core';
+import { Type } from '@sinclair/typebox';
+import type { DatabaseClient } from '../../db/client.js';
+
+export type AgentResurrector = (
+  agentId: number,
+  callerAgentId: number,
+  message: string
+) => Promise<void>;
+
+export function createResurrectAgentTool(
+  db: DatabaseClient,
+  agentId: number,
+  resurrector: AgentResurrector
+) {
+  const params = Type.Object({
+    agent_id: Type.Number({
+      description:
+        'Database ID of the archived agent to resurrect. The agent will be set back to active, its session resumed from its persisted JSONL history, and it will be re-registered in the agent registry.',
+    }),
+    message: Type.String({
+      description:
+        'Context message delivered to the resurrected agent. Must orient the agent about the time gap since termination, why it is being resurrected, and what work is now expected. Be specific: include project context, any changes since the agent was last active, and the new objectives.',
+    }),
+  });
+
+  const tool: AgentTool<typeof params> = {
+    name: 'resurrect_agent',
+    label: 'Resurrect Agent',
+    description:
+      'Resurrect an archived agent: restore its session from persisted history, re-register it, and deliver a context message. ' +
+      'IMPORTANT: Resurrection is a significant decision. Before using this tool, confirm with the user that resurrection (rather than starting a new project or carrying out a bespoke task) is the right approach. ' +
+      'Help the user think through the tradeoffs: the resurrected agent retains its full conversation history and context, but that context may be stale. ' +
+      'Only the Guide may resurrect agents. After resurrection, update the project record via write_system2_db: clear end_at and set status to "in progress".',
+    parameters: params,
+    execute: async (_toolCallId, params, _signal, _onUpdate) => {
+      const caller = db.getAgent(agentId);
+      if (!caller) {
+        return {
+          content: [{ type: 'text' as const, text: 'Error: Calling agent not found.' }],
+          details: { error: 'caller_not_found' },
+        };
+      }
+
+      // Only the Guide may resurrect agents
+      if (caller.role !== 'guide') {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error: Only the Guide may resurrect agents. Your role is "${caller.role}".`,
+            },
+          ],
+          details: { error: 'unauthorized_role' },
+        };
+      }
+
+      const target = db.getAgent(params.agent_id);
+      if (!target) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error: Agent ${params.agent_id} not found.`,
+            },
+          ],
+          details: { error: 'target_not_found' },
+        };
+      }
+
+      // Singleton agents cannot be resurrected (they are never archived)
+      if (target.role === 'guide' || target.role === 'narrator') {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error: Cannot resurrect singleton agent (role: ${target.role}). Singleton agents run for the lifetime of the server.`,
+            },
+          ],
+          details: { error: 'singleton_agent' },
+        };
+      }
+
+      // Must be archived to resurrect
+      if (target.status !== 'archived') {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error: Agent ${params.agent_id} is already active. Only archived agents can be resurrected.`,
+            },
+          ],
+          details: { error: 'already_active' },
+        };
+      }
+
+      // Update DB status
+      db.updateAgentStatus(params.agent_id, 'active');
+
+      try {
+        // Initialize AgentHost (resumes from JSONL) and deliver message
+        await resurrector(params.agent_id, agentId, params.message);
+      } catch (error) {
+        // Roll back DB status on failure
+        db.updateAgentStatus(params.agent_id, 'archived');
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Error resurrecting agent: ${(error as Error).message}`,
+            },
+          ],
+          details: { error: (error as Error).message },
+        };
+      }
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text:
+              `Agent ${params.agent_id} (role: ${target.role}, project: ${target.project}) has been resurrected. ` +
+              `Its session has been restored from persisted history and the context message delivered. ` +
+              `Remember to update the project record via write_system2_db: clear end_at and set status to "in progress".`,
+          },
+        ],
+        details: { resurrected: true, agentId: params.agent_id, role: target.role },
+      };
+    },
+  };
+
+  return tool;
+}

--- a/packages/server/src/agents/tools/trigger-project-story.test.ts
+++ b/packages/server/src/agents/tools/trigger-project-story.test.ts
@@ -1,5 +1,6 @@
+import { existsSync } from 'node:fs';
 import type { Agent, Project, Task } from '@system2/shared';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, type Mock, vi } from 'vitest';
 import type { DatabaseClient } from '../../db/client.js';
 import type { AgentRegistry } from '../registry.js';
 import { createTriggerProjectStoryTool } from './trigger-project-story.js';
@@ -230,5 +231,26 @@ describe('trigger_project_story tool', () => {
 
     // Guide is not a conductor, so the "own project" check doesn't apply
     expect((result.content[0] as { text: string }).text).toContain('Project story triggered');
+  });
+
+  it('includes existing story note when project_story.md exists', async () => {
+    (existsSync as Mock).mockImplementation(
+      (p: string) => typeof p === 'string' && p.endsWith('project_story.md')
+    );
+    try {
+      const conductor = makeAgent(2, 'conductor', 1);
+      const narrator = makeAgent(10, 'narrator', null);
+      const project = makeProject(1, 'test-project');
+      const { tool, deliverMessage } = setup(2, [conductor, narrator], [project], [10]);
+
+      await exec(tool, { project_id: 1 });
+
+      const msg2 = deliverMessage.mock.calls[1][0] as string;
+      expect(msg2).toContain('Existing Project Story');
+      expect(msg2).toContain('project_story.md');
+      expect(msg2).toContain('Read it and decide whether to edit or rewrite');
+    } finally {
+      (existsSync as Mock).mockReturnValue(false);
+    }
   });
 });

--- a/packages/server/src/agents/tools/trigger-project-story.ts
+++ b/packages/server/src/agents/tools/trigger-project-story.ts
@@ -212,12 +212,18 @@ ${projectDbChanges}`;
               ) as Record<string, unknown>[])
             : [];
 
+        // Check for an existing project story (from a previous completion cycle)
+        const storyFile = join(projectDir, 'project_story.md');
+        const existingStoryNote = existsSync(storyFile)
+          ? `\n\n## Existing Project Story\n\nA previous project story exists at ${storyFile}. Read it and decide whether to edit or rewrite it to incorporate this new phase of work.`
+          : '';
+
         const projectStoryMessage = `[Task: project-story]
 
 project_id: ${project.id}
 project_name: ${project.name}
 task_id: ${storyTask.id}
-conductor_id: ${agentId}
+conductor_id: ${agentId}${existingStoryNote}
 
 ## Project Record
 

--- a/packages/server/src/agents/tools/trigger-project-story.ts
+++ b/packages/server/src/agents/tools/trigger-project-story.ts
@@ -223,8 +223,8 @@ ${projectDbChanges}`;
 project_id: ${project.id}
 project_name: ${project.name}
 task_id: ${storyTask.id}
-conductor_id: ${agentId}${existingStoryNote}
-
+conductor_id: ${agentId}
+${existingStoryNote}
 ## Project Record
 
 ${formatMarkdownTable(projectRecord)}

--- a/packages/server/src/agents/tools/trigger-project-story.ts
+++ b/packages/server/src/agents/tools/trigger-project-story.ts
@@ -215,7 +215,7 @@ ${projectDbChanges}`;
         // Check for an existing project story (from a previous completion cycle)
         const storyFile = join(projectDir, 'project_story.md');
         const existingStoryNote = existsSync(storyFile)
-          ? `\n\n## Existing Project Story\n\nA previous project story exists at ${storyFile}. Read it and decide whether to edit or rewrite it to incorporate this new phase of work.`
+          ? `\n## Existing Project Story\n\nA previous project story exists at ${storyFile}. Read it and decide whether to edit or rewrite it to incorporate this new phase of work.\n`
           : '';
 
         const projectStoryMessage = `[Task: project-story]

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -23,6 +23,7 @@ import express from 'express';
 import { WebSocketServer } from 'ws';
 import { AgentHost } from './agents/host.js';
 import { AgentRegistry } from './agents/registry.js';
+import type { AgentResurrector } from './agents/tools/resurrect-agent.js';
 import type { AgentSpawner } from './agents/tools/spawn-agent.js';
 import { MessageHistory } from './chat/history.js';
 import { DatabaseClient } from './db/client.js';
@@ -90,6 +91,7 @@ export class Server {
       servicesConfig: config.servicesConfig,
       toolsConfig: config.toolsConfig,
       spawner: this.makeSpawner(),
+      resurrector: this.makeResurrector(),
     });
     this.agentRegistry.register(guideAgent.id, this.agentHost);
 
@@ -338,6 +340,22 @@ export class Server {
     };
 
     return spawner;
+  }
+
+  /**
+   * Create a resurrector callback that re-initializes archived agents.
+   * Reuses initializeAgentHost which resumes from persisted JSONL sessions.
+   */
+  private makeResurrector(): AgentResurrector {
+    return async (agentId, callerAgentId, message) => {
+      const host = await this.initializeAgentHost(agentId);
+
+      host.deliverMessage(message, {
+        sender: callerAgentId,
+        receiver: agentId,
+        timestamp: Date.now(),
+      });
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds a `resurrect_agent` tool that allows the Guide to re-activate archived agents, enabling project restarts without losing session history. Closes #12.

- New `resurrect_agent` tool (Guide-only): validates target is archived and non-singleton, updates DB status, resumes JSONL session via `initializeAgentHost`, delivers context message, rolls back on failure
- Project story re-completion: `trigger-project-story` checks for existing `project_story.md` and tells the Narrator to read it before writing
- Documentation updates across `docs/agents.md`, `docs/tools.md`, `agents.md` (shared reference), and `guide.md` (system prompt)
- 8 new tests covering permissions, edge cases, and failure rollback

## Changes

| File | Change |
|------|--------|
| `packages/server/src/agents/tools/resurrect-agent.ts` | New tool implementation |
| `packages/server/src/agents/tools/resurrect-agent.test.ts` | New test file (8 tests) |
| `packages/server/src/agents/host.ts` | Add `resurrector` option, wire tool in `buildTools()` |
| `packages/server/src/server.ts` | Add `makeResurrector()`, pass to Guide |
| `packages/server/src/agents/tools/trigger-project-story.ts` | Existing story detection for re-completion |
| `packages/server/src/agents/agents.md` | Updated permissions table, tool reference, fixed status values |
| `packages/server/src/agents/library/guide.md` | Added tool + Project Restart Flow section |
| `docs/agents.md` | Resurrection lifecycle documentation |
| `docs/tools.md` | `resurrect_agent` tool reference |

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (253 tests, including 8 new)