### PR TITLE
perf(narrator): strip verbose JSONL fields before injecting agent activity

### DIFF
--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -37,7 +37,7 @@ For each active project (those with a non-archived Conductor):
 1. Ensure `~/.system2/projects/{id}_{name}/` directory exists
 2. Create `log.md` with YAML frontmatter if it doesn't exist
 3. Read most recent `log.md` content (last 10,000 characters via `readTailChars`)
-4. Collect activity from all agents involved in the project (project-scoped agents + Guide; Narrator is excluded via `projectLogSystemAgents` to prevent recursive embedding)
+4. Collect activity from all agents involved in the project (project-scoped agents + Guide; Narrator is excluded via `projectLogSystemAgents` to prevent recursive embedding). JSONL entries are stripped of verbose fields before injection: `thoughtSignature`, `usage`, `api`, `provider`, `model`, and `details` are dropped; tool call argument values and tool result content are truncated to 100 chars.
 5. Collect project-scoped DB changes (task, project, task_comment, task_link records belonging to the project)
 6. If there is activity, deliver a `[Scheduled task: project-log]` message to the Narrator
 

--- a/packages/server/src/scheduler/jobs.test.ts
+++ b/packages/server/src/scheduler/jobs.test.ts
@@ -11,6 +11,7 @@ import {
   readFrontmatterField,
   readTailChars,
   resolveDailySummaryTimestamp,
+  stripSessionEntry,
 } from './jobs.js';
 
 function makeTmpDir(): string {
@@ -259,5 +260,270 @@ describe('buildAndDeliverMemoryUpdate', () => {
     buildAndDeliverMemoryUpdate(host, 2, dir);
     expect(host.calls).toHaveLength(1);
     expect(host.calls[0].content).toContain('2026-03-10.md');
+  });
+});
+
+describe('stripSessionEntry', () => {
+  it('passes through unknown entry types unchanged', () => {
+    const entry = { type: 'session', version: 3, id: 'abc' };
+    expect(stripSessionEntry(entry)).toEqual(entry);
+  });
+
+  it('passes through message with user role unchanged', () => {
+    const entry = {
+      type: 'message',
+      timestamp: '2026-01-01T00:00:00Z',
+      message: { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+    };
+    expect(stripSessionEntry(entry)).toEqual(entry);
+  });
+
+  it('passes through message with missing message field unchanged', () => {
+    const entry = { type: 'message', timestamp: '2026-01-01T00:00:00Z' };
+    expect(stripSessionEntry(entry)).toEqual(entry);
+  });
+
+  describe('custom_message', () => {
+    it('drops details', () => {
+      const entry = {
+        type: 'custom_message',
+        content: 'hello',
+        details: { sender: 1, receiver: 2, timestamp: 0 },
+      };
+      const result = stripSessionEntry(entry);
+      expect(result).not.toHaveProperty('details');
+      expect(result.content).toBe('hello');
+    });
+
+    it('does not crash when details is absent', () => {
+      const entry = { type: 'custom_message', content: 'hello' };
+      expect(stripSessionEntry(entry)).toEqual({ type: 'custom_message', content: 'hello' });
+    });
+  });
+
+  describe('assistant message', () => {
+    it('drops usage, api, provider, model', () => {
+      const entry = {
+        type: 'message',
+        message: {
+          role: 'assistant',
+          api: 'google-generative-ai',
+          provider: 'google',
+          model: 'gemini-2.0-flash',
+          usage: { input: 1000, output: 50, totalTokens: 1050 },
+          content: [],
+        },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      expect(result.message).not.toHaveProperty('api');
+      expect(result.message).not.toHaveProperty('provider');
+      expect(result.message).not.toHaveProperty('model');
+      expect(result.message).not.toHaveProperty('usage');
+    });
+
+    it('drops thoughtSignature and id from toolCall blocks', () => {
+      const entry = {
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'toolCall',
+              id: 'call-123',
+              name: 'bash',
+              thoughtSignature: 'a'.repeat(500),
+              arguments: { command: 'echo hi' },
+            },
+          ],
+        },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      const block = (result.message.content as Record<string, unknown>[])[0];
+      expect(block).not.toHaveProperty('thoughtSignature');
+      expect(block).not.toHaveProperty('id');
+      expect(block.name).toBe('bash');
+    });
+
+    it('truncates long string argument values to 100 chars', () => {
+      const longCmd = 'x'.repeat(300);
+      const entry = {
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'toolCall', name: 'bash', arguments: { command: longCmd } }],
+        },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      const block = (result.message.content as Record<string, unknown>[])[0];
+      const args = block.arguments as Record<string, unknown>;
+      expect(typeof args.command).toBe('string');
+      expect((args.command as string).length).toBe(100);
+    });
+
+    it('does not truncate argument values already under 100 chars', () => {
+      const entry = {
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'toolCall', name: 'bash', arguments: { command: 'echo hi' } }],
+        },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      const block = (result.message.content as Record<string, unknown>[])[0];
+      const args = block.arguments as Record<string, unknown>;
+      expect(args.command).toBe('echo hi');
+    });
+
+    it('passes non-string argument values through unchanged', () => {
+      const entry = {
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [
+            { type: 'toolCall', name: 'read_system2_db', arguments: { limit: 10, dry: true } },
+          ],
+        },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      const block = (result.message.content as Record<string, unknown>[])[0];
+      const args = block.arguments as Record<string, unknown>;
+      expect(args.limit).toBe(10);
+      expect(args.dry).toBe(true);
+    });
+
+    it('does not add arguments key when absent on toolCall', () => {
+      const entry = {
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'toolCall', name: 'bash' }],
+        },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      const block = (result.message.content as Record<string, unknown>[])[0];
+      expect(block).not.toHaveProperty('arguments');
+    });
+
+    it('preserves thinking blocks unchanged', () => {
+      const thinking = 'deep thought '.repeat(20);
+      const entry = {
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'thinking', thinking, thinkingSignature: 'sig' }],
+        },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      const block = (result.message.content as Record<string, unknown>[])[0];
+      expect(block.thinking).toBe(thinking);
+      expect(block.thinkingSignature).toBe('sig');
+    });
+
+    it('preserves text blocks unchanged', () => {
+      const entry = {
+        type: 'message',
+        message: { role: 'assistant', content: [{ type: 'text', text: 'Done.' }] },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      const block = (result.message.content as Record<string, unknown>[])[0];
+      expect(block.text).toBe('Done.');
+    });
+
+    it('does not crash when content is not an array', () => {
+      const entry = {
+        type: 'message',
+        message: { role: 'assistant', content: null },
+      };
+      expect(() => stripSessionEntry(entry)).not.toThrow();
+    });
+  });
+
+  describe('toolResult message', () => {
+    it('drops details', () => {
+      const entry = {
+        type: 'message',
+        message: {
+          role: 'toolResult',
+          toolName: 'bash',
+          details: { exitCode: 0, stdout: 'hello' },
+          content: [{ type: 'text', text: 'hello' }],
+        },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      expect(result.message).not.toHaveProperty('details');
+      expect(result.message.toolName).toBe('bash');
+    });
+
+    it('truncates long text content to 100 chars', () => {
+      const longText = 'a'.repeat(300);
+      const entry = {
+        type: 'message',
+        message: {
+          role: 'toolResult',
+          toolName: 'read',
+          content: [{ type: 'text', text: longText }],
+        },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      const block = (result.message.content as Record<string, unknown>[])[0];
+      expect(typeof block.text).toBe('string');
+      expect((block.text as string).length).toBe(100);
+    });
+
+    it('does not truncate text content already under 100 chars', () => {
+      const entry = {
+        type: 'message',
+        message: {
+          role: 'toolResult',
+          toolName: 'read',
+          content: [{ type: 'text', text: 'short result' }],
+        },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      const block = (result.message.content as Record<string, unknown>[])[0];
+      expect(block.text).toBe('short result');
+    });
+
+    it('passes through non-text content blocks unchanged', () => {
+      const entry = {
+        type: 'message',
+        message: {
+          role: 'toolResult',
+          toolName: 'read',
+          content: [{ type: 'image', data: 'base64...' }],
+        },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      const block = (result.message.content as Record<string, unknown>[])[0];
+      expect(block.type).toBe('image');
+      expect(block.data).toBe('base64...');
+    });
+
+    it('does not crash with empty content array', () => {
+      const entry = {
+        type: 'message',
+        message: { role: 'toolResult', toolName: 'bash', content: [] },
+      };
+      expect(() => stripSessionEntry(entry)).not.toThrow();
+    });
+
+    it('truncates string-form content to 100 chars', () => {
+      const entry = {
+        type: 'message',
+        message: { role: 'toolResult', toolName: 'bash', content: 'x'.repeat(300) },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      expect(typeof result.message.content).toBe('string');
+      expect((result.message.content as string).length).toBe(100);
+    });
+
+    it('does not truncate string-form content already under 100 chars', () => {
+      const entry = {
+        type: 'message',
+        message: { role: 'toolResult', toolName: 'bash', content: 'short' },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      expect(result.message.content).toBe('short');
+    });
   });
 });

--- a/packages/server/src/scheduler/jobs.test.ts
+++ b/packages/server/src/scheduler/jobs.test.ts
@@ -321,7 +321,7 @@ describe('stripSessionEntry', () => {
       expect(result.message).not.toHaveProperty('usage');
     });
 
-    it('drops thoughtSignature and id from toolCall blocks', () => {
+    it('drops thoughtSignature but preserves id in toolCall blocks', () => {
       const entry = {
         type: 'message',
         message: {
@@ -340,7 +340,7 @@ describe('stripSessionEntry', () => {
       const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
       const block = (result.message.content as Record<string, unknown>[])[0];
       expect(block).not.toHaveProperty('thoughtSignature');
-      expect(block).not.toHaveProperty('id');
+      expect(block.id).toBe('call-123');
       expect(block.name).toBe('bash');
     });
 
@@ -389,6 +389,35 @@ describe('stripSessionEntry', () => {
       const args = block.arguments as Record<string, unknown>;
       expect(args.limit).toBe(10);
       expect(args.dry).toBe(true);
+    });
+
+    it('truncates string-form arguments to 100 chars', () => {
+      const longJson = 'x'.repeat(300);
+      const entry = {
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'toolCall', name: 'bash', arguments: longJson }],
+        },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      const block = (result.message.content as Record<string, unknown>[])[0];
+      expect(typeof block.arguments).toBe('string');
+      expect((block.arguments as string).length).toBe(100);
+    });
+
+    it('preserves array arguments as-is', () => {
+      const entry = {
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'toolCall', name: 'bash', arguments: ['arg1', 'arg2'] }],
+        },
+      };
+      const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
+      const block = (result.message.content as Record<string, unknown>[])[0];
+      expect(Array.isArray(block.arguments)).toBe(true);
+      expect(block.arguments).toEqual(['arg1', 'arg2']);
     });
 
     it('does not add arguments key when absent on toolCall', () => {

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -127,6 +127,69 @@ export function collectAgentActivity(
 }
 
 /**
+ * Strip verbose fields from a parsed JSONL session entry before injecting into
+ * the Narrator's context. Removes fields that are useless for narrative synthesis
+ * (crypto signatures, token usage, provider metadata, raw tool outputs) and
+ * truncates large argument/result values to 100 chars.
+ *
+ * Operates on plain objects — never mutates the input.
+ */
+export function stripSessionEntry(entry: Record<string, unknown>): Record<string, unknown> {
+  const type = entry.type;
+
+  if (type === 'custom_message') {
+    const { details: _d, ...rest } = entry;
+    return rest;
+  }
+
+  if (type !== 'message') return entry;
+
+  const msg = entry.message;
+  if (!msg || typeof msg !== 'object' || Array.isArray(msg)) return entry;
+  const message = msg as Record<string, unknown>;
+  const role = message.role;
+
+  if (role === 'assistant') {
+    const { usage: _u, api: _a, provider: _p, model: _m, ...strippedMsg } = message;
+    const content = message.content;
+    if (Array.isArray(content)) {
+      strippedMsg.content = content.map((block) => {
+        if (!block || typeof block !== 'object' || Array.isArray(block)) return block;
+        const b = block as Record<string, unknown>;
+        if (b.type !== 'toolCall') return b;
+        const { thoughtSignature: _ts, id: _id, arguments: args, ...rest } = b;
+        const truncatedArgs: Record<string, unknown> = {};
+        if (args && typeof args === 'object' && !Array.isArray(args)) {
+          for (const [k, v] of Object.entries(args as Record<string, unknown>)) {
+            truncatedArgs[k] = typeof v === 'string' && v.length > 100 ? v.slice(0, 100) : v;
+          }
+        }
+        return args ? { ...rest, arguments: truncatedArgs } : rest;
+      });
+    }
+    return { ...entry, message: strippedMsg };
+  }
+
+  if (role === 'toolResult') {
+    const { details: _d, ...strippedMsg } = message;
+    const content = message.content;
+    if (Array.isArray(content)) {
+      strippedMsg.content = content.map((block) => {
+        if (!block || typeof block !== 'object' || Array.isArray(block)) return block;
+        const b = block as Record<string, unknown>;
+        if (b.type !== 'text' || typeof b.text !== 'string') return b;
+        return b.text.length > 100 ? { ...b, text: b.text.slice(0, 100) } : b;
+      });
+    } else if (typeof content === 'string' && content.length > 100) {
+      strippedMsg.content = content.slice(0, 100);
+    }
+    return { ...entry, message: strippedMsg };
+  }
+
+  return entry;
+}
+
+/**
  * Read JSONL entries from all session files in a directory, filtered by time window.
  */
 function readSessionEntries(sessionDir: string, lastRunTs: string, newRunTs: string): string[] {
@@ -149,7 +212,7 @@ function readSessionEntries(sessionDir: string, lastRunTs: string, newRunTs: str
 
         const ts = entry.timestamp;
         if (ts >= lastRunTs && ts < newRunTs) {
-          entries.push(line);
+          entries.push(JSON.stringify(stripSessionEntry(entry)));
         }
       } catch {
         // Skip malformed lines

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -157,14 +157,23 @@ export function stripSessionEntry(entry: Record<string, unknown>): Record<string
         if (!block || typeof block !== 'object' || Array.isArray(block)) return block;
         const b = block as Record<string, unknown>;
         if (b.type !== 'toolCall') return b;
-        const { thoughtSignature: _ts, id: _id, arguments: args, ...rest } = b;
-        const truncatedArgs: Record<string, unknown> = {};
-        if (args && typeof args === 'object' && !Array.isArray(args)) {
-          for (const [k, v] of Object.entries(args as Record<string, unknown>)) {
-            truncatedArgs[k] = typeof v === 'string' && v.length > 100 ? v.slice(0, 100) : v;
+        const { thoughtSignature: _ts, arguments: args, ...rest } = b;
+        if (args !== undefined) {
+          let processedArgs: unknown;
+          if (args && typeof args === 'object' && !Array.isArray(args)) {
+            const truncatedArgs: Record<string, unknown> = {};
+            for (const [k, v] of Object.entries(args as Record<string, unknown>)) {
+              truncatedArgs[k] = typeof v === 'string' && v.length > 100 ? v.slice(0, 100) : v;
+            }
+            processedArgs = truncatedArgs;
+          } else if (typeof args === 'string' && args.length > 100) {
+            processedArgs = args.slice(0, 100);
+          } else {
+            processedArgs = args;
           }
+          return { ...rest, arguments: processedArgs };
         }
-        return args ? { ...rest, arguments: truncatedArgs } : rest;
+        return rest;
       });
     }
     return { ...entry, message: strippedMsg };


### PR DESCRIPTION
Fixes #25

## Summary

- Adds `stripSessionEntry()` in `jobs.ts`, called inside `readSessionEntries()` so it applies to every JSONL entry injected by both the project-log and daily-summary jobs
- Drops `thoughtSignature`, `usage`, `api`, `provider`, `model` from assistant messages and `details` from `toolResult`/`custom_message` entries
- Truncates each toolCall argument value and toolResult content text to 100 chars

## Why

A single 30-minute scheduler window with an active Conductor produced ~465K chars of injected agent activity, of which ~96% was noise (raw tool outputs, crypto signatures, token metadata). This caused ~190K token spikes per delivery that pushed the Narrator's session past Gemini's 1M token context limit, deadlocking compaction and crashing the server.

Field breakdown from the representative spike window:

| Field | Chars | % |
|-------|-------|---|
| `details` | 128,965 | 36.7% |
| tool result content | 92,988 | 26.4% |
| `thoughtSignature` | 61,268 | 17.4% |
| tool call args | 32,451 | 9.2% |
| `usage` + `cost` | 14,315 | 4.1% |
| `thinking` blocks (kept) | 13,964 | 4.0% |

## Test plan

- [ ] New `describe('stripSessionEntry')` block with 20 unit tests covering all transformation rules, edge cases (missing fields, null content, non-array content, string-form toolResult content), and the two originally-found bugs (spurious `arguments: {}` on absent args, untruncated string content)
- [ ] All 254 existing tests pass