### PR TITLE
fix(messaging): prevent silent message drop when agent is streaming

### DIFF
--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -189,7 +189,7 @@ describe('AgentHost', () => {
       expect(hostInternal.pendingPrompt).toBeNull();
     });
 
-    it('retry paths restore pendingPrompt before calling session.prompt()', async () => {
+    it('retry paths restore pendingPrompt and pass streamingBehavior before calling session.prompt()', async () => {
       const host = new AgentHost({
         db: makeDbStub(),
         agentId: 1,
@@ -239,6 +239,11 @@ describe('AgentHost', () => {
 
       // pendingPrompt was restored before session.prompt() was called
       expect(pendingAtRetryTime).toBe('original message');
+      // streamingBehavior: 'followUp' prevents a throw if a deliverMessage turn
+      // happens to start during the retry delay
+      expect(hostInternal.session.prompt).toHaveBeenCalledWith('original message', {
+        streamingBehavior: 'followUp',
+      });
     });
 
     it('pendingPrompt persists if session.prompt() throws', async () => {

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -123,7 +123,7 @@ describe('AgentHost', () => {
       expect(hostInternal.authResolver.markKeyFailed).toHaveBeenCalled();
     });
 
-    it('prompt() sets and clears pendingPrompt around session.prompt()', async () => {
+    it('prompt() sets pendingPrompt and keeps it set until agent_end fires', async () => {
       const host = new AgentHost({
         db: makeDbStub(),
         agentId: 1,
@@ -134,6 +134,7 @@ describe('AgentHost', () => {
       const hostInternal = host as unknown as {
         pendingPrompt: string | null;
         session: { prompt: ReturnType<typeof vi.fn> };
+        handleSessionEvent: (event: { type: string }) => void;
       };
 
       // Track pendingPrompt value during session.prompt()
@@ -148,8 +149,103 @@ describe('AgentHost', () => {
 
       // During session.prompt(), pendingPrompt was set
       expect(promptDuringSession).toBe('hello world');
-      // After session.prompt() resolves, pendingPrompt is cleared
+      // After session.prompt() resolves, pendingPrompt is still set —
+      // clearing moved to agent_end so queued turns (followUp/steer) stay retryable
+      expect(hostInternal.pendingPrompt).toBe('hello world');
+
+      // Simulate agent_end: pendingPrompt is now cleared
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
       expect(hostInternal.pendingPrompt).toBeNull();
+    });
+
+    it('handleSessionEvent clears pendingPrompt on agent_end but not on other events', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        pendingPrompt: string | null;
+        handleSessionEvent: (event: { type: string }) => void;
+        handlePotentialError: ReturnType<typeof vi.fn>;
+        handleCompactionTracking: ReturnType<typeof vi.fn>;
+      };
+
+      // Suppress internal method calls (not under test here)
+      hostInternal.handlePotentialError = vi.fn();
+      hostInternal.handleCompactionTracking = vi.fn();
+
+      hostInternal.pendingPrompt = 'pending message';
+
+      hostInternal.handleSessionEvent({ type: 'message_update' });
+      expect(hostInternal.pendingPrompt).toBe('pending message');
+
+      hostInternal.handleSessionEvent({ type: 'tool_execution_start' });
+      expect(hostInternal.pendingPrompt).toBe('pending message');
+
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
+      expect(hostInternal.pendingPrompt).toBeNull();
+    });
+
+    it('retry paths restore pendingPrompt before calling session.prompt()', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        pendingPrompt: string | null;
+        session: { prompt: ReturnType<typeof vi.fn> };
+        handlePotentialError: (event: unknown) => Promise<void>;
+        authResolver: {
+          markKeyFailed: ReturnType<typeof vi.fn>;
+          getNextProvider: ReturnType<typeof vi.fn>;
+        };
+        retryAttempts: Map<string, number>;
+        currentProvider: string;
+      };
+
+      let pendingAtRetryTime: string | null = null;
+      hostInternal.session = {
+        prompt: vi.fn().mockImplementation(async () => {
+          pendingAtRetryTime = hostInternal.pendingPrompt;
+        }),
+      };
+      hostInternal.currentProvider = 'cerebras';
+      hostInternal.pendingPrompt = 'original message';
+      // Simulate agent_end having cleared it before the error handler retries
+      hostInternal.pendingPrompt = null;
+
+      // Use a rate_limit error — shouldRetry returns true for first attempt
+      const errorEvent = {
+        type: 'message_end',
+        message: {
+          stopReason: 'error',
+          errorMessage: 'Error 429: rate limit exceeded',
+        },
+      };
+
+      // Capture promptToRetry via a saved reference before pendingPrompt was cleared
+      // This simulates the real scenario: pendingPrompt was 'original message' when
+      // the error was captured, but was then cleared by agent_end
+      hostInternal.pendingPrompt = 'original message';
+
+      // No failover — just retry path (mark enough attempts to skip retry and go to failover,
+      // but have no next provider so it exits cleanly after retrying once)
+      hostInternal.authResolver.markKeyFailed = vi.fn().mockReturnValue(false);
+      hostInternal.authResolver.getNextProvider = vi.fn().mockReturnValue(null);
+
+      // Set retryAttempts to 0 so the first shouldRetry call returns true
+      hostInternal.retryAttempts = new Map();
+
+      await hostInternal.handlePotentialError(errorEvent);
+
+      // pendingPrompt was restored before session.prompt() was called
+      expect(pendingAtRetryTime).toBe('original message');
     });
 
     it('pendingPrompt persists if session.prompt() throws', async () => {
@@ -171,7 +267,8 @@ describe('AgentHost', () => {
 
       await expect(host.prompt('hello world')).rejects.toThrow('connection failed');
 
-      // pendingPrompt is NOT cleared because the clear line (after await) was never reached
+      // pendingPrompt stays set — clearing only happens on agent_end, which never
+      // fires when session.prompt() throws synchronously
       expect(hostInternal.pendingPrompt).toBe('hello world');
     });
   });
@@ -230,6 +327,17 @@ describe('AgentHost', () => {
       host.abort();
 
       expect(host.isBusy()).toBe(false);
+    });
+
+    it('abort() clears pendingPrompt', () => {
+      const { host, internal } = makeHostWithBusyTracking();
+      setupWithFakeSession(internal);
+
+      internal.pendingPrompt = 'message in flight';
+
+      host.abort();
+
+      expect(internal.pendingPrompt).toBeNull();
     });
 
     it('abort() is a no-op when already idle', () => {

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -152,10 +152,21 @@ describe('AgentHost', () => {
       // After session.prompt() resolves, pendingPrompt is still set —
       // clearing moved to agent_end so queued turns (followUp/steer) stay retryable
       expect(hostInternal.pendingPrompt).toBe('hello world');
+      // Non-steering: streamingBehavior must be 'followUp' (not undefined) to prevent
+      // silent drops when a background sendCustomMessage turn is in flight
+      expect(hostInternal.session.prompt).toHaveBeenCalledWith('hello world', {
+        streamingBehavior: 'followUp',
+      });
 
       // Simulate agent_end: pendingPrompt is now cleared
       hostInternal.handleSessionEvent({ type: 'agent_end' });
       expect(hostInternal.pendingPrompt).toBeNull();
+
+      // Steering: streamingBehavior must be 'steer'
+      await host.prompt('steer message', { isSteering: true });
+      expect(hostInternal.session.prompt).toHaveBeenLastCalledWith('steer message', {
+        streamingBehavior: 'steer',
+      });
     });
 
     it('handleSessionEvent clears pendingPrompt on agent_end but not on other events', () => {
@@ -174,7 +185,8 @@ describe('AgentHost', () => {
       };
 
       // Suppress internal method calls (not under test here)
-      hostInternal.handlePotentialError = vi.fn();
+      // handlePotentialError must return a Promise since handleSessionEvent calls .catch() on it
+      hostInternal.handlePotentialError = vi.fn().mockResolvedValue(undefined);
       hostInternal.handleCompactionTracking = vi.fn();
 
       hostInternal.pendingPrompt = 'pending message';
@@ -227,12 +239,11 @@ describe('AgentHost', () => {
         },
       };
 
-      // No failover — just retry path (mark enough attempts to skip retry and go to failover,
-      // but have no next provider so it exits cleanly after retrying once)
+      // retryAttempts=0 means shouldRetry returns true → handlePotentialError takes the
+      // retry path, calls session.prompt(), then returns early. The failover mocks are
+      // set up defensively but are not exercised in this scenario.
       hostInternal.authResolver.markKeyFailed = vi.fn().mockReturnValue(false);
       hostInternal.authResolver.getNextProvider = vi.fn().mockReturnValue(null);
-
-      // Set retryAttempts to 0 so the first shouldRetry call returns true
       hostInternal.retryAttempts = new Map();
 
       await hostInternal.handlePotentialError(errorEvent);

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -217,8 +217,6 @@ describe('AgentHost', () => {
       };
       hostInternal.currentProvider = 'cerebras';
       hostInternal.pendingPrompt = 'original message';
-      // Simulate agent_end having cleared it before the error handler retries
-      hostInternal.pendingPrompt = null;
 
       // Use a rate_limit error — shouldRetry returns true for first attempt
       const errorEvent = {
@@ -228,11 +226,6 @@ describe('AgentHost', () => {
           errorMessage: 'Error 429: rate limit exceeded',
         },
       };
-
-      // Capture promptToRetry via a saved reference before pendingPrompt was cleared
-      // This simulates the real scenario: pendingPrompt was 'original message' when
-      // the error was captured, but was then cleared by agent_end
-      hostInternal.pendingPrompt = 'original message';
 
       // No failover — just retry path (mark enough attempts to skip retry and go to failover,
       // but have no next provider so it exits cleanly after retrying once)

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -586,8 +586,13 @@ export class AgentHost {
     // Store for potential retry on failover
     this.pendingPrompt = content;
 
-    // Use streamingBehavior to queue steering messages properly
-    const promptOptions = options?.isSteering ? { streamingBehavior: 'steer' as const } : undefined;
+    // Use streamingBehavior to queue messages properly if the session is already streaming.
+    // Defaulting non-steering messages to 'followUp' prevents silent drops when a background
+    // sendCustomMessage turn is in flight — session.prompt() throws if streamingBehavior is
+    // undefined and isStreaming is true. 'followUp' is a no-op when the session is idle.
+    const promptOptions = options?.isSteering
+      ? { streamingBehavior: 'steer' as const }
+      : { streamingBehavior: 'followUp' as const };
 
     // Reload resource loader to pick up knowledge file changes
     await this.resourceLoader?.reload();

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -296,31 +296,46 @@ export class AgentHost {
 
     // Subscribe to session events and forward to listeners
     session.subscribe((event) => {
-      // Check for API errors that need failover handling
-      this.handlePotentialError(event);
-
-      // Track busy state from agent activity
-      if (event.type === 'message_update' || event.type === 'tool_execution_start') {
-        if (!this.busy) {
-          this.busy = true;
-        }
-      } else if (event.type === 'agent_end') {
-        if (this.busy) {
-          this.busy = false;
-        }
-      }
-
-      // Track compaction for pruning
-      this.handleCompactionTracking(event);
-
-      // Forward to external listeners
-      this.listeners.forEach((listener) => {
-        listener(event);
-      });
+      this.handleSessionEvent(event);
     });
 
     console.log(`[AgentHost] ${agentRecord.role} agent session initialized with JSONL persistence`);
     console.log('[AgentHost] Using provider:', this.currentProvider);
+  }
+
+  /**
+   * Handle a session event: error detection, busy/pendingPrompt tracking,
+   * compaction, and external listener forwarding.
+   *
+   * Extracted from the initialize() subscribe callback so tests can invoke it directly.
+   */
+  private handleSessionEvent(event: AgentSessionEvent): void {
+    // Check for API errors that need failover handling
+    this.handlePotentialError(event);
+
+    // Track busy state from agent activity
+    if (event.type === 'message_update' || event.type === 'tool_execution_start') {
+      if (!this.busy) {
+        this.busy = true;
+      }
+    } else if (event.type === 'agent_end') {
+      if (this.busy) {
+        this.busy = false;
+      }
+      // Clear pendingPrompt here — not in prompt() after session.prompt() returns.
+      // When streamingBehavior is 'followUp' or 'steer', session.prompt() queues
+      // the message and returns immediately, so clearing it there would be too early.
+      // Waiting for agent_end ensures the message stays retryable until the turn runs.
+      this.pendingPrompt = null;
+    }
+
+    // Track compaction for pruning
+    this.handleCompactionTracking(event);
+
+    // Forward to external listeners
+    this.listeners.forEach((listener) => {
+      listener(event);
+    });
   }
 
   /**
@@ -350,7 +365,7 @@ export class AgentHost {
     const retryKey = `${this.currentProvider}:${category}`;
     const currentAttempts = this.retryAttempts.get(retryKey) ?? 0;
 
-    // Capture before any await — prompt() may clear it after session.prompt() resolves
+    // Capture before any await — agent_end may clear it before this async handler resumes
     const promptToRetry = this.pendingPrompt;
 
     // Check if we should retry
@@ -368,6 +383,7 @@ export class AgentHost {
       // Retry the pending prompt if there is one
       if (promptToRetry && this.session) {
         console.log('[AgentHost] Retrying prompt...');
+        this.pendingPrompt = promptToRetry; // restore so the retry turn is also retryable
         await this.resourceLoader?.reload();
         await this.session.prompt(promptToRetry);
       }
@@ -453,6 +469,7 @@ export class AgentHost {
       // Retry the pending prompt with the new provider
       if (promptToRetry && this.session) {
         console.log('[AgentHost] Retrying prompt with new provider...');
+        this.pendingPrompt = promptToRetry; // restore so the retry turn is also retryable
         await this.session.prompt(promptToRetry);
       }
     } catch (error) {
@@ -597,8 +614,9 @@ export class AgentHost {
     // Reload resource loader to pick up knowledge file changes
     await this.resourceLoader?.reload();
     await this.session.prompt(content, promptOptions);
-    // Clear on successful completion (no error triggered failover)
-    this.pendingPrompt = null;
+    // pendingPrompt is cleared by handleSessionEvent() on agent_end.
+    // Do NOT clear here: for queued turns (streamingBehavior 'followUp'/'steer'),
+    // session.prompt() returns immediately and the turn hasn't run yet.
   }
 
   /**
@@ -661,10 +679,11 @@ export class AgentHost {
   abort(): void {
     if (this.session) {
       this.session.abort();
-      // abort() may not trigger agent_end, so clear busy explicitly
+      // abort() may not trigger agent_end, so clear busy and pendingPrompt explicitly
       if (this.busy) {
         this.busy = false;
       }
+      this.pendingPrompt = null;
     }
   }
 

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -310,8 +310,10 @@ export class AgentHost {
    * Extracted from the initialize() subscribe callback so tests can invoke it directly.
    */
   private handleSessionEvent(event: AgentSessionEvent): void {
-    // Check for API errors that need failover handling
-    this.handlePotentialError(event);
+    // Check for API errors that need failover handling (async, errors logged internally)
+    void this.handlePotentialError(event).catch((err) => {
+      console.error('[AgentHost] handlePotentialError threw unexpectedly:', err);
+    });
 
     // Track busy state from agent activity
     if (event.type === 'message_update' || event.type === 'tool_execution_start') {
@@ -383,7 +385,9 @@ export class AgentHost {
       // Retry the pending prompt if there is one
       if (promptToRetry && this.session) {
         console.log('[AgentHost] Retrying prompt...');
-        this.pendingPrompt = promptToRetry; // restore so the retry turn is also retryable
+        // Restore only if nothing newer arrived during sleep — a new prompt() call during the
+        // delay would have set pendingPrompt to the newer message; don't overwrite it.
+        this.pendingPrompt = this.pendingPrompt ?? promptToRetry;
         await this.resourceLoader?.reload();
         await this.session.prompt(promptToRetry, { streamingBehavior: 'followUp' });
       }
@@ -469,7 +473,8 @@ export class AgentHost {
       // Retry the pending prompt with the new provider
       if (promptToRetry && this.session) {
         console.log('[AgentHost] Retrying prompt with new provider...');
-        this.pendingPrompt = promptToRetry; // restore so the retry turn is also retryable
+        // Restore only if nothing newer arrived during reinitialization.
+        this.pendingPrompt = this.pendingPrompt ?? promptToRetry;
         await this.session.prompt(promptToRetry, { streamingBehavior: 'followUp' });
       }
     } catch (error) {

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -385,7 +385,7 @@ export class AgentHost {
         console.log('[AgentHost] Retrying prompt...');
         this.pendingPrompt = promptToRetry; // restore so the retry turn is also retryable
         await this.resourceLoader?.reload();
-        await this.session.prompt(promptToRetry);
+        await this.session.prompt(promptToRetry, { streamingBehavior: 'followUp' });
       }
       return;
     }
@@ -470,7 +470,7 @@ export class AgentHost {
       if (promptToRetry && this.session) {
         console.log('[AgentHost] Retrying prompt with new provider...');
         this.pendingPrompt = promptToRetry; // restore so the retry turn is also retryable
-        await this.session.prompt(promptToRetry);
+        await this.session.prompt(promptToRetry, { streamingBehavior: 'followUp' });
       }
     } catch (error) {
       console.error('[AgentHost] Failed to reinitialize:', error);

--- a/packages/server/src/agents/tools/bash.test.ts
+++ b/packages/server/src/agents/tools/bash.test.ts
@@ -102,10 +102,11 @@ describe('bash tool', () => {
       expect((result.content[0] as { text: string }).text).toContain('started in background');
       expect((result.details as { background: boolean }).background).toBe(true);
 
-      // Wait for background process to finish
-      await new Promise((resolve) => setTimeout(resolve, 500));
-
-      expect(notifyBackground).toHaveBeenCalledTimes(1);
+      // Poll until the background process notifies — avoids a fixed sleep that
+      // can be too short on slow CI runners (Windows in particular)
+      await vi.waitFor(() => expect(notifyBackground).toHaveBeenCalledTimes(1), {
+        timeout: 5000,
+      });
       const [content] = notifyBackground.mock.calls[0];
       expect(content).toContain('background');
       expect(content).toContain('completed');

--- a/packages/ui/src/components/MessageInput.tsx
+++ b/packages/ui/src/components/MessageInput.tsx
@@ -36,7 +36,7 @@ export function MessageInput({ onSend, onQueue, onAbort }: MessageInputProps) {
     if (!input.trim()) return;
 
     if (isStreaming) {
-      onQueue(input.trim(), true);
+      onQueue(input.trim());
     } else {
       onSend(input.trim());
     }

--- a/packages/ui/src/components/MessageInput.tsx
+++ b/packages/ui/src/components/MessageInput.tsx
@@ -36,7 +36,7 @@ export function MessageInput({ onSend, onQueue, onAbort }: MessageInputProps) {
     if (!input.trim()) return;
 
     if (isStreaming) {
-      onQueue(input.trim());
+      onQueue(input.trim(), true);
     } else {
       onSend(input.trim());
     }


### PR DESCRIPTION
## Summary

- **Commit 1 — prevent silent message drop when agent is streaming:** In `AgentHost.prompt()`, non-steering messages now default to `streamingBehavior: 'followUp'` instead of `undefined`. When a background `sendCustomMessage` turn is in flight, `session.prompt()` throws if `streamingBehavior` is unspecified and `isStreaming` is true — the error was silently caught by the WebSocket handler, leaving the message visible in the UI but never delivered to the session. `'followUp'` is a no-op when the session is idle, so normal message flow is unchanged.

- **Commit 2 — keep `pendingPrompt` set until `agent_end` for reliable failover retry:** `session.prompt()` returns immediately when using `'followUp'` or `'steer'` (the turn is queued, not yet executed). Clearing `pendingPrompt` right after that return meant a provider error during the queued turn had nothing to retry. Fix: extract session event handling into `handleSessionEvent()`, clear `pendingPrompt` on `agent_end` instead. Also restore `pendingPrompt` before each retry call so the retry itself is retryable. Clear it in `abort()` since that may not fire `agent_end`.

## Design notes

**Normal path unaffected:** `streamingBehavior` is only checked inside `if (this.isStreaming)` in `session.prompt()`. When the session is idle, the option is ignored and `session.prompt()` awaits the full turn as before. `pendingPrompt` is cleared by `agent_end`, which fires before `session.prompt()` resolves in the idle path.

## What was considered and ruled out

Passing `isSteering: true` to `onQueue` in `MessageInput.tsx` when streaming was implemented and then reverted. `queueMessage` with `isSteering: true` **prepends** to the front of the queue, so multiple messages sent while streaming would be processed in reverse order. Issue #22 tracks the correct fix (send immediately as `steering_message`, bypass the queue entirely).

## Test plan

- [ ] Send a user message while the Guide is responding to a background agent message — confirm it is no longer silently dropped
- [ ] Send two messages in quick succession while streaming — confirm they are delivered in order after the current turn completes
- [ ] Normal (non-streaming) message flow unchanged
- [ ] Simulate a provider error during a queued follow-up turn — confirm the message is retried with the next provider

Fixes #21