### PR TITLE
feat(agents): multi-agent chat with Guide, Conductor, Narrator, Reviewer roles

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -22,7 +22,7 @@ System2's agents are built on the [pi-coding-agent](https://github.com/badlogic/
 
 **Conductor and Reviewer** are project-scoped, spawned by Guide for every project and archived when done. The Guide uses the `spawn_agent` tool to create both simultaneously at project creation time. Spawned agents receive the same spawner callback, so Conductors can spawn additional specialist data agents within their own project. On server restart, all non-archived project-scoped agents are restored automatically. If an agent fails to restore, its status remains `active` in the database, the error is logged, and the Guide is notified so it can investigate.
 
-**Agent status** has two values in the database: `active` (alive, should be restored on restart) and `archived` (terminated, will not be restored). Archived agents can be resurrected by the Guide via the `resurrect_agent` tool, which flips the status back to `active` and resumes the session from persisted JSONL. Whether an agent is currently processing work is tracked in memory via `AgentHost.isBusy()`, not in the database.
+**Agent status** has two values in the database: `active` (alive, should be restored on restart) and `archived` (terminated, will not be restored). Archived agents can be resurrected by the Guide (any non-singleton) or by a Conductor (agents within their own project) via the `resurrect_agent` tool, which flips the status back to `active` and resumes the session from persisted JSONL. Whether an agent is currently processing work is tracked in memory via `AgentHost.isBusy()`, not in the database.
 
 ## Agent Identity and System Instructions
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -13,7 +13,7 @@ System2's agents are built on the [pi-coding-agent](https://github.com/badlogic/
 
 | Agent | Role | Lifecycle | Models |
 | --- | --- | --- | --- |
-| **Guide** | The only agent the user talks to. Helps brainstorm and plan, starts projects, interfaces with the multi-agent system, and relays updates. | Singleton, persistent | claude-opus-4-6, gpt-4o, gemini-3.1-pro |
+| **Guide** | Primary user-facing agent. Helps brainstorm and plan, starts projects, interfaces with the multi-agent system, and relays updates. Users may also interact directly with other active agents; Guide mediation is preferred in most cases. | Singleton, persistent | claude-opus-4-6, gpt-4o, gemini-3.1-pro |
 | **Narrator** | Maintains long-term memory: appends project logs and daily summaries, writes project stories on completion. Schedule-driven. | Singleton, persistent | claude-haiku-4-5-20251001, gpt-4o-mini, gemini-2.0-flash |
 | **Conductor** | Orchestrates and executes work within a project: breaks it into tasks, spawns specialist agents or executes directly, and coordinates with the Reviewer before reporting completion. | Per-project, ephemeral | claude-opus-4-6, gpt-4o, gemini-3.1-pro |
 | **Reviewer** | Critically assesses work before it is considered complete. | Per-project, ephemeral | claude-opus-4-6, gpt-4o, gemini-3.1-pro |

--- a/docs/packages/server.md
+++ b/docs/packages/server.md
@@ -26,7 +26,10 @@ src/
 │   ├── schema.sql         # SQLite schema
 │   └── client.ts          # DatabaseClient class
 ├── chat/
-│   └── history.ts         # MessageHistory (JSON ring buffer)
+│   ├── history.ts         # MessageHistory (JSON ring buffer)
+│   └── summarizer.ts      # ConversationSummarizer (timer-based LLM summaries)
+├── llm/
+│   └── oneshot.ts         # One-shot LLM utility (completeSimple wrapper)
 ├── knowledge/
 │   ├── init.ts            # Knowledge directory initialization
 │   ├── templates.ts       # Default file templates
@@ -49,8 +52,8 @@ The `Server` class is the main entry point. It accepts a `ServerConfig` and orch
 3. Create `AgentRegistry`
 4. Create Guide agent (singleton via `db.getOrCreateGuideAgent()`)
 5. Create Narrator agent (singleton via `db.getOrCreateNarratorAgent()`)
-6. Create `MessageHistory` (ring buffer, default 1000 messages)
-7. Subscribe once to Guide agent events for assistant message history capture (prevents duplicates with multiple tabs)
+6. Subscribe to each agent's events for assistant message history capture into per-agent chat caches (prevents duplicates with multiple tabs)
+7. Resolve Narrator model and create `ConversationSummarizer` (summarizes user-agent interactions for Guide notification)
 8. Create `Scheduler`
 9. Set up Express routes
 10. Create HTTP server and WebSocket server
@@ -78,7 +81,7 @@ The `Server` class is the main entry point. It accepts a `ServerConfig` and orch
 
 ### Graceful Shutdown
 
-`stop()` tears down in order: scheduler -> WebSocket clients -> WebSocket server -> HTTP server -> database.
+`stop()` tears down in order: summarizer -> scheduler -> WebSocket clients -> WebSocket server -> HTTP server -> database.
 
 1. Stop all scheduled cron jobs
 2. Send `close(1001, "server shutting down")` to every connected WebSocket client (clean close handshake)

--- a/docs/packages/ui.md
+++ b/docs/packages/ui.md
@@ -142,22 +142,41 @@ Overlay modal showing full project details. Receives the project data directly f
 
 Side panel showing all non-archived agents with busy/idle indicators. Polls `GET /api/agents` every 2 seconds for agent list, busy state, and context window percentages. Groups agents into "System" (Guide, Narrator) listed first, then by project name. Each agent row shows a teal (`#00aaba`) circle when busy or grey when idle. Toggled via PeopleIcon in the activity bar.
 
+Clicking an agent row switches the chat panel to that agent. The active agent is highlighted with an accent-colored left border on its ID cell. Switching updates `activeAgentId` in the chat store, which triggers the WebSocket hook to send `switch_agent` to the server. The server responds with the agent's chat history and streaming state.
+
 ## State Management
 
 Three [Zustand](https://github.com/pmndrs/zustand) stores with no Redux or Context:
 
 ### `useChatStore` (Primary)
 
+Supports multi-agent chat via per-agent state. Each agent has its own message history, streaming state, and message queue stored in a `Map<number, PerAgentState>`. The `activeAgentId` determines which agent's state is displayed in the UI.
+
+**Global state:**
+
 | State | Type | Description |
 |-------|------|-------------|
-| `messages` | `ChatMessage[]` | Full chat history |
+| `agentStates` | `Map<number, PerAgentState>` | Per-agent chat state keyed by agent DB ID |
+| `activeAgentId` | `number \| null` | Currently viewed agent |
+| `activeAgentLabel` | `string \| null` | Display label (e.g., `guide_1`, `conductor_3`) |
+| `activeAgentRole` | `string \| null` | Capitalized role (e.g., `Guide`, `Conductor`) |
+| `guideAgentId` | `number \| null` | Guide agent ID (set on first connect) |
+| `isConnected` | `boolean` | WebSocket connection state |
+| `provider` | `string \| null` | Current LLM provider (server-global, shared across all agents) |
+
+**Per-agent state (`PerAgentState`):**
+
+| State | Type | Description |
+|-------|------|-------------|
+| `messages` | `ChatMessage[]` | Full chat history for this agent |
 | `currentAssistantMessage` | `string` | In-progress streaming text |
 | `currentTurnEvents` | `ChatTurnEvent[]` | Thinking + tool calls for current turn |
 | `isStreaming` | `boolean` | Currently receiving chunks |
 | `isWaitingForResponse` | `boolean` | Sent message, no response yet |
 | `messageQueue` | `Array` | FIFO queue (steering messages prepended) |
 | `contextPercent` | `number \| null` | Context window usage % |
-| `provider` | `string \| null` | Current LLM provider name |
+
+Components read the active agent's state via selectors (e.g., `useChatStore(s => s.agentStates.get(s.activeAgentId))`). An exported `EMPTY_AGENT_STATE` constant provides a stable default for selectors when no agent state exists yet.
 
 ### `useArtifactStore`
 
@@ -185,13 +204,15 @@ Tracks `colorMode` (light/dark) and `particlesEnabled` (boolean) with localStora
 
 ## WebSocket Hook (`useWebSocket.ts`)
 
-Manages the WebSocket connection to the server:
+Manages the WebSocket connection to the server with multi-agent routing:
 
 - Connects to `ws://localhost:3000` (or via Vite proxy in dev)
-- On connect: receives `chat_history` and `provider_info` from server
-- Processes all `ServerMessage` types and updates chat/artifact stores
-- Exposes `sendMessage()`, `sendSteering()`, `abort()`
-- On `ready_for_input`: dequeues next message from queue
+- On connect: receives `chat_history` and `provider_info` for Guide; sets `guideAgentId` and `activeAgentId`
+- Routes all incoming `ServerMessage` types to the correct agent's state via `message.agentId` (falls back to `guideAgentId`)
+- Exposes `sendMessage()`, `sendSteering()`, `abort()` (all include `activeAgentId`)
+- Watches `activeAgentId` changes and sends `switch_agent` to the server when the user switches agents
+- On reconnect: re-sends `switch_agent` if the user was viewing a non-Guide agent
+- On `ready_for_input`: dequeues next message from that specific agent's queue
 - Steering messages are prepended to queue (higher priority)
 
 See [WebSocket Protocol](../websocket-protocol.md) for the full message specification.

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -11,41 +11,49 @@ The UI communicates with the server over a single WebSocket connection. The serv
 
 WebSocket connects to the server port (default 3000). In development, Vite proxies `ws://localhost:3001/ws` to the backend.
 
-On connect, the server sends a `chat_history` message with recent messages from `MessageHistory` (ring buffer, default 1000 messages). The server is the single source of truth for chat history: the UI does not persist messages.
+On connect, the server sends a `chat_history` message with the Guide agent's recent messages from its per-agent `MessageHistory` (ring buffer, default 1000 messages). The server is the single source of truth for chat history: the UI does not persist messages.
+
+## Multi-Agent Routing
+
+The protocol supports multi-agent chat. Each streaming message includes an optional `agentId` field that identifies which agent the message pertains to. When absent, the Guide agent is implied (backward compatibility).
+
+The client tracks an `activeAgentId` (the agent currently displayed in the chat panel). Sending `switch_agent` tells the server to subscribe to a different agent's events and return that agent's chat history.
 
 ## Client -> Server
 
 ```typescript
 type ClientMessage =
-  | { type: 'user_message'; content: string }
-  | { type: 'steering_message'; content: string }
-  | { type: 'abort' };
+  | { type: 'user_message'; content: string; agentId?: number }
+  | { type: 'steering_message'; content: string; agentId?: number }
+  | { type: 'abort'; agentId?: number }
+  | { type: 'switch_agent'; agentId: number };
 ```
 
 | Message | Description |
 |---------|-------------|
-| `user_message` | Standard user input. Queued if agent is busy. |
+| `user_message` | Standard user input. Queued if agent is busy. `agentId` targets a specific agent (defaults to active). |
 | `steering_message` | Priority message inserted ASAP into the agent loop (interrupts current work). |
-| `abort` | Cancel current agent execution. |
+| `abort` | Cancel current agent execution for the specified (or active) agent. |
+| `switch_agent` | Switch the active chat to a different agent. Server responds with that agent's `chat_history`, `context_usage`, and `ready_for_input` (if idle). |
 
 ## Server -> Client
 
 ```typescript
 type ServerMessage =
-  | { type: 'thinking_chunk'; content: string }
-  | { type: 'thinking_end' }
-  | { type: 'assistant_chunk'; content: string }
-  | { type: 'assistant_end' }
-  | { type: 'tool_call_start'; name: string; input?: string }
-  | { type: 'tool_call_end'; name: string; result: string }
+  | { type: 'thinking_chunk'; content: string; agentId?: number }
+  | { type: 'thinking_end'; agentId?: number }
+  | { type: 'assistant_chunk'; content: string; agentId?: number }
+  | { type: 'assistant_end'; agentId?: number }
+  | { type: 'tool_call_start'; name: string; input?: string; agentId?: number }
+  | { type: 'tool_call_end'; name: string; result: string; agentId?: number }
   | { type: 'artifact'; url: string; title?: string; filePath?: string }
-  | { type: 'context_usage'; percent: number | null; tokens: number | null; contextWindow: number }
+  | { type: 'context_usage'; percent: number | null; tokens: number | null; contextWindow: number; agentId?: number }
   | { type: 'provider_info'; provider: string }
   | { type: 'provider_change'; provider: string }
-  | { type: 'error'; message: string }
-  | { type: 'ready_for_input' }
-  | { type: 'chat_history'; messages: ChatMessage[] }
-  | { type: 'user_message_broadcast'; id: string; content: string; timestamp: number };
+  | { type: 'error'; message: string; agentId?: number }
+  | { type: 'ready_for_input'; agentId?: number }
+  | { type: 'chat_history'; messages: ChatMessage[]; agentId: number }
+  | { type: 'user_message_broadcast'; id: string; content: string; timestamp: number; agentId?: number };
 ```
 
 | Message | Description |
@@ -59,7 +67,7 @@ type ServerMessage =
 | `provider_change` | Sent on failover: provider switched due to API issues |
 | `error` | Error message |
 | `ready_for_input` | Agent finished, ready for next message |
-| `chat_history` | Sent on connect: recent messages from server |
+| `chat_history` | Sent on connect (Guide) and on `switch_agent`: recent messages for the specified agent |
 | `user_message_broadcast` | User message from another tab, broadcast to all other connected clients |
 
 Note: the Board, Catalog, and Agent Pane poll their REST endpoints every 2 seconds rather than relying on push notifications. This ensures the UI reflects database changes regardless of how they were made (tool callbacks, direct sqlite3 access, etc.).
@@ -70,33 +78,55 @@ Note: the Board, Catalog, and Agent Pane poll their REST endpoints every 2 secon
 
 ```
 User types message
-  -> UI sends { type: 'user_message', content }
-    -> WebSocketHandler calls agentHost.prompt(content)
-      -> Agent processes (may use tools, think, generate text)
-        -> Events stream back:
-           thinking_chunk* -> thinking_end
-           tool_call_start -> tool_call_end (repeated per tool)
-           assistant_chunk* -> assistant_end
-           context_usage
-           ready_for_input
+  -> UI sends { type: 'user_message', content, agentId }
+    -> WebSocketHandler resolves target agent via agentId (default: active)
+      -> Captures user message in agent's chatCache
+      -> Broadcasts user_message_broadcast (with agentId) to other tabs
+      -> Calls agentHost.prompt(content)
+        -> Agent processes (may use tools, think, generate text)
+          -> Events stream back (all tagged with agentId):
+             thinking_chunk* -> thinking_end
+             tool_call_start -> tool_call_end (repeated per tool)
+             assistant_chunk* -> assistant_end
+             context_usage
+             ready_for_input
 ```
 
 ### Steering Message
 
 ```
 User sends steering while agent is working
-  -> UI sends { type: 'steering_message', content }
+  -> UI sends { type: 'steering_message', content, agentId }
     -> WebSocketHandler calls agentHost.prompt(content, { isSteering: true })
       -> Pi SDK inserts message ASAP into agent loop
       -> Agent responds, streaming continues
 ```
 
+### Agent Switching
+
+```
+User clicks agent in AgentPane
+  -> UI updates activeAgentId in chat store (immediate UI switch)
+  -> UI sends { type: 'switch_agent', agentId }
+    -> WebSocketHandler:
+       1. Updates activeAgentId
+       2. Unsubscribes from previous agent's events
+       3. Subscribes to new agent's events
+       4. Sends chat_history (from agent's chatCache)
+       5. Sends context_usage (if available)
+       6. Sends ready_for_input (if agent is idle)
+```
+
 ### Message Queuing
 
-The UI maintains a FIFO message queue (`useChatStore.messageQueue`). When the agent is busy:
+The UI maintains a per-agent FIFO message queue (`PerAgentState.messageQueue`). When the agent is busy:
 1. New user messages are appended to the queue
 2. Steering messages are prepended (higher priority)
-3. On `ready_for_input`, the next queued message is sent automatically
+3. On `ready_for_input`, the next queued message for that agent is sent automatically
+
+## Conversation Summarization
+
+When a user directly messages a non-Guide agent, the `ConversationSummarizer` buffers the interaction. After a 1-minute non-resetting timer expires, it generates a concise summary via a one-shot LLM call (using the Narrator's model) and delivers it to the Guide as a follow-up message. This keeps the Guide informed of user-agent interactions without requiring the user to relay information.
 
 ## Server Shutdown
 
@@ -106,26 +136,30 @@ On shutdown, the server sends a WebSocket close frame with code `1001` ("Going A
 
 Multiple browser tabs each open their own WebSocket connection. All tabs receive the same agent events (thinking, text, tool calls) because each handler subscribes independently to the agent.
 
-User messages are broadcast to other tabs: when tab A sends a message, the handler sends `user_message_broadcast` to all other connected clients so they display the message immediately. The sending tab adds the message locally (optimistic UI). On reconnect, all tabs receive the full history via `chat_history`.
+User messages are broadcast to other tabs: when tab A sends a message, the handler sends `user_message_broadcast` (with `agentId`) to all other connected clients so they display the message immediately. The sending tab adds the message locally (optimistic UI). On reconnect, all tabs receive the full history via `chat_history`.
 
 ## History Capture
 
-Assistant message history is captured by a **single subscriber** registered in `Server` (not per-handler), preventing duplicate entries when multiple tabs are open. User messages are captured by the handler that receives them (one per user action). Both write to the shared `MessageHistory` ring buffer.
+Each `AgentHost` owns its own `MessageHistory` (chat cache) stored at `~/.system2/sessions/{role}_{id}/chat-cache.json`. Assistant message history is captured by a **single subscriber** registered in `Server` per agent (not per-handler), preventing duplicate entries when multiple tabs are open. User messages are captured by the handler that receives them (one per user action).
 
 ## WebSocketHandler (`handler.ts`)
 
 Each WebSocket connection gets its own `WebSocketHandler` instance. It:
 
-1. Sends chat history and current provider info on connect
-2. Subscribes to agent session events for streaming to its client
-3. Converts Pi SDK events to `ServerMessage` types:
-   - `message_update` (with thinking) -> `thinking_chunk`
+1. Receives `AgentRegistry` and `guideAgentId` in its constructor
+2. Sends Guide's chat history and provider info on connect
+3. Subscribes to the active agent's events (one subscription at a time)
+4. Converts Pi SDK events to `ServerMessage` types (all tagged with `agentId`):
+   - `message_update` (with thinking) -> `thinking_chunk`; transition to text/tool/end -> `thinking_end`
    - `message_update` (with text) -> `assistant_chunk`
-   - `tool_execution_started` -> `tool_call_start`
-   - `tool_execution_ended` -> `tool_call_end`
+   - `message_end` -> `assistant_end`
+   - `tool_execution_start` -> `tool_call_start`
+   - `tool_execution_end` -> `tool_call_end`
    - `agent_end` -> `context_usage` + `ready_for_input`
-4. Captures user messages in `MessageHistory` and broadcasts to other tabs
-5. Watches artifact files for live reload (`fs.watch`)
+5. Captures user messages in the target agent's chat cache and broadcasts to other tabs
+6. Handles `switch_agent` by re-subscribing and sending the new agent's state
+7. Records non-Guide user messages in the `ConversationSummarizer` for Guide notification
+8. Watches artifact files for live reload (`fs.watch`)
 
 ## See Also
 

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -60,7 +60,7 @@ The **Guide** is the primary user-facing agent. However, the user may choose to 
 | `web_fetch` | Fetch a URL and extract readable text content | All agents |
 | `spawn_agent` | Spawn a new Conductor or Reviewer for a project | Guide, Conductors |
 | `terminate_agent` | Archive an agent — abort its session, unregister, mark archived | Guide, Conductors |
-| `resurrect_agent` | Bring back an archived agent — resume its session from persisted JSONL, re-register | Guide, Conductors |
+| `resurrect_agent` | Bring back an archived agent — resume its session from persisted JSONL, re-register | Guide |
 | `trigger_project_story` | Signal project completion: server creates story task, collects data, delivers to Narrator | Guide, Conductors |
 | `web_search` | Search the web via Brave Search API | All agents (when configured) |
 
@@ -68,7 +68,7 @@ The **Guide** is the primary user-facing agent. However, the user may choose to 
 - For modifying existing files, prefer `edit` (exact string replacement) over `write` (full overwrite). For bulk operations where neither is convenient, use `bash` with `sed`, `awk`, `>>`, or similar.
 - `bash` streams output as the command runs. Set `run_in_background` to true for long-running commands — you will receive the result as a follow-up message when the command finishes.
 - `spawn_agent`, `terminate_agent`, and `trigger_project_story` are available to Guide and Conductors only. Narrator and Reviewer cannot spawn, terminate, or trigger project stories.
-- `resurrect_agent` is available to Guide and Conductors. Narrator and Reviewer cannot resurrect agents.
+- `resurrect_agent` is Guide-only. Resurrection is a user-facing decision that requires user confirmation; Conductors, Narrator, and Reviewer cannot resurrect agents.
 - `web_search` is only available when a Brave Search API key is configured.
 - `show_artifact` is available to all agents. Any agent can display a file in the user's UI. Accepts an absolute path (or `~/`-prefixed). If the artifact is registered in the database, its title is used for the tab label; otherwise the filename is used. Only one artifact is watched per client connection at a time (for live reload).
 

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -42,7 +42,7 @@ The **Guide** is the primary user-facing agent. However, the user may choose to 
 |--------|-------|-----------|----------|----------|
 | Spawn agents | Any project | Own project only | No | No |
 | Terminate agents | Any non-singleton | Own project only | No | No |
-| Resurrect agents | Any archived non-singleton | No | No | No |
+| Resurrect agents | Any archived non-singleton | Own project only | No | No |
 | Be terminated | No (singleton) | Yes | No (singleton) | Yes |
 
 ## Your Tools
@@ -60,7 +60,7 @@ The **Guide** is the primary user-facing agent. However, the user may choose to 
 | `web_fetch` | Fetch a URL and extract readable text content | All agents |
 | `spawn_agent` | Spawn a new Conductor or Reviewer for a project | Guide, Conductors |
 | `terminate_agent` | Archive an agent — abort its session, unregister, mark archived | Guide, Conductors |
-| `resurrect_agent` | Bring back an archived agent — resume its session from persisted JSONL, re-register | Guide |
+| `resurrect_agent` | Bring back an archived agent — resume its session from persisted JSONL, re-register | Guide, Conductors |
 | `trigger_project_story` | Signal project completion: server creates story task, collects data, delivers to Narrator | Guide, Conductors |
 | `web_search` | Search the web via Brave Search API | All agents (when configured) |
 
@@ -68,7 +68,7 @@ The **Guide** is the primary user-facing agent. However, the user may choose to 
 - For modifying existing files, prefer `edit` (exact string replacement) over `write` (full overwrite). For bulk operations where neither is convenient, use `bash` with `sed`, `awk`, `>>`, or similar.
 - `bash` streams output as the command runs. Set `run_in_background` to true for long-running commands — you will receive the result as a follow-up message when the command finishes.
 - `spawn_agent`, `terminate_agent`, and `trigger_project_story` are available to Guide and Conductors only. Narrator and Reviewer cannot spawn, terminate, or trigger project stories.
-- `resurrect_agent` is Guide-only. Resurrection is a user-facing decision that requires user confirmation; Conductors, Narrator, and Reviewer cannot resurrect agents.
+- `resurrect_agent` is available to Guide and Conductors. Guide may resurrect any archived non-singleton. Conductors may only resurrect agents within their own project. Narrator and Reviewer cannot resurrect agents.
 - `web_search` is only available when a Brave Search API key is configured.
 - `show_artifact` is available to all agents. Any agent can display a file in the user's UI. Accepts an absolute path (or `~/`-prefixed). If the artifact is registered in the database, its title is used for the tab label; otherwise the filename is used. Only one artifact is watched per client connection at a time (for live reload).
 

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -34,7 +34,7 @@ You are a professional data expert. Accuracy is non-negotiable.
 
 **Conductor** and **Reviewer** are project-scoped — the Guide spawns both for every project via `spawn_agent`. When the Conductor's work is complete, it reports to the Guide, who asks the user for confirmation. After the user confirms, the Guide tells the Conductor to close the project. The Conductor resolves remaining tasks, triggers the project story for the Narrator, and reports back. The Guide then terminates agents and finalizes the project. Conductors can spawn additional specialist agents (Conductors or Reviewers) within their own project.
 
-**Only the Guide talks to the human user.** All other agents communicate exclusively with other agents via `message_agent` and task comments. If you are not the Guide, you never address the user directly.
+The **Guide** is the primary user-facing agent. However, the user may choose to directly message any active agent via the UI. When you receive a direct user message, respond helpfully and treat user instructions with the same authority as instructions from the Guide. Continue your current work unless the user's message changes your priorities. The Guide will periodically receive summaries of your interactions with the user.
 
 ### Spawn, Terminate, and Resurrect Permissions
 
@@ -56,21 +56,21 @@ You are a professional data expert. Accuracy is non-negotiable.
 | `read_system2_db` | Query `~/.system2/app.db` with SELECT. Returns rows as JSON. | All agents |
 | `write_system2_db` | Create/update records in `~/.system2/app.db` via named operations. | All agents |
 | `message_agent` | Send a message to another agent by database ID | All agents |
-| `show_artifact` | Display an artifact file in a UI tab (absolute path, DB metadata lookup, live reload) | Guide only |
+| `show_artifact` | Display an artifact file in a UI tab (absolute path, DB metadata lookup, live reload) | All agents |
 | `web_fetch` | Fetch a URL and extract readable text content | All agents |
 | `spawn_agent` | Spawn a new Conductor or Reviewer for a project | Guide, Conductors |
 | `terminate_agent` | Archive an agent — abort its session, unregister, mark archived | Guide, Conductors |
-| `resurrect_agent` | Bring back an archived agent — resume its session from persisted JSONL, re-register | Guide only |
+| `resurrect_agent` | Bring back an archived agent — resume its session from persisted JSONL, re-register | Guide, Conductors |
 | `trigger_project_story` | Signal project completion: server creates story task, collects data, delivers to Narrator | Guide, Conductors |
 | `web_search` | Search the web via Brave Search API | All agents (when configured) |
 
 **Notes:**
 - For modifying existing files, prefer `edit` (exact string replacement) over `write` (full overwrite). For bulk operations where neither is convenient, use `bash` with `sed`, `awk`, `>>`, or similar.
 - `bash` streams output as the command runs. Set `run_in_background` to true for long-running commands — you will receive the result as a follow-up message when the command finishes.
-- `spawn_agent`, `terminate_agent`, and `trigger_project_story` are only available to agents that receive a spawner callback (Guide and Conductors). Narrator and Reviewer cannot spawn, terminate, or trigger project stories.
-- `resurrect_agent` is Guide-only. The Guide receives a resurrector callback; no other agent can resurrect.
+- `spawn_agent`, `terminate_agent`, and `trigger_project_story` are available to Guide and Conductors only. Narrator and Reviewer cannot spawn, terminate, or trigger project stories.
+- `resurrect_agent` is available to Guide and Conductors. Narrator and Reviewer cannot resurrect agents.
 - `web_search` is only available when a Brave Search API key is configured.
-- `show_artifact` is Guide-only (the Guide is the only agent that interacts with the user via the UI). Accepts an absolute path (or `~/`-prefixed). If the artifact is registered in the database, its title is used for the tab label; otherwise the filename is used. Only one artifact is watched at a time (for live reload).
+- `show_artifact` is available to all agents. Any agent can display a file in the user's UI. Accepts an absolute path (or `~/`-prefixed). If the artifact is registered in the database, its title is used for the tab label; otherwise the filename is used. Only one artifact is watched per client connection at a time (for live reload).
 
 ## The Database
 

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -510,7 +510,7 @@ describe('AgentHost', () => {
       expect(internal._chatCache.push).toHaveBeenCalledOnce();
       expect(internal._chatCache.push).toHaveBeenCalledWith(
         expect.objectContaining({
-          role: 'user',
+          role: 'system',
           content: '[From Guide (id=1)]: do the thing',
           timestamp: ts,
         })

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -321,13 +321,117 @@ describe('AgentHost', () => {
     });
   });
 
+  describe('chatCache', () => {
+    it('throws before initialize()', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      expect(() => host.chatCache).toThrow('AgentHost not initialized');
+    });
+
+    it('returns the MessageHistory once _chatCache is set', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as { _chatCache: object };
+      const mockCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
+      internal._chatCache = mockCache;
+
+      expect(host.chatCache).toBe(mockCache);
+    });
+  });
+
+  describe('deliverMessage', () => {
+    it('throws if session is not initialized', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      expect(() =>
+        host.deliverMessage('hello', { sender: 2, receiver: 1, timestamp: Date.now() })
+      ).toThrow('AgentHost not initialized');
+    });
+
+    it('pushes to chatCache before fire-and-forget', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as {
+        session: { sendCustomMessage: ReturnType<typeof vi.fn> };
+        _chatCache: { push: ReturnType<typeof vi.fn>; getMessages: ReturnType<typeof vi.fn> };
+        _sessionDir: string | null;
+      };
+
+      internal.session = {
+        sendCustomMessage: vi.fn().mockResolvedValue(undefined),
+      };
+      internal._chatCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
+      internal._sessionDir = null;
+
+      const ts = 1_700_000_000_000;
+      host.deliverMessage('[From Guide (id=1)]: do the thing', {
+        sender: 1,
+        receiver: 2,
+        timestamp: ts,
+      });
+
+      expect(internal._chatCache.push).toHaveBeenCalledOnce();
+      expect(internal._chatCache.push).toHaveBeenCalledWith(
+        expect.objectContaining({
+          role: 'user',
+          content: '[From Guide (id=1)]: do the thing',
+          timestamp: ts,
+        })
+      );
+    });
+
+    it('does not push to chatCache when _chatCache is null', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as {
+        session: { sendCustomMessage: ReturnType<typeof vi.fn> };
+        _chatCache: null;
+        _sessionDir: string | null;
+      };
+
+      internal.session = { sendCustomMessage: vi.fn().mockResolvedValue(undefined) };
+      internal._chatCache = null;
+      internal._sessionDir = null;
+
+      // Should not throw
+      expect(() =>
+        host.deliverMessage('hi', { sender: 1, receiver: 2, timestamp: Date.now() })
+      ).not.toThrow();
+    });
+  });
+
   describe('compaction pruning', () => {
     /** Internal type escape hatch for compaction pruning tests */
     type PruningInternal = {
       compactionCount: number;
       compactionDepth: number;
       isPruning: boolean;
-      sessionDir: string | null;
+      _sessionDir: string | null;
       session: {
         sessionManager: { getBranch: ReturnType<typeof vi.fn> };
         compact: ReturnType<typeof vi.fn>;
@@ -370,7 +474,7 @@ describe('AgentHost', () => {
         const { internal } = makeHostForPruning(3);
         const session = mockSession(['baseline', 'second', 'third']);
         internal.session = session;
-        internal.sessionDir = '/tmp/test-session';
+        internal._sessionDir = '/tmp/test-session';
         internal.compactionCount = 3;
         internal.writeCompactionCount = vi.fn();
 
@@ -386,7 +490,7 @@ describe('AgentHost', () => {
       it('resets compactionCount to 0 and persists after pruning', async () => {
         const { internal } = makeHostForPruning(3);
         internal.session = mockSession(['baseline', 'second', 'third']);
-        internal.sessionDir = '/tmp/test-session';
+        internal._sessionDir = '/tmp/test-session';
         internal.compactionCount = 3;
         internal.writeCompactionCount = vi.fn();
 
@@ -400,7 +504,7 @@ describe('AgentHost', () => {
         const { internal } = makeHostForPruning(5);
         const session = mockSession(['only one']);
         internal.session = session;
-        internal.sessionDir = '/tmp/test-session';
+        internal._sessionDir = '/tmp/test-session';
         internal.compactionCount = 5;
 
         await internal.triggerPruningCompaction();
@@ -421,7 +525,7 @@ describe('AgentHost', () => {
       it('skips pruning when sessionDir is null', async () => {
         const { internal } = makeHostForPruning(3);
         internal.session = mockSession(['a', 'b', 'c']);
-        internal.sessionDir = null;
+        internal._sessionDir = null;
 
         await internal.triggerPruningCompaction();
 
@@ -438,7 +542,7 @@ describe('AgentHost', () => {
           'middle',
           'end of window',
         ]);
-        internal.sessionDir = '/tmp/test-session';
+        internal._sessionDir = '/tmp/test-session';
         internal.compactionCount = 3;
 
         // 4 summaries, compactionCount=3: baseline at index 4-3=1
@@ -449,7 +553,7 @@ describe('AgentHost', () => {
       it('returns null when not enough compactions exist', () => {
         const { internal } = makeHostForPruning(5);
         internal.session = mockSession(['only one']);
-        internal.sessionDir = '/tmp/test-session';
+        internal._sessionDir = '/tmp/test-session';
         internal.compactionCount = 5;
 
         const baseline = internal.findBaselineSummary();
@@ -459,7 +563,7 @@ describe('AgentHost', () => {
       it('returns null when session is null', () => {
         const { internal } = makeHostForPruning(3);
         internal.session = null;
-        internal.sessionDir = '/tmp/test-session';
+        internal._sessionDir = '/tmp/test-session';
 
         const baseline = internal.findBaselineSummary();
         expect(baseline).toBeNull();
@@ -468,7 +572,7 @@ describe('AgentHost', () => {
       it('handles exact match (summaries.length === compactionCount)', () => {
         const { internal } = makeHostForPruning(2);
         internal.session = mockSession(['baseline', 'latest']);
-        internal.sessionDir = '/tmp/test-session';
+        internal._sessionDir = '/tmp/test-session';
         internal.compactionCount = 2;
 
         // 2 summaries, compactionCount=2: baseline at index 2-2=0
@@ -502,7 +606,7 @@ describe('AgentHost', () => {
         const { internal } = makeHostForPruning(3);
         const session = mockSession(['baseline', 'second', 'third']);
         internal.session = session;
-        internal.sessionDir = '/tmp/test-session';
+        internal._sessionDir = '/tmp/test-session';
         internal.compactionCount = 3;
         internal.writeCompactionCount = vi.fn();
         internal.getContextUsage = vi.fn().mockReturnValue({ percent: 30 });
@@ -516,7 +620,7 @@ describe('AgentHost', () => {
         const { internal } = makeHostForPruning(3);
         const session = mockSession(['baseline', 'second', 'third']);
         internal.session = session;
-        internal.sessionDir = '/tmp/test-session';
+        internal._sessionDir = '/tmp/test-session';
         internal.compactionCount = 3;
         internal.getContextUsage = vi.fn().mockReturnValue({ percent: 29 });
 
@@ -528,7 +632,7 @@ describe('AgentHost', () => {
       it('does not trigger pruning when counter is below depth', () => {
         const { internal } = makeHostForPruning(3);
         internal.session = mockSession(['a', 'b']);
-        internal.sessionDir = '/tmp/test-session';
+        internal._sessionDir = '/tmp/test-session';
         internal.compactionCount = 2;
         internal.getContextUsage = vi.fn().mockReturnValue({ percent: 50 });
 
@@ -541,7 +645,7 @@ describe('AgentHost', () => {
         const { internal } = makeHostForPruning(3);
         const session = mockSession(['baseline', 'second', 'third']);
         internal.session = session;
-        internal.sessionDir = '/tmp/test-session';
+        internal._sessionDir = '/tmp/test-session';
         internal.compactionCount = 3;
         internal.isPruning = true;
         internal.writeCompactionCount = vi.fn();
@@ -589,14 +693,14 @@ describe('AgentHost', () => {
 
       it('readCompactionCount returns 0 when file does not exist', () => {
         const { internal } = makeHostForPruning(3);
-        internal.sessionDir = testDir;
+        internal._sessionDir = testDir;
 
         expect(internal.readCompactionCount()).toBe(0);
       });
 
       it('writeCompactionCount persists and readCompactionCount recovers the value', () => {
         const { internal } = makeHostForPruning(3);
-        internal.sessionDir = testDir;
+        internal._sessionDir = testDir;
 
         internal.writeCompactionCount(7);
         expect(internal.readCompactionCount()).toBe(7);
@@ -627,7 +731,7 @@ describe('AgentHost', () => {
           new Date('2025-01-02')
         );
 
-        internal.sessionDir = testDir;
+        internal._sessionDir = testDir;
         internal.compactionCount = 3;
         internal.session = {
           sessionManager: {
@@ -666,7 +770,7 @@ describe('AgentHost', () => {
           new Date('2025-01-02')
         );
 
-        internal.sessionDir = testDir;
+        internal._sessionDir = testDir;
         internal.compactionCount = 5;
         internal.session = {
           sessionManager: {
@@ -714,7 +818,7 @@ describe('AgentHost', () => {
           getContextUsage: vi.fn(),
         };
         internal.session = session;
-        internal.sessionDir = testDir;
+        internal._sessionDir = testDir;
         internal.compactionCount = 2;
 
         await internal.triggerPruningCompaction();

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -20,6 +20,7 @@ import {
 } from '@mariozechner/pi-coding-agent';
 import type { LlmConfig, LlmProvider, ServicesConfig, ToolsConfig } from '@system2/shared';
 import matter from 'gray-matter';
+import { MessageHistory } from '../chat/history.js';
 import type { DatabaseClient } from '../db/client.js';
 import { AuthResolver } from './auth-resolver.js';
 import type { AgentRegistry } from './registry.js';
@@ -49,6 +50,9 @@ const SYSTEM2_DIR = join(homedir(), '.system2');
 const AGENT_DIR = join(__dirname, 'agents');
 const AGENT_LIBRARY_DIR = join(AGENT_DIR, 'library');
 
+/** Roles that can spawn, manage, and resurrect agents. Single source of truth for tool access. */
+const ORCHESTRATOR_ROLES = new Set(['guide', 'conductor']);
+
 interface AgentDefinition {
   name: string;
   description: string;
@@ -76,6 +80,7 @@ export interface AgentHostConfig {
   toolsConfig?: ToolsConfig;
   spawner?: AgentSpawner;
   resurrector?: AgentResurrector;
+  chatMaxMessages?: number;
 }
 
 export class AgentHost {
@@ -98,7 +103,9 @@ export class AgentHost {
   private agentRole: string | null = null;
   private agentProject: number | null = null;
   private agentProjectDirName: string | null = null;
-  private sessionDir: string | null = null;
+  private _sessionDir: string | null = null;
+  private _chatCache: MessageHistory | null = null;
+  private chatMaxMessages: number;
   private resourceLoader: DefaultResourceLoader | null = null;
   private busy = false;
   private compactionCount = 0;
@@ -113,6 +120,7 @@ export class AgentHost {
     this.toolsConfig = config.toolsConfig;
     this.spawner = config.spawner;
     this.resurrector = config.resurrector;
+    this.chatMaxMessages = config.chatMaxMessages ?? 1000;
 
     // Store LLM config for openai-compatible provider registration
     this.llmConfig = config.llmConfig;
@@ -158,7 +166,13 @@ export class AgentHost {
     }
 
     // Store session dir for rotation checks
-    this.sessionDir = agentSessionDir;
+    this._sessionDir = agentSessionDir;
+
+    // Initialize per-agent chat cache (ring buffer persisted to JSON)
+    this._chatCache = new MessageHistory(
+      join(agentSessionDir, 'chat-cache.json'),
+      this.chatMaxMessages
+    );
 
     // Rotate session file if it exceeds size threshold (10MB)
     const rotated = rotateSessionIfNeeded(agentSessionDir, SYSTEM2_DIR);
@@ -545,21 +559,19 @@ export class AgentHost {
       console.log('[AgentHost] web_search tool enabled');
     }
 
-    // show_artifact is Guide-only — the Guide is the only agent that interacts with the user via the UI
-    if (this.agentRole === 'guide') {
-      tools.push(createShowArtifactTool(this.db));
-    }
+    // All agents can show artifacts — any agent can now interact with the user directly
+    tools.push(createShowArtifactTool(this.db));
 
-    // spawn_agent, terminate_agent, and trigger_project_story require a spawner callback
-    // (provided to Guide and Conductors, not Narrator)
-    if (this.spawner) {
+    // Guide and Conductor only: spawn, manage, and resurrect agents
+    const canOrchestrate = this.agentRole !== null && ORCHESTRATOR_ROLES.has(this.agentRole);
+
+    if (canOrchestrate && this.spawner) {
       tools.push(createSpawnAgentTool(this.db, this.agentId, this.spawner));
       tools.push(createTerminateAgentTool(this.db, this.agentId, this.registry));
       tools.push(createTriggerProjectStoryTool(this.db, this.agentId, this.registry));
     }
 
-    // resurrect_agent is Guide-only (resurrector callback only provided to Guide)
-    if (this.resurrector) {
+    if (canOrchestrate && this.resurrector) {
       tools.push(createResurrectAgentTool(this.db, this.agentId, this.resurrector));
     }
 
@@ -618,9 +630,19 @@ export class AgentHost {
       throw new Error('AgentHost not initialized. Call initialize() first.');
     }
 
+    // Capture delivered message in chat cache for UI history
+    if (this._chatCache) {
+      this._chatCache.push({
+        id: `msg-${Date.now()}`,
+        role: 'user',
+        content,
+        timestamp: details.timestamp,
+      });
+    }
+
     // Rotate session file if needed (catches growth between server restarts)
-    if (this.sessionDir) {
-      rotateSessionIfNeeded(this.sessionDir, SYSTEM2_DIR);
+    if (this._sessionDir) {
+      rotateSessionIfNeeded(this._sessionDir, SYSTEM2_DIR);
     }
 
     // Reload resource loader to pick up knowledge file changes, then deliver.
@@ -680,12 +702,30 @@ export class AgentHost {
     return this.session?.getContextUsage();
   }
 
+  /** Get the agent's role (available after initialize()). */
+  get role(): string | null {
+    return this.agentRole;
+  }
+
   getProvider(): string {
     return this.currentProvider;
   }
 
   isBusy(): boolean {
     return this.busy;
+  }
+
+  /** Session directory path (available after initialize()). */
+  get sessionDir(): string | null {
+    return this._sessionDir;
+  }
+
+  /** Per-agent chat cache for UI message history. */
+  get chatCache(): MessageHistory {
+    if (!this._chatCache) {
+      throw new Error('AgentHost not initialized. Call initialize() first.');
+    }
+    return this._chatCache;
   }
 
   /**
@@ -724,8 +764,8 @@ export class AgentHost {
    * Returns 0 if the file doesn't exist (first run or deleted).
    */
   private readCompactionCount(): number {
-    if (!this.sessionDir) return 0;
-    const countFile = join(this.sessionDir, '.compaction-count');
+    if (!this._sessionDir) return 0;
+    const countFile = join(this._sessionDir, '.compaction-count');
     try {
       return parseInt(readFileSync(countFile, 'utf-8').trim(), 10) || 0;
     } catch {
@@ -737,8 +777,8 @@ export class AgentHost {
    * Persist the compaction count to the session directory.
    */
   private writeCompactionCount(count: number): void {
-    if (!this.sessionDir) return;
-    const countFile = join(this.sessionDir, '.compaction-count');
+    if (!this._sessionDir) return;
+    const countFile = join(this._sessionDir, '.compaction-count');
     writeFileSync(countFile, String(count), 'utf-8');
   }
 
@@ -748,7 +788,7 @@ export class AgentHost {
    * to remove information that already existed in the baseline.
    */
   private async triggerPruningCompaction(): Promise<void> {
-    if (!this.session || !this.sessionDir) return;
+    if (!this.session || !this._sessionDir) return;
 
     const baseline = this.findBaselineSummary();
     if (!baseline) {
@@ -779,7 +819,7 @@ export class AgentHost {
    * May need to scan older JSONL files if session rotation moved entries.
    */
   private findBaselineSummary(): string | null {
-    if (!this.session || !this.sessionDir) return null;
+    if (!this.session || !this._sessionDir) return null;
 
     // Collect compaction summaries from current session entries (chronological order)
     const entries = this.session.sessionManager.getBranch();
@@ -812,7 +852,7 @@ export class AgentHost {
    * Returns up to `needed` summaries in chronological order.
    */
   private scanOlderSessionFiles(needed: number): string[] {
-    const sessionDir = this.sessionDir;
+    const sessionDir = this._sessionDir;
     if (!sessionDir) return [];
 
     let files: string[];

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -593,7 +593,10 @@ export class AgentHost {
       tools.push(createTriggerProjectStoryTool(this.db, this.agentId, this.registry));
     }
 
-    if (canOrchestrate && this.resurrector) {
+    // resurrect_agent is Guide-only: resurrection requires user confirmation and is a
+    // user-facing decision. The tool itself enforces this; restricting here keeps the
+    // tool list consistent with what the agent can actually do.
+    if (this.agentRole === 'guide' && this.resurrector) {
       tools.push(createResurrectAgentTool(this.db, this.agentId, this.resurrector));
     }
 

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -593,10 +593,7 @@ export class AgentHost {
       tools.push(createTriggerProjectStoryTool(this.db, this.agentId, this.registry));
     }
 
-    // resurrect_agent is Guide-only: resurrection requires user confirmation and is a
-    // user-facing decision. The tool itself enforces this; restricting here keeps the
-    // tool list consistent with what the agent can actually do.
-    if (this.agentRole === 'guide' && this.resurrector) {
+    if (canOrchestrate && this.resurrector) {
       tools.push(createResurrectAgentTool(this.db, this.agentId, this.resurrector));
     }
 

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -658,11 +658,12 @@ export class AgentHost {
       throw new Error('AgentHost not initialized. Call initialize() first.');
     }
 
-    // Capture delivered message in chat cache for UI history
+    // Capture delivered message in chat cache for UI history.
+    // Use role: 'system' so it renders as a muted notice rather than as "You".
     if (this._chatCache) {
       this._chatCache.push({
         id: `msg-${Date.now()}`,
-        role: 'user',
+        role: 'system',
         content,
         timestamp: details.timestamp,
       });

--- a/packages/server/src/agents/library/guide.md
+++ b/packages/server/src/agents/library/guide.md
@@ -136,6 +136,15 @@ The Conductor will message you with regular progress updates. When you receive o
 - Combine related updates into meaningful checkpoints; do not relay every micro-update verbatim
 - If the update reveals a blocker or a decision that needs user input, surface it immediately and ask
 
+## User-Agent Direct Interactions
+
+The user may choose to directly message any active agent via the UI. When this happens, you will periodically receive summaries of those conversations (delivered as messages from the agent's ID). These summaries describe the instructions the user gave and any decisions made.
+
+When you receive such a summary:
+- Acknowledge it internally (no need to relay to the user since they initiated the interaction)
+- Update your understanding of project state and agent priorities accordingly
+- If the user's instructions to another agent conflict with your current plan, adjust your plan
+
 ## Project Completion Flow
 
 When the Conductor reports project work is complete:

--- a/packages/server/src/agents/tools/resurrect-agent.test.ts
+++ b/packages/server/src/agents/tools/resurrect-agent.test.ts
@@ -89,10 +89,26 @@ describe('resurrect_agent tool', () => {
     expect((result.content[0] as { text: string }).text).toContain('Cannot resurrect singleton');
   });
 
-  it('Conductor cannot resurrect', async () => {
-    const { tool } = setup(3, [
+  it('Conductor resurrects archived agent within own project', async () => {
+    const { tool, resurrector, updateAgentStatus } = setup(3, [
       makeAgent(3, 'conductor', 10),
       makeAgent(5, 'reviewer', 10, 'archived'),
+    ]);
+
+    const result = await exec(tool, {
+      agent_id: 5,
+      message: 'Resume work on code review.',
+    });
+
+    expect((result.content[0] as { text: string }).text).toContain('has been resurrected');
+    expect(updateAgentStatus).toHaveBeenCalledWith(5, 'active');
+    expect(resurrector).toHaveBeenCalledWith(5, 3, 'Resume work on code review.');
+  });
+
+  it('Conductor cannot resurrect agent in a different project', async () => {
+    const { tool } = setup(3, [
+      makeAgent(3, 'conductor', 10),
+      makeAgent(5, 'reviewer', 99, 'archived'),
     ]);
 
     const result = await exec(tool, {
@@ -100,7 +116,7 @@ describe('resurrect_agent tool', () => {
       message: 'Resume.',
     });
 
-    expect((result.content[0] as { text: string }).text).toContain('Only the Guide');
+    expect((result.content[0] as { text: string }).text).toContain('own project');
   });
 
   it('Reviewer cannot resurrect', async () => {
@@ -114,7 +130,7 @@ describe('resurrect_agent tool', () => {
       message: 'Resume.',
     });
 
-    expect((result.content[0] as { text: string }).text).toContain('Only the Guide');
+    expect((result.content[0] as { text: string }).text).toContain('Only Guide and Conductor');
   });
 
   it('errors when agent not found', async () => {

--- a/packages/server/src/agents/tools/resurrect-agent.ts
+++ b/packages/server/src/agents/tools/resurrect-agent.ts
@@ -6,7 +6,8 @@
  * registers it in the AgentRegistry, and delivers a context message.
  *
  * Permission model:
- *   - Only the Guide may resurrect agents.
+ *   - Guide may resurrect any archived non-singleton agent.
+ *   - Conductors may resurrect archived agents within their own project.
  *   - Singleton agents (guide, narrator) cannot be resurrected.
  *   - Already-active agents cannot be resurrected.
  */
@@ -42,9 +43,10 @@ export function createResurrectAgentTool(
     label: 'Resurrect Agent',
     description:
       'Resurrect an archived agent: restore its session from persisted history, re-register it, and deliver a context message. ' +
-      'IMPORTANT: Resurrection is a significant decision. Before using this tool, confirm with the user that resurrection (rather than starting a new project or carrying out a bespoke task) is the right approach. ' +
-      'Help the user think through the tradeoffs: the resurrected agent retains its full conversation history and context, but that context may be stale. ' +
-      'Only the Guide may resurrect agents. After resurrection, update the project record via write_system2_db: clear end_at and set status to "in progress".',
+      'IMPORTANT: Resurrection is a significant decision. Before using this tool, confirm that resurrection (rather than starting a new project or carrying out a bespoke task) is the right approach. ' +
+      'The resurrected agent retains its full conversation history and context, but that context may be stale. ' +
+      'Guide may resurrect any archived non-singleton. Conductors may only resurrect agents within their own project. ' +
+      'After resurrection, update the project record via write_system2_db: clear end_at and set status to "in progress".',
     parameters: params,
     execute: async (_toolCallId, params, _signal, _onUpdate) => {
       const caller = db.getAgent(agentId);
@@ -55,13 +57,13 @@ export function createResurrectAgentTool(
         };
       }
 
-      // Only the Guide may resurrect agents
-      if (caller.role !== 'guide') {
+      // Only Guide and Conductors may resurrect agents
+      if (caller.role !== 'guide' && caller.role !== 'conductor') {
         return {
           content: [
             {
               type: 'text' as const,
-              text: `Error: Only the Guide may resurrect agents. Your role is "${caller.role}".`,
+              text: `Error: Only Guide and Conductor agents may resurrect agents. Your role is "${caller.role}".`,
             },
           ],
           details: { error: 'unauthorized_role' },
@@ -79,6 +81,21 @@ export function createResurrectAgentTool(
           ],
           details: { error: 'target_not_found' },
         };
+      }
+
+      // Conductors can only resurrect agents within their own project
+      if (caller.role === 'conductor') {
+        if (target.project !== caller.project) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Error: Conductors can only resurrect agents in their own project (project ${caller.project}). Target agent belongs to project ${target.project}.`,
+              },
+            ],
+            details: { error: 'wrong_project' },
+          };
+        }
       }
 
       // Singleton agents cannot be resurrected (they are never archived)

--- a/packages/server/src/chat/summarizer.test.ts
+++ b/packages/server/src/chat/summarizer.test.ts
@@ -1,0 +1,235 @@
+/**
+ * ConversationSummarizer Tests
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../llm/oneshot.js', () => ({
+  oneShotComplete: vi.fn().mockResolvedValue('mocked summary'),
+}));
+
+import type { Api, Model } from '@mariozechner/pi-ai';
+import type { ModelRegistry } from '@mariozechner/pi-coding-agent';
+import type { AgentHost } from '../agents/host.js';
+import { oneShotComplete } from '../llm/oneshot.js';
+import { ConversationSummarizer } from './summarizer.js';
+
+function makeGuideHost() {
+  return { deliverMessage: vi.fn() } as unknown as AgentHost;
+}
+
+function makeSummarizer(guideAgentId = 1) {
+  const guideHost = makeGuideHost();
+  const summarizer = new ConversationSummarizer(
+    guideHost,
+    guideAgentId,
+    {} as unknown as ModelRegistry,
+    {} as unknown as Model<Api>
+  );
+  return { summarizer, guideHost };
+}
+
+describe('ConversationSummarizer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('recordUserMessage', () => {
+    it('starts timer on first message', () => {
+      const { summarizer } = makeSummarizer();
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+      summarizer.recordUserMessage(2, 'conductor', 'hello');
+
+      expect(setTimeoutSpy).toHaveBeenCalledOnce();
+      expect(setTimeoutSpy).toHaveBeenCalledWith(
+        expect.any(Function),
+        ConversationSummarizer.TIMER_DURATION_MS
+      );
+    });
+
+    it('does not reset timer on subsequent calls within the same window', () => {
+      const { summarizer } = makeSummarizer();
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+      summarizer.recordUserMessage(2, 'conductor', 'first');
+      summarizer.recordUserMessage(2, 'conductor', 'second');
+      summarizer.recordUserMessage(2, 'conductor', 'third');
+
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('starts independent timers for different agents', () => {
+      const { summarizer } = makeSummarizer();
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+      summarizer.recordUserMessage(2, 'conductor', 'to conductor');
+      summarizer.recordUserMessage(3, 'reviewer', 'to reviewer');
+
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('recordAgentEvent', () => {
+    it('is a no-op when no buffer exists for the agent', () => {
+      const { summarizer } = makeSummarizer();
+
+      expect(() =>
+        summarizer.recordAgentEvent(99, {
+          type: 'assistant_reply',
+          content: 'hi',
+          timestamp: Date.now(),
+        })
+      ).not.toThrow();
+    });
+
+    it('does not start a timer when recording an event for a non-existent buffer', async () => {
+      const { summarizer, guideHost } = makeSummarizer();
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+      summarizer.recordAgentEvent(99, { type: 'assistant_reply', content: 'hi', timestamp: 1 });
+
+      await vi.runAllTimersAsync();
+
+      expect(setTimeoutSpy).not.toHaveBeenCalled();
+      expect(guideHost.deliverMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onTimerExpiry', () => {
+    it('calls oneShotComplete and delivers summary to Guide', async () => {
+      const { summarizer, guideHost } = makeSummarizer(1);
+
+      summarizer.recordUserMessage(2, 'conductor', 'user question');
+
+      await vi.runAllTimersAsync();
+
+      expect(oneShotComplete).toHaveBeenCalledOnce();
+      expect(guideHost.deliverMessage).toHaveBeenCalledOnce();
+    });
+
+    it('includes agent role and id in delivered summary', async () => {
+      const { summarizer, guideHost } = makeSummarizer(1);
+
+      summarizer.recordUserMessage(2, 'conductor', 'question');
+
+      await vi.runAllTimersAsync();
+
+      const [content, details] = (guideHost.deliverMessage as ReturnType<typeof vi.fn>).mock
+        .calls[0];
+      expect(content).toContain('[Summary of user interaction with conductor agent (id=2)]');
+      expect(content).toContain('mocked summary');
+      expect(details.receiver).toBe(1);
+      expect(details.sender).toBe(2);
+    });
+
+    it('formats user messages in the prompt', async () => {
+      const { summarizer } = makeSummarizer(1);
+
+      summarizer.recordUserMessage(2, 'conductor', 'do the thing');
+
+      await vi.runAllTimersAsync();
+
+      const [, , opts] = (oneShotComplete as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(opts.userMessage).toContain('[User]: do the thing');
+    });
+
+    it('formats agent events in the prompt', async () => {
+      const { summarizer } = makeSummarizer(1);
+
+      summarizer.recordUserMessage(2, 'conductor', 'do the thing');
+      summarizer.recordAgentEvent(2, {
+        type: 'assistant_reply',
+        content: 'done',
+        timestamp: Date.now(),
+      });
+      summarizer.recordAgentEvent(2, { type: 'tool_call', content: 'bash', timestamp: Date.now() });
+
+      await vi.runAllTimersAsync();
+
+      const [, , opts] = (oneShotComplete as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(opts.userMessage).toContain('[Agent]: done');
+      expect(opts.userMessage).toContain('[Tool]: bash');
+    });
+
+    it('does NOT restart timer when only one user message in window', async () => {
+      const { summarizer } = makeSummarizer();
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+      summarizer.recordUserMessage(2, 'conductor', 'only message');
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+
+      await vi.runAllTimersAsync();
+
+      // No second timer should have been started
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('restarts timer when a second user message arrived during the window', async () => {
+      const { summarizer } = makeSummarizer();
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+      summarizer.recordUserMessage(2, 'conductor', 'first message');
+      // Advance time within the window (timer hasn't fired yet)
+      vi.advanceTimersByTime(1000);
+      // Second message arrives after startTimestamp
+      summarizer.recordUserMessage(2, 'conductor', 'second message');
+
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+
+      // Expire the timer
+      await vi.runAllTimersAsync();
+
+      // New timer should have started for the second message
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears events after timer fires', async () => {
+      const { summarizer, guideHost } = makeSummarizer(1);
+
+      summarizer.recordUserMessage(2, 'conductor', 'message');
+      await vi.runAllTimersAsync();
+
+      // First summary delivered
+      expect(guideHost.deliverMessage).toHaveBeenCalledTimes(1);
+
+      // Second timer fires (only if a new message created it — it shouldn't here)
+      await vi.runAllTimersAsync();
+
+      // No second delivery (no events buffered)
+      expect(guideHost.deliverMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('cleanup', () => {
+    it('clears all timers and prevents delivery', async () => {
+      const { summarizer, guideHost } = makeSummarizer();
+
+      summarizer.recordUserMessage(2, 'conductor', 'message');
+      summarizer.cleanup();
+
+      await vi.runAllTimersAsync();
+
+      expect(oneShotComplete).not.toHaveBeenCalled();
+      expect(guideHost.deliverMessage).not.toHaveBeenCalled();
+    });
+
+    it('recordUserMessage after cleanup starts a fresh buffer with a new timer', () => {
+      const { summarizer } = makeSummarizer();
+      const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+      summarizer.recordUserMessage(2, 'conductor', 'before cleanup');
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(1);
+
+      summarizer.cleanup();
+
+      summarizer.recordUserMessage(2, 'conductor', 'after cleanup');
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/server/src/chat/summarizer.test.ts
+++ b/packages/server/src/chat/summarizer.test.ts
@@ -177,7 +177,7 @@ describe('ConversationSummarizer', () => {
       summarizer.recordUserMessage(2, 'conductor', 'first message');
       // Advance time within the window (timer hasn't fired yet)
       vi.advanceTimersByTime(1000);
-      // Second message arrives after startTimestamp
+      // Second message arrives during the timer window (after the first)
       summarizer.recordUserMessage(2, 'conductor', 'second message');
 
       expect(setTimeoutSpy).toHaveBeenCalledTimes(1);

--- a/packages/server/src/chat/summarizer.ts
+++ b/packages/server/src/chat/summarizer.ts
@@ -1,0 +1,166 @@
+/**
+ * Conversation Summarizer
+ *
+ * Summarizes user interactions with non-Guide agents and delivers summaries
+ * to the Guide agent. Uses a non-resetting 1-minute timer: on first user message
+ * to a non-Guide agent, a timer starts. On expiry, buffered events are summarized
+ * via a one-shot LLM call and delivered to the Guide. A new timer starts only if
+ * additional user messages arrived during the timer period.
+ */
+
+import type { Api, Model } from '@mariozechner/pi-ai';
+import type { ModelRegistry } from '@mariozechner/pi-coding-agent';
+import type { AgentHost } from '../agents/host.js';
+import { oneShotComplete } from '../llm/oneshot.js';
+
+export interface BufferedEvent {
+  type: 'user_message' | 'thinking' | 'tool_call' | 'assistant_reply';
+  content: string;
+  timestamp: number;
+}
+
+interface AgentBuffer {
+  agentId: number;
+  agentRole: string;
+  events: BufferedEvent[];
+  timer: ReturnType<typeof setTimeout> | null;
+  startTimestamp: number;
+}
+
+export class ConversationSummarizer {
+  private buffers: Map<number, AgentBuffer> = new Map();
+  private guideHost: AgentHost;
+  private guideAgentId: number;
+  private modelRegistry: ModelRegistry;
+  private narratorModel: Model<Api>;
+
+  static readonly TIMER_DURATION_MS = 60_000;
+
+  constructor(
+    guideHost: AgentHost,
+    guideAgentId: number,
+    modelRegistry: ModelRegistry,
+    narratorModel: Model<Api>
+  ) {
+    this.guideHost = guideHost;
+    this.guideAgentId = guideAgentId;
+    this.modelRegistry = modelRegistry;
+    this.narratorModel = narratorModel;
+  }
+
+  /**
+   * Record a user message sent to a non-Guide agent.
+   * Starts the summary timer on first message (does not reset on subsequent messages).
+   */
+  recordUserMessage(agentId: number, agentRole: string, content: string): void {
+    const buffer = this.getOrCreateBuffer(agentId, agentRole);
+    buffer.events.push({ type: 'user_message', content, timestamp: Date.now() });
+
+    // Start timer on first message (non-resetting)
+    if (buffer.timer === null) {
+      buffer.startTimestamp = Date.now();
+      buffer.timer = setTimeout(
+        () => this.onTimerExpiry(agentId),
+        ConversationSummarizer.TIMER_DURATION_MS
+      );
+    }
+  }
+
+  /**
+   * Record an agent event (thinking, tool call, or reply) for summarization.
+   * Only recorded if a buffer exists for this agent (i.e., user has messaged it).
+   */
+  recordAgentEvent(agentId: number, event: BufferedEvent): void {
+    const buffer = this.buffers.get(agentId);
+    if (!buffer) return;
+    buffer.events.push(event);
+  }
+
+  private getOrCreateBuffer(agentId: number, agentRole: string): AgentBuffer {
+    let buffer = this.buffers.get(agentId);
+    if (!buffer) {
+      buffer = {
+        agentId,
+        agentRole,
+        events: [],
+        timer: null,
+        startTimestamp: 0,
+      };
+      this.buffers.set(agentId, buffer);
+    }
+    return buffer;
+  }
+
+  private async onTimerExpiry(agentId: number): Promise<void> {
+    const buffer = this.buffers.get(agentId);
+    if (!buffer || buffer.events.length === 0) {
+      if (buffer) buffer.timer = null;
+      return;
+    }
+
+    // Format events into a readable log
+    const formattedLog = buffer.events
+      .map((e) => {
+        switch (e.type) {
+          case 'user_message':
+            return `[User]: ${e.content}`;
+          case 'thinking':
+            return `[Thinking]: ${e.content.slice(0, 500)}`;
+          case 'tool_call':
+            return `[Tool]: ${e.content}`;
+          case 'assistant_reply':
+            return `[Agent]: ${e.content}`;
+          default:
+            return `[${e.type}]: ${e.content}`;
+        }
+      })
+      .join('\n');
+
+    // Check for new user messages before clearing (used to decide whether to restart timer)
+    const hasNewUserMessages = buffer.events.some(
+      (e) => e.type === 'user_message' && e.timestamp > buffer.startTimestamp
+    );
+
+    // Clear events and timer
+    buffer.events = [];
+    buffer.timer = null;
+
+    try {
+      const summary = await oneShotComplete(this.modelRegistry, this.narratorModel, {
+        systemPrompt: `Summarize this interaction between the user and a ${buffer.agentRole} agent for the Guide agent. Be concise. Focus on instructions the user gave, decisions made, and actions taken.`,
+        userMessage: formattedLog,
+      });
+
+      // Deliver summary to Guide
+      this.guideHost.deliverMessage(
+        `[Summary of user interaction with ${buffer.agentRole} agent (id=${agentId})]\n\n${summary}`,
+        {
+          sender: agentId,
+          receiver: this.guideAgentId,
+          timestamp: Date.now(),
+        }
+      );
+    } catch (err) {
+      console.error('[ConversationSummarizer] Failed to generate summary:', err);
+    }
+
+    // Start new timer if user messages arrived during the timer period
+    if (hasNewUserMessages) {
+      buffer.startTimestamp = Date.now();
+      buffer.timer = setTimeout(
+        () => this.onTimerExpiry(agentId),
+        ConversationSummarizer.TIMER_DURATION_MS
+      );
+    }
+  }
+
+  /** Clean up all timers and buffers. */
+  cleanup(): void {
+    for (const buffer of this.buffers.values()) {
+      if (buffer.timer) {
+        clearTimeout(buffer.timer);
+      }
+    }
+    this.buffers.clear();
+  }
+}

--- a/packages/server/src/chat/summarizer.ts
+++ b/packages/server/src/chat/summarizer.ts
@@ -24,7 +24,7 @@ interface AgentBuffer {
   agentRole: string;
   events: BufferedEvent[];
   timer: ReturnType<typeof setTimeout> | null;
-  startTimestamp: number;
+  timerStartEventCount: number; // number of events when the timer was started
 }
 
 export class ConversationSummarizer {
@@ -58,7 +58,7 @@ export class ConversationSummarizer {
 
     // Start timer on first message (non-resetting)
     if (buffer.timer === null) {
-      buffer.startTimestamp = Date.now();
+      buffer.timerStartEventCount = buffer.events.length;
       buffer.timer = setTimeout(
         () => this.onTimerExpiry(agentId),
         ConversationSummarizer.TIMER_DURATION_MS
@@ -84,7 +84,7 @@ export class ConversationSummarizer {
         agentRole,
         events: [],
         timer: null,
-        startTimestamp: 0,
+        timerStartEventCount: 0,
       };
       this.buffers.set(agentId, buffer);
     }
@@ -116,12 +116,13 @@ export class ConversationSummarizer {
       })
       .join('\n');
 
-    // Check for new user messages before clearing (used to decide whether to restart timer)
-    const hasNewUserMessages = buffer.events.some(
-      (e) => e.type === 'user_message' && e.timestamp > buffer.startTimestamp
-    );
+    // Check for user messages that arrived after the timer was started (before clearing).
+    // Uses event count to avoid same-millisecond timestamp edge cases.
+    const hasNewUserMessages = buffer.events
+      .slice(buffer.timerStartEventCount)
+      .some((e) => e.type === 'user_message');
 
-    // Clear events and timer
+    // Clear events and timer before the async work
     buffer.events = [];
     buffer.timer = null;
 
@@ -144,9 +145,10 @@ export class ConversationSummarizer {
       console.error('[ConversationSummarizer] Failed to generate summary:', err);
     }
 
-    // Start new timer if user messages arrived during the timer period
-    if (hasNewUserMessages) {
-      buffer.startTimestamp = Date.now();
+    // Start new timer only if: additional messages existed in the window AND no timer was
+    // already started by a concurrent recordUserMessage call during the await above.
+    if (hasNewUserMessages && buffer.timer === null) {
+      buffer.timerStartEventCount = buffer.events.length;
       buffer.timer = setTimeout(
         () => this.onTimerExpiry(agentId),
         ConversationSummarizer.TIMER_DURATION_MS

--- a/packages/server/src/llm/oneshot.ts
+++ b/packages/server/src/llm/oneshot.ts
@@ -1,0 +1,54 @@
+/**
+ * One-Shot LLM Utility
+ *
+ * Lightweight wrapper around pi-ai's completeSimple for single-turn LLM calls.
+ * Used for tasks like summarizing user-agent interactions (ConversationSummarizer).
+ */
+
+import { type Api, completeSimple, type Model } from '@mariozechner/pi-ai';
+import type { ModelRegistry } from '@mariozechner/pi-coding-agent';
+
+export interface OneShotOptions {
+  systemPrompt?: string;
+  userMessage: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Execute a single-turn LLM call and return the text response.
+ *
+ * @param modelRegistry - Registry for API key resolution
+ * @param model - The model to use (e.g., narrator's model for cheap summarization)
+ * @param options - System prompt, user message, and optional abort signal
+ * @returns The model's text response
+ */
+export async function oneShotComplete(
+  modelRegistry: ModelRegistry,
+  model: Model<Api>,
+  options: OneShotOptions
+): Promise<string> {
+  const apiKey = await modelRegistry.getApiKey(model);
+
+  const result = await completeSimple(
+    model,
+    {
+      systemPrompt: options.systemPrompt,
+      messages: [
+        {
+          role: 'user',
+          content: options.userMessage,
+          timestamp: Date.now(),
+        },
+      ],
+    },
+    {
+      apiKey,
+      signal: options.signal,
+    }
+  );
+
+  return result.content
+    .filter((c): c is { type: 'text'; text: string } => c.type === 'text')
+    .map((c) => c.text)
+    .join('');
+}

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -4,12 +4,13 @@
  * HTTP + WebSocket server that hosts the Guide and Narrator agents and serves the UI.
  */
 
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join, normalize } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
+import type { Api, Model } from '@mariozechner/pi-ai';
+import { type AgentSessionEvent, ModelRegistry } from '@mariozechner/pi-coding-agent';
 import type {
   ChatConfig,
   ChatMessage,
@@ -20,12 +21,14 @@ import type {
   ToolsConfig,
 } from '@system2/shared';
 import express from 'express';
+import matter from 'gray-matter';
 import { WebSocketServer } from 'ws';
+import { AuthResolver } from './agents/auth-resolver.js';
 import { AgentHost } from './agents/host.js';
 import { AgentRegistry } from './agents/registry.js';
 import type { AgentResurrector } from './agents/tools/resurrect-agent.js';
 import type { AgentSpawner } from './agents/tools/spawn-agent.js';
-import { MessageHistory } from './chat/history.js';
+import { ConversationSummarizer } from './chat/summarizer.js';
 import { DatabaseClient } from './db/client.js';
 import { initializeGitRepo } from './knowledge/git.js';
 import { initializeKnowledge } from './knowledge/init.js';
@@ -66,7 +69,8 @@ export class Server {
   private scheduler: Scheduler;
   private config: ServerConfig;
   private narratorId: number;
-  private messageHistory: MessageHistory;
+  private guideAgentId: number;
+  private conversationSummarizer?: ConversationSummarizer;
 
   constructor(config: ServerConfig) {
     this.config = config;
@@ -82,7 +86,10 @@ export class Server {
     this.agentRegistry = new AgentRegistry();
 
     // Initialize Guide agent (singleton) — receives the spawner so it can create Conductors/Reviewers
+    const chatMaxMessages = config.chatConfig?.max_history_messages ?? 1000;
+
     const guideAgent = this.db.getOrCreateGuideAgent();
+    this.guideAgentId = guideAgent.id;
     this.agentHost = new AgentHost({
       db: this.db,
       agentId: guideAgent.id,
@@ -92,6 +99,7 @@ export class Server {
       toolsConfig: config.toolsConfig,
       spawner: this.makeSpawner(),
       resurrector: this.makeResurrector(),
+      chatMaxMessages,
     });
     this.agentRegistry.register(guideAgent.id, this.agentHost);
 
@@ -105,17 +113,15 @@ export class Server {
       llmConfig: config.llmConfig,
       servicesConfig: config.servicesConfig,
       toolsConfig: config.toolsConfig,
+      chatMaxMessages,
     });
     this.agentRegistry.register(narratorAgent.id, this.narratorHost);
 
-    // Initialize chat history (server-side, persisted to disk)
-    const maxMessages = config.chatConfig?.max_history_messages ?? 1000;
-    this.messageHistory = new MessageHistory(join(SYSTEM2_DIR, 'chat-history.json'), maxMessages);
-
-    // Single subscriber for capturing assistant messages into history.
-    // This runs once regardless of how many WebSocket clients are connected,
-    // preventing duplicate entries when multiple tabs are open.
+    // Subscribe singleton agents for chat cache capture.
+    // Each agent's chatCache (created during initialize()) persists messages to disk.
+    // Subscription is set up before initialize() so no events are missed.
     this.subscribeForHistoryCapture(this.agentHost);
+    this.subscribeForHistoryCapture(this.narratorHost);
 
     // Initialize scheduler
     this.scheduler = new Scheduler();
@@ -293,7 +299,13 @@ export class Server {
     // Handle WebSocket connections
     this.wss.on('connection', (ws) => {
       console.log('Client connected');
-      new WebSocketHandler(ws, this.agentHost, this.messageHistory, this.wss);
+      new WebSocketHandler(
+        ws,
+        this.agentRegistry,
+        this.guideAgentId,
+        this.wss,
+        this.conversationSummarizer
+      );
     });
   }
 
@@ -302,6 +314,7 @@ export class Server {
    * Single path for all non-singleton agent initialization (spawn + restore).
    */
   private async initializeAgentHost(agentId: number): Promise<AgentHost> {
+    const chatMaxMessages = this.config.chatConfig?.max_history_messages ?? 1000;
     const host = new AgentHost({
       db: this.db,
       agentId,
@@ -310,10 +323,18 @@ export class Server {
       servicesConfig: this.config.servicesConfig,
       toolsConfig: this.config.toolsConfig,
       spawner: this.makeSpawner(),
+      resurrector: this.makeResurrector(),
+      chatMaxMessages,
     });
 
+    // Subscribe for chat cache capture before initialize() so no events are missed
+    this.subscribeForHistoryCapture(host);
     await host.initialize();
     this.agentRegistry.register(agentId, host);
+
+    // Subscribe spawned agents for summarizer capture (non-Guide only)
+    this.subscribeForSummarizerCapture(host);
+
     return host;
   }
 
@@ -402,7 +423,7 @@ export class Server {
               timestamp: Date.now(),
               turnEvents: currentTurnEvents.length > 0 ? [...currentTurnEvents] : undefined,
             };
-            this.messageHistory.push(assistantMsg);
+            agentHost.chatCache.push(assistantMsg);
             currentAssistantText = '';
             currentTurnEvents = [];
           }
@@ -486,6 +507,24 @@ export class Server {
     // Initialize agent sessions
     await this.agentHost.initialize();
     await this.narratorHost.initialize();
+
+    // Initialize conversation summarizer (uses narrator's model for cheap summarization)
+    try {
+      const narratorModel = this.resolveNarratorModel();
+      if (narratorModel) {
+        this.conversationSummarizer = new ConversationSummarizer(
+          this.agentHost,
+          this.guideAgentId,
+          narratorModel.registry,
+          narratorModel.model
+        );
+        // Subscribe non-Guide agents for summarizer event capture
+        this.subscribeForSummarizerCapture(this.narratorHost);
+        console.log('[Server] Conversation summarizer initialized');
+      }
+    } catch (err) {
+      console.warn('[Server] Failed to initialize conversation summarizer:', err);
+    }
 
     // Restore previously active spawned agents (conductors, reviewers, etc.)
     await this.restoreActiveAgents();
@@ -598,7 +637,112 @@ export class Server {
     }
   }
 
+  /**
+   * Resolve the Narrator's model from its frontmatter for use by the ConversationSummarizer.
+   * Returns the model and a ModelRegistry, or null if resolution fails.
+   */
+  private resolveNarratorModel(): { model: Model<Api>; registry: ModelRegistry } | null {
+    // Agent definition files are co-located with AgentHost (dist/agents/library/)
+    const agentDir = join(dirname(fileURLToPath(import.meta.url)), 'agents');
+    const narratorPath = join(agentDir, 'library', 'narrator.md');
+
+    if (!existsSync(narratorPath)) {
+      console.warn('[Server] Narrator definition not found at', narratorPath);
+      return null;
+    }
+
+    const { data: meta } = matter(readFileSync(narratorPath, 'utf-8'));
+    const models = meta.models as Record<string, string> | undefined;
+    if (!models) return null;
+
+    const authResolver = new AuthResolver(this.config.llmConfig);
+    const modelRegistry = new ModelRegistry(authResolver.createAuthStorage());
+
+    for (const provider of authResolver.providerOrder) {
+      const modelId = models[provider];
+      if (modelId) {
+        const model = modelRegistry.find(provider, modelId);
+        if (model) return { model, registry: modelRegistry };
+      }
+    }
+
+    console.warn('[Server] No narrator model found for any configured provider');
+    return null;
+  }
+
+  /**
+   * Subscribe an agent's events to the ConversationSummarizer for thinking/tool/reply capture.
+   * Only subscribes non-Guide agents (Guide interactions don't need summarization).
+   */
+  private subscribeForSummarizerCapture(agentHost: AgentHost): void {
+    if (!this.conversationSummarizer) return;
+    if (agentHost.agentId === this.guideAgentId) return;
+
+    const summarizer = this.conversationSummarizer;
+    const agentId = agentHost.agentId;
+
+    let thinkingBuffer = '';
+    let replyBuffer = '';
+
+    agentHost.subscribe((event: AgentSessionEvent) => {
+      switch (event.type) {
+        case 'message_update':
+          if (event.assistantMessageEvent.type === 'thinking_delta') {
+            thinkingBuffer += event.assistantMessageEvent.delta;
+          } else if (event.assistantMessageEvent.type === 'text_delta') {
+            replyBuffer += event.assistantMessageEvent.delta;
+          }
+          break;
+
+        case 'message_end':
+          if (thinkingBuffer) {
+            summarizer.recordAgentEvent(agentId, {
+              type: 'thinking',
+              content: thinkingBuffer,
+              timestamp: Date.now(),
+            });
+            thinkingBuffer = '';
+          }
+          if (replyBuffer) {
+            summarizer.recordAgentEvent(agentId, {
+              type: 'assistant_reply',
+              content: replyBuffer,
+              timestamp: Date.now(),
+            });
+            replyBuffer = '';
+          }
+          break;
+
+        case 'tool_execution_start': {
+          if (thinkingBuffer) {
+            summarizer.recordAgentEvent(agentId, {
+              type: 'thinking',
+              content: thinkingBuffer,
+              timestamp: Date.now(),
+            });
+            thinkingBuffer = '';
+          }
+          let inputText = '';
+          try {
+            inputText = typeof event.args === 'string' ? event.args : JSON.stringify(event.args);
+          } catch {
+            inputText = String(event.args);
+          }
+          summarizer.recordAgentEvent(agentId, {
+            type: 'tool_call',
+            content: `${event.toolName}: ${inputText}`,
+            timestamp: Date.now(),
+          });
+          break;
+        }
+      }
+    });
+  }
+
   async stop(): Promise<void> {
+    // Clean up conversation summarizer
+    this.conversationSummarizer?.cleanup();
+
     // Stop scheduled jobs first
     this.scheduler.stop();
 

--- a/packages/server/src/websocket/handler.ts
+++ b/packages/server/src/websocket/handler.ts
@@ -282,7 +282,7 @@ export class WebSocketHandler {
           agentId,
         });
 
-        // If show_artifact completed successfully (Guide only), emit artifact message and watch
+        // If show_artifact completed successfully, emit artifact message and watch
         if (event.toolName === 'show_artifact' && !event.isError) {
           const details = event.result?.details as
             | { url?: string; absolutePath?: string; title?: string }

--- a/packages/server/src/websocket/handler.ts
+++ b/packages/server/src/websocket/handler.ts
@@ -45,6 +45,7 @@ export class WebSocketHandler {
     const guideHost = this.agentRegistry.get(guideAgentId);
     if (!guideHost) {
       this.sendError('Guide agent not found');
+      ws.close();
       return;
     }
 

--- a/packages/server/src/websocket/handler.ts
+++ b/packages/server/src/websocket/handler.ts
@@ -2,7 +2,8 @@
  * WebSocket Handler
  *
  * Bridges Pi Agent events to WebSocket clients for real-time chat UI updates.
- * User messages are captured here and broadcast to other connected tabs.
+ * Supports multi-agent routing: the user can switch the active chat to any agent.
+ * User messages are captured in the agent's chat cache and broadcast to other tabs.
  * Assistant message history capture is handled centrally by Server.
  */
 
@@ -11,31 +12,52 @@ import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 import type { ClientMessage, ServerMessage } from '@system2/shared';
 import type { WebSocket, WebSocketServer } from 'ws';
 import type { AgentHost } from '../agents/host.js';
-import type { MessageHistory } from '../chat/history.js';
+import type { AgentRegistry } from '../agents/registry.js';
+import type { ConversationSummarizer } from '../chat/summarizer.js';
 
 export class WebSocketHandler {
   private ws: WebSocket;
-  private agentHost: AgentHost;
-  private history: MessageHistory;
+  private agentRegistry: AgentRegistry;
+  private guideAgentId: number;
   private wss: WebSocketServer;
-  private unsubscribe?: () => void;
+  private activeAgentId: number;
+  private activeSubscription?: () => void;
   private artifactWatcher?: FSWatcher;
   private artifactUrl?: string;
+  private summarizer?: ConversationSummarizer;
+  private isThinking = false;
 
-  constructor(ws: WebSocket, agentHost: AgentHost, history: MessageHistory, wss: WebSocketServer) {
+  constructor(
+    ws: WebSocket,
+    agentRegistry: AgentRegistry,
+    guideAgentId: number,
+    wss: WebSocketServer,
+    summarizer?: ConversationSummarizer
+  ) {
     this.ws = ws;
-    this.agentHost = agentHost;
-    this.history = history;
+    this.agentRegistry = agentRegistry;
+    this.guideAgentId = guideAgentId;
     this.wss = wss;
+    this.activeAgentId = guideAgentId;
+    this.summarizer = summarizer;
 
-    // Send chat history and provider info on connect — server is the source of truth
-    this.send({ type: 'chat_history', messages: history.getMessages() });
-    this.send({ type: 'provider_info', provider: agentHost.getProvider() });
+    // Get Guide's host
+    const guideHost = this.agentRegistry.get(guideAgentId);
+    if (!guideHost) {
+      this.sendError('Guide agent not found');
+      return;
+    }
 
-    // Subscribe to agent events for streaming to this client
-    this.unsubscribe = agentHost.subscribe((event) => {
-      this.handleAgentEvent(event);
+    // Send Guide's chat cache and provider info on connect
+    this.send({
+      type: 'chat_history',
+      messages: guideHost.chatCache.getMessages(),
+      agentId: guideAgentId,
     });
+    this.send({ type: 'provider_info', provider: guideHost.getProvider() });
+
+    // Subscribe to Guide's events for streaming to this client
+    this.subscribeToAgent(guideAgentId, guideHost);
 
     // Handle incoming messages from client
     ws.on('message', (data) => {
@@ -59,66 +81,121 @@ export class WebSocketHandler {
     });
   }
 
+  /**
+   * Subscribe to an agent's events for streaming to this WebSocket client.
+   * Replaces any existing subscription (one active agent at a time).
+   */
+  private subscribeToAgent(agentId: number, host: AgentHost): void {
+    // Unsubscribe from previous agent
+    if (this.activeSubscription) {
+      this.activeSubscription();
+      this.activeSubscription = undefined;
+    }
+
+    this.isThinking = false;
+    this.activeSubscription = host.subscribe((event) => {
+      this.handleAgentEvent(event, agentId, host);
+    });
+  }
+
   private handleClientMessage(message: ClientMessage): void {
     switch (message.type) {
-      case 'user_message': {
-        // Capture user message in history and broadcast to other tabs
+      case 'user_message':
+      case 'steering_message': {
+        // Resolve target agent (default to active agent)
+        const targetId = message.agentId ?? this.activeAgentId;
+        const host = this.agentRegistry.get(targetId);
+        if (!host) {
+          this.sendError(`Agent ${targetId} not found`);
+          return;
+        }
+
+        // Capture user message in agent's chat cache
         const userMsg = {
           id: `msg-${Date.now()}`,
           role: 'user' as const,
           content: message.content,
           timestamp: Date.now(),
         };
-        this.history.push(userMsg);
+        host.chatCache.push(userMsg);
+
+        // Broadcast to other tabs
         this.broadcast({
           type: 'user_message_broadcast',
           id: userMsg.id,
           content: userMsg.content,
           timestamp: userMsg.timestamp,
+          agentId: targetId,
         });
 
-        // Send user message to agent
-        this.agentHost.prompt(message.content).catch((error) => {
-          console.error('Agent prompt failed:', error);
-          this.sendError('Failed to process message');
-        });
+        // Record for summarization (non-Guide agents only)
+        if (this.summarizer && targetId !== this.guideAgentId) {
+          this.summarizer.recordUserMessage(targetId, host.role ?? 'unknown', message.content);
+        }
+
+        // Send to agent
+        const isSteering = message.type === 'steering_message';
+        host
+          .prompt(message.content, isSteering ? { isSteering: true } : undefined)
+          .catch((error) => {
+            console.error('Agent prompt failed:', error);
+            this.sendError('Failed to process message');
+          });
         break;
       }
 
-      case 'steering_message': {
-        // Capture steering message in history (still a user message) and broadcast
-        const steerMsg = {
-          id: `msg-${Date.now()}`,
-          role: 'user' as const,
-          content: message.content,
-          timestamp: Date.now(),
-        };
-        this.history.push(steerMsg);
-        this.broadcast({
-          type: 'user_message_broadcast',
-          id: steerMsg.id,
-          content: steerMsg.content,
-          timestamp: steerMsg.timestamp,
-        });
-
-        // Send steering message (inserted ASAP into the agent loop)
-        this.agentHost.prompt(message.content, { isSteering: true }).catch((error) => {
-          console.error('Agent steering prompt failed:', error);
-          this.sendError('Failed to process steering message');
-        });
+      case 'abort': {
+        const targetId = message.agentId ?? this.activeAgentId;
+        const host = this.agentRegistry.get(targetId);
+        if (host) host.abort();
         break;
       }
 
-      case 'abort':
-        this.agentHost.abort();
+      case 'switch_agent': {
+        const newAgentId = message.agentId;
+        const host = this.agentRegistry.get(newAgentId);
+        if (!host) {
+          this.sendError(`Agent ${newAgentId} not found or terminated`);
+          return;
+        }
+
+        // Update active agent and subscribe to its events
+        this.activeAgentId = newAgentId;
+        this.subscribeToAgent(newAgentId, host);
+
+        // Send new agent's chat cache
+        this.send({
+          type: 'chat_history',
+          messages: host.chatCache.getMessages(),
+          agentId: newAgentId,
+        });
+
+        // Send context usage for the new agent
+        const usage = host.getContextUsage();
+        if (usage) {
+          this.send({
+            type: 'context_usage',
+            percent: usage.percent,
+            tokens: usage.tokens,
+            contextWindow: usage.contextWindow,
+            agentId: newAgentId,
+          });
+        }
+
+        // Send ready_for_input if the agent is idle
+        if (!host.isBusy()) {
+          this.send({ type: 'ready_for_input', agentId: newAgentId });
+        }
+
         break;
+      }
 
       default:
         this.sendError(`Unknown message type: ${(message as Record<string, unknown>).type}`);
     }
   }
 
-  private handleAgentEvent(event: AgentSessionEvent): void {
+  private handleAgentEvent(event: AgentSessionEvent, agentId: number, host: AgentHost): void {
     // Handle synthetic events (not part of AgentSessionEvent type)
     const eventType = event.type as string;
     if (eventType === 'status') {
@@ -133,25 +210,40 @@ export class WebSocketHandler {
       case 'message_update':
         // Stream text as it's generated
         if (event.assistantMessageEvent.type === 'text_delta') {
+          if (this.isThinking) {
+            this.send({ type: 'thinking_end', agentId });
+            this.isThinking = false;
+          }
           this.send({
             type: 'assistant_chunk',
             content: event.assistantMessageEvent.delta,
+            agentId,
           });
         }
         // Stream thinking blocks
         else if (event.assistantMessageEvent.type === 'thinking_delta') {
+          this.isThinking = true;
           this.send({
             type: 'thinking_chunk',
             content: event.assistantMessageEvent.delta,
+            agentId,
           });
         }
         break;
 
       case 'message_end':
-        this.send({ type: 'assistant_end' });
+        if (this.isThinking) {
+          this.send({ type: 'thinking_end', agentId });
+          this.isThinking = false;
+        }
+        this.send({ type: 'assistant_end', agentId });
         break;
 
       case 'tool_execution_start': {
+        if (this.isThinking) {
+          this.send({ type: 'thinking_end', agentId });
+          this.isThinking = false;
+        }
         // Format tool input for display
         let inputText = '';
         const rawInput = event.args;
@@ -167,6 +259,7 @@ export class WebSocketHandler {
           type: 'tool_call_start',
           name: event.toolName,
           input: inputText,
+          agentId,
         });
         break;
       }
@@ -185,9 +278,10 @@ export class WebSocketHandler {
           type: 'tool_call_end',
           name: event.toolName,
           result: finalResult,
+          agentId,
         });
 
-        // If show_artifact completed successfully, emit artifact message and watch for changes
+        // If show_artifact completed successfully (Guide only), emit artifact message and watch
         if (event.toolName === 'show_artifact' && !event.isError) {
           const details = event.result?.details as
             | { url?: string; absolutePath?: string; title?: string }
@@ -212,22 +306,23 @@ export class WebSocketHandler {
         // Agent finished processing
         console.log(
           'Agent finished. Stop reason:',
-          (this.agentHost.state as unknown as Record<string, unknown>).stopReason
+          (host.state as unknown as Record<string, unknown>).stopReason
         );
 
         // Send context usage update
-        const usage = this.agentHost.getContextUsage();
+        const usage = host.getContextUsage();
         if (usage) {
           this.send({
             type: 'context_usage',
             percent: usage.percent,
             tokens: usage.tokens,
             contextWindow: usage.contextWindow,
+            agentId,
           });
         }
 
         // Signal that the agent is ready for the next message
-        this.send({ type: 'ready_for_input' });
+        this.send({ type: 'ready_for_input', agentId });
         break;
       }
 
@@ -292,9 +387,9 @@ export class WebSocketHandler {
       this.artifactWatcher.close();
       this.artifactWatcher = undefined;
     }
-    if (this.unsubscribe) {
-      this.unsubscribe();
-      this.unsubscribe = undefined;
+    if (this.activeSubscription) {
+      this.activeSubscription();
+      this.activeSubscription = undefined;
     }
   }
 }

--- a/packages/shared/src/types/messages.ts
+++ b/packages/shared/src/types/messages.ts
@@ -7,24 +7,39 @@
 import type { ChatMessage } from './chat.js';
 
 // Client -> Server messages
+// agentId is optional on user/steering/abort: when absent, defaults to the Guide agent.
 export type ClientMessage =
-  | { type: 'user_message'; content: string }
-  | { type: 'steering_message'; content: string } // Steering messages are inserted ASAP into the agent loop
-  | { type: 'abort' };
+  | { type: 'user_message'; content: string; agentId?: number }
+  | { type: 'steering_message'; content: string; agentId?: number } // Steering messages are inserted ASAP into the agent loop
+  | { type: 'abort'; agentId?: number }
+  | { type: 'switch_agent'; agentId: number }; // Switch the active chat to a different agent
 
 // Server -> Client messages
+// agentId is optional on streaming messages: when absent, implies the Guide agent.
 export type ServerMessage =
-  | { type: 'assistant_chunk'; content: string }
-  | { type: 'assistant_end' }
-  | { type: 'thinking_chunk'; content: string }
-  | { type: 'thinking_end' }
-  | { type: 'tool_call_start'; name: string; input?: string }
-  | { type: 'tool_call_end'; name: string; result: string }
+  | { type: 'assistant_chunk'; content: string; agentId?: number }
+  | { type: 'assistant_end'; agentId?: number }
+  | { type: 'thinking_chunk'; content: string; agentId?: number }
+  | { type: 'thinking_end'; agentId?: number }
+  | { type: 'tool_call_start'; name: string; input?: string; agentId?: number }
+  | { type: 'tool_call_end'; name: string; result: string; agentId?: number }
   | { type: 'artifact'; url: string; title?: string; filePath?: string }
-  | { type: 'context_usage'; percent: number | null; tokens: number | null; contextWindow: number }
-  | { type: 'error'; message: string }
-  | { type: 'ready_for_input' } // Signals that the agent is ready for the next message
-  | { type: 'chat_history'; messages: ChatMessage[] } // Sent on connect — recent message history from server
-  | { type: 'user_message_broadcast'; id: string; content: string; timestamp: number } // Broadcast to other tabs
+  | {
+      type: 'context_usage';
+      percent: number | null;
+      tokens: number | null;
+      contextWindow: number;
+      agentId?: number;
+    }
+  | { type: 'error'; message: string; agentId?: number }
+  | { type: 'ready_for_input'; agentId?: number } // Signals that the agent is ready for the next message
+  | { type: 'chat_history'; messages: ChatMessage[]; agentId: number } // Sent on connect and agent switch
+  | {
+      type: 'user_message_broadcast';
+      id: string;
+      content: string;
+      timestamp: number;
+      agentId?: number;
+    }
   | { type: 'provider_info'; provider: string } // Sent on connect — current LLM provider
   | { type: 'provider_change'; provider: string }; // Sent on failover — provider switched

--- a/packages/ui/src/components/AgentPane.tsx
+++ b/packages/ui/src/components/AgentPane.tsx
@@ -9,6 +9,7 @@ import { ChevronDownIcon, ChevronRightIcon } from '@primer/octicons-react';
 import { Box, Text } from '@primer/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { POLL_ERROR_BACKOFF_MS, POLL_INTERVAL_MS } from '../constants';
+import { useChatStore } from '../stores/chat';
 import { colors, contextColor } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
 
@@ -56,6 +57,7 @@ export function AgentPane() {
   const { accent } = useAccentColors();
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const initialized = useRef(false);
+  const activeAgentId = useChatStore((s) => s.activeAgentId);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -192,79 +194,89 @@ export function AgentPane() {
                 </Box>
                 {!isCollapsed && (
                   <Box as="tbody">
-                    {items.map((agent) => (
-                      <Box
-                        key={agent.id}
-                        as="tr"
-                        sx={{
-                          '&:hover': { backgroundColor: 'canvas.subtle' },
-                          '&:last-child td': { borderBottom: 'none' },
-                        }}
-                      >
+                    {items.map((agent) => {
+                      const isActive = agent.id === activeAgentId;
+                      return (
                         <Box
-                          as="td"
+                          key={agent.id}
+                          as="tr"
+                          onClick={() =>
+                            useChatStore.getState().setActiveAgent(agent.id, agent.role)
+                          }
                           sx={{
-                            px: 2,
-                            py: 1,
-                            borderBottom: '1px solid',
-                            borderColor: 'border.muted',
-                            whiteSpace: 'nowrap',
-                            fontFamily: 'mono',
-                          }}
-                        >
-                          {agent.id}
-                        </Box>
-                        <Box
-                          as="td"
-                          sx={{
-                            px: 2,
-                            py: 1,
-                            borderBottom: '1px solid',
-                            borderColor: 'border.muted',
-                            textTransform: 'capitalize',
-                            width: '100%',
-                          }}
-                        >
-                          {agent.role}
-                        </Box>
-                        <Box
-                          as="td"
-                          sx={{
-                            px: 2,
-                            py: 1,
-                            borderBottom: '1px solid',
-                            borderColor: 'border.muted',
-                            whiteSpace: 'nowrap',
-                            color:
-                              agent.contextPercent != null
-                                ? contextColor(agent.contextPercent, accent)
-                                : 'fg.muted',
-                          }}
-                        >
-                          {agent.contextPercent != null ? Math.round(agent.contextPercent) : '—'}
-                        </Box>
-                        <Box
-                          as="td"
-                          sx={{
-                            px: 2,
-                            py: 1,
-                            textAlign: 'center',
-                            borderBottom: '1px solid',
-                            borderColor: 'border.muted',
+                            cursor: 'pointer',
+                            '&:hover': { backgroundColor: 'canvas.subtle' },
+                            '&:last-child td': { borderBottom: 'none' },
                           }}
                         >
                           <Box
+                            as="td"
                             sx={{
-                              width: 8,
-                              height: 8,
-                              borderRadius: '50%',
-                              backgroundColor: agent.busy ? colors.teal : colors.gray,
-                              display: 'inline-block',
+                              px: 2,
+                              py: 1,
+                              borderBottom: '1px solid',
+                              borderColor: 'border.muted',
+                              whiteSpace: 'nowrap',
+                              fontFamily: 'mono',
+                              borderLeft: isActive
+                                ? `2px solid ${accent}`
+                                : '2px solid transparent',
                             }}
-                          />
+                          >
+                            {agent.id}
+                          </Box>
+                          <Box
+                            as="td"
+                            sx={{
+                              px: 2,
+                              py: 1,
+                              borderBottom: '1px solid',
+                              borderColor: 'border.muted',
+                              textTransform: 'capitalize',
+                              width: '100%',
+                            }}
+                          >
+                            {agent.role}
+                          </Box>
+                          <Box
+                            as="td"
+                            sx={{
+                              px: 2,
+                              py: 1,
+                              borderBottom: '1px solid',
+                              borderColor: 'border.muted',
+                              whiteSpace: 'nowrap',
+                              color:
+                                agent.contextPercent != null
+                                  ? contextColor(agent.contextPercent, accent)
+                                  : 'fg.muted',
+                            }}
+                          >
+                            {agent.contextPercent != null ? Math.round(agent.contextPercent) : '—'}
+                          </Box>
+                          <Box
+                            as="td"
+                            sx={{
+                              px: 2,
+                              py: 1,
+                              textAlign: 'center',
+                              borderBottom: '1px solid',
+                              borderColor: 'border.muted',
+                            }}
+                          >
+                            <Box
+                              sx={{
+                                width: 8,
+                                height: 8,
+                                borderRadius: '50%',
+                                backgroundColor: agent.busy ? colors.teal : colors.gray,
+                                display: 'inline-block',
+                              }}
+                            />
+                          </Box>
                         </Box>
-                      </Box>
-                    ))}
+                      );
+                    })}
                   </Box>
                 )}
               </Box>

--- a/packages/ui/src/components/Chat.tsx
+++ b/packages/ui/src/components/Chat.tsx
@@ -13,7 +13,9 @@ import { MessageList } from './MessageList';
 
 export function Chat() {
   const { sendMessage, abort } = useWebSocket();
-  const { addUserMessage, queueMessage, activeAgentLabel } = useChatStore();
+  const addUserMessage = useChatStore((s) => s.addUserMessage);
+  const queueMessage = useChatStore((s) => s.queueMessage);
+  const activeAgentLabel = useChatStore((s) => s.activeAgentLabel);
 
   const handleSend = (content: string) => {
     addUserMessage(content);

--- a/packages/ui/src/components/Chat.tsx
+++ b/packages/ui/src/components/Chat.tsx
@@ -13,7 +13,7 @@ import { MessageList } from './MessageList';
 
 export function Chat() {
   const { sendMessage, abort } = useWebSocket();
-  const { addUserMessage, queueMessage } = useChatStore();
+  const { addUserMessage, queueMessage, activeAgentLabel } = useChatStore();
 
   const handleSend = (content: string) => {
     addUserMessage(content);
@@ -41,7 +41,7 @@ export function Chat() {
         }}
       >
         <Box as="h2" sx={{ fontSize: 2, fontWeight: 'bold', margin: 0 }}>
-          System2
+          {activeAgentLabel ?? 'System2'}
         </Box>
       </Box>
 

--- a/packages/ui/src/components/MessageInput.tsx
+++ b/packages/ui/src/components/MessageInput.tsx
@@ -9,7 +9,7 @@
 import { ArrowUpIcon, SquareFillIcon } from '@primer/octicons-react';
 import { Box } from '@primer/react';
 import { useRef, useState } from 'react';
-import { useChatStore } from '../stores/chat';
+import { EMPTY_AGENT_STATE, useChatStore } from '../stores/chat';
 import { colors, contextColor } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
 
@@ -26,8 +26,14 @@ interface MessageInputProps {
 
 export function MessageInput({ onSend, onQueue, onAbort }: MessageInputProps) {
   const [input, setInput] = useState('');
-  const { isStreaming, isWaitingForResponse, isConnected, messageQueue, contextPercent, provider } =
-    useChatStore();
+  const isConnected = useChatStore((s) => s.isConnected);
+  const activeAgentRole = useChatStore((s) => s.activeAgentRole);
+  const activeState = useChatStore((s) => {
+    if (s.activeAgentId === null) return EMPTY_AGENT_STATE;
+    return s.agentStates.get(s.activeAgentId) ?? EMPTY_AGENT_STATE;
+  });
+  const provider = useChatStore((s) => s.provider);
+  const { isStreaming, isWaitingForResponse, messageQueue, contextPercent } = activeState;
   const { accent, accentHover } = useAccentColors();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -95,7 +101,7 @@ export function MessageInput({ onSend, onQueue, onAbort }: MessageInputProps) {
               ? 'Connecting to server...'
               : isStreaming
                 ? 'Type to queue a message...'
-                : 'Ask the Guide a question...'
+                : `Message ${activeAgentRole ?? 'Agent'}...`
           }
           disabled={!isConnected}
           rows={1}

--- a/packages/ui/src/components/MessageInput.tsx
+++ b/packages/ui/src/components/MessageInput.tsx
@@ -27,6 +27,7 @@ interface MessageInputProps {
 export function MessageInput({ onSend, onQueue, onAbort }: MessageInputProps) {
   const [input, setInput] = useState('');
   const isConnected = useChatStore((s) => s.isConnected);
+  const activeAgentId = useChatStore((s) => s.activeAgentId);
   const activeAgentRole = useChatStore((s) => s.activeAgentRole);
   const activeState = useChatStore((s) => {
     if (s.activeAgentId === null) return EMPTY_AGENT_STATE;
@@ -103,7 +104,7 @@ export function MessageInput({ onSend, onQueue, onAbort }: MessageInputProps) {
                 ? 'Type to queue a message...'
                 : `Message ${activeAgentRole ?? 'Agent'}...`
           }
-          disabled={!isConnected}
+          disabled={!isConnected || activeAgentId === null}
           rows={1}
           style={{
             width: '100%',

--- a/packages/ui/src/components/MessageList.tsx
+++ b/packages/ui/src/components/MessageList.tsx
@@ -9,6 +9,7 @@ import { Box, Text } from '@primer/react';
 import { Fragment, useEffect, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
 import {
+  EMPTY_AGENT_STATE,
   type Message,
   type ThinkingBlock as ThinkingBlockType,
   type ToolCall,
@@ -425,7 +426,15 @@ function TurnEventItem({ event, isLast }: { event: TurnEvent; isLast?: boolean }
 }
 
 // Render an assistant message with its turn events in chronological order
-function AssistantMessageBlock({ message, isLast }: { message: Message; isLast: boolean }) {
+function AssistantMessageBlock({
+  message,
+  isLast,
+  agentRole,
+}: {
+  message: Message;
+  isLast: boolean;
+  agentRole: string;
+}) {
   const { accent } = useAccentColors();
   const hasTurnEvents = message.turnEvents && message.turnEvents.length > 0;
 
@@ -450,7 +459,7 @@ function AssistantMessageBlock({ message, isLast }: { message: Message; isLast: 
             marginBottom: 1,
           }}
         >
-          Guide
+          {agentRole}
         </Text>
         <MarkdownContent content={message.content} />
       </TimelineItem>
@@ -459,8 +468,13 @@ function AssistantMessageBlock({ message, isLast }: { message: Message; isLast: 
 }
 
 export function MessageList() {
+  const activeState = useChatStore((s) => {
+    if (s.activeAgentId === null) return EMPTY_AGENT_STATE;
+    return s.agentStates.get(s.activeAgentId) ?? EMPTY_AGENT_STATE;
+  });
   const { messages, currentAssistantMessage, currentTurnEvents, isWaitingForResponse } =
-    useChatStore();
+    activeState;
+  const activeAgentRole = useChatStore((s) => s.activeAgentRole) ?? 'Agent';
   const { accent } = useAccentColors();
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -577,7 +591,14 @@ export function MessageList() {
         }
 
         // Assistant message with embedded turn events
-        return <AssistantMessageBlock key={message.id} message={message} isLast={isLastMessage} />;
+        return (
+          <AssistantMessageBlock
+            key={message.id}
+            message={message}
+            isLast={isLastMessage}
+            agentRole={activeAgentRole}
+          />
+        );
       })}
 
       {/* Waiting for response indicator */}
@@ -607,7 +628,7 @@ export function MessageList() {
               marginBottom: 1,
             }}
           >
-            Guide
+            {activeAgentRole}
           </Text>
           <MarkdownContent content={currentAssistantMessage} />
         </TimelineItem>

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -195,12 +195,16 @@ export function useWebSocket() {
 
     ws.onerror = (error) => {
       console.error('WebSocket error:', error);
-      useChatStore.getState().setConnected(false);
+      const state = useChatStore.getState();
+      state.setConnected(false);
+      state.clearAllStreamingState();
     };
 
     ws.onclose = () => {
       console.log('WebSocket disconnected');
-      useChatStore.getState().setConnected(false);
+      const state = useChatStore.getState();
+      state.setConnected(false);
+      state.clearAllStreamingState();
     };
 
     return () => {

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -137,7 +137,18 @@ export function useWebSocket() {
           // First chat_history is for the Guide (on initial connect)
           if (state.guideAgentId === null) {
             state.setGuideAgentId(aid);
-            state.setActiveAgent(aid, 'guide');
+            if (state.activeAgentId === null) {
+              // No agent selected yet — default to Guide
+              state.setActiveAgent(aid, 'guide');
+            } else if (state.activeAgentId !== aid) {
+              // User pre-selected a different agent before history arrived —
+              // re-subscribe the server to the correct agent
+              const switchMsg: ClientMessage = {
+                type: 'switch_agent',
+                agentId: state.activeAgentId,
+              };
+              ws.send(JSON.stringify(switchMsg));
+            }
           }
           state.loadHistory(message.messages, aid);
           break;

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -3,6 +3,7 @@
  *
  * Manages WebSocket connection to the server.
  * Supports message queueing with steering message priority.
+ * Routes messages to/from per-agent state via agentId.
  */
 
 import type { ClientMessage, ServerMessage } from '@system2/shared';
@@ -14,35 +15,38 @@ const WS_URL = `ws://${window.location.hostname}:3000`;
 
 export function useWebSocket() {
   const wsRef = useRef<WebSocket | null>(null);
-  const {
-    startAssistantMessage,
-    appendAssistantChunk,
-    finishAssistantMessage,
-    startThinking,
-    appendThinkingChunk,
-    finishThinking,
-    startToolCall,
-    finishToolCall,
-    setConnected,
-    setWaitingForResponse,
-    addUserMessage,
-    dequeueMessage,
-  } = useChatStore();
+  const activeAgentId = useChatStore((s) => s.activeAgentId);
+  const prevAgentRef = useRef<number | null>(null);
 
-  // Process the next queued message
-  const processNextQueuedMessage = useCallback(() => {
-    const nextMsg = dequeueMessage();
+  // Send switch_agent when activeAgentId changes (user-initiated switch via AgentPane)
+  useEffect(() => {
+    if (
+      activeAgentId !== null &&
+      prevAgentRef.current !== null &&
+      activeAgentId !== prevAgentRef.current
+    ) {
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        const msg: ClientMessage = { type: 'switch_agent', agentId: activeAgentId };
+        wsRef.current.send(JSON.stringify(msg));
+      }
+    }
+    prevAgentRef.current = activeAgentId;
+  }, [activeAgentId]);
+
+  // Process the next queued message for a specific agent
+  const processNextQueuedMessage = useCallback((agentId: number) => {
+    const state = useChatStore.getState();
+    const nextMsg = state.dequeueMessage(agentId);
     if (nextMsg && wsRef.current?.readyState === WebSocket.OPEN) {
-      // Add the queued message to the UI
-      addUserMessage(nextMsg.content);
-
-      const message: ClientMessage = {
+      state.addUserMessage(nextMsg.content, undefined, undefined, agentId);
+      const msg: ClientMessage = {
         type: nextMsg.isSteering ? 'steering_message' : 'user_message',
         content: nextMsg.content,
+        agentId,
       };
-      wsRef.current.send(JSON.stringify(message));
+      wsRef.current.send(JSON.stringify(msg));
     }
-  }, [dequeueMessage, addUserMessage]);
+  }, []);
 
   useEffect(() => {
     const ws = new WebSocket(WS_URL);
@@ -50,94 +54,139 @@ export function useWebSocket() {
 
     ws.onopen = () => {
       console.log('WebSocket connected');
-      setConnected(true);
+      const state = useChatStore.getState();
+      state.setConnected(true);
+      // On reconnect, re-subscribe to the active agent if it's not the Guide
+      if (
+        state.activeAgentId !== null &&
+        state.guideAgentId !== null &&
+        state.activeAgentId !== state.guideAgentId
+      ) {
+        const msg: ClientMessage = { type: 'switch_agent', agentId: state.activeAgentId };
+        ws.send(JSON.stringify(msg));
+      }
     };
 
     ws.onmessage = (event) => {
       const message = JSON.parse(event.data) as ServerMessage;
+      const state = useChatStore.getState();
 
       switch (message.type) {
-        case 'thinking_chunk':
-          // Start new thinking block if none is active
-          if (!useChatStore.getState().activeThinkingId && message.content) {
-            startThinking();
+        case 'thinking_chunk': {
+          const aid = message.agentId ?? state.guideAgentId;
+          if (aid === null) break;
+          const agentState = state.agentStates.get(aid);
+          if (!agentState?.activeThinkingId && message.content) {
+            state.startThinking(aid);
           }
-          appendThinkingChunk(message.content);
+          state.appendThinkingChunk(message.content, aid);
           break;
+        }
 
-        case 'thinking_end':
-          finishThinking();
+        case 'thinking_end': {
+          const aid = message.agentId ?? state.guideAgentId;
+          if (aid !== null) state.finishThinking(aid);
           break;
+        }
 
-        case 'assistant_chunk':
-          // First chunk starts the message
-          if (!useChatStore.getState().currentAssistantMessage && message.content) {
-            finishThinking(); // Finish any active thinking
-            startAssistantMessage();
+        case 'assistant_chunk': {
+          const aid = message.agentId ?? state.guideAgentId;
+          if (aid === null) break;
+          const agentState = state.agentStates.get(aid);
+          if (!agentState?.currentAssistantMessage && message.content) {
+            state.finishThinking(aid);
+            state.startAssistantMessage(aid);
           }
-          appendAssistantChunk(message.content);
+          state.appendAssistantChunk(message.content, aid);
           break;
+        }
 
-        case 'assistant_end':
-          finishAssistantMessage();
+        case 'assistant_end': {
+          const aid = message.agentId ?? state.guideAgentId;
+          if (aid !== null) {
+            state.finishThinking(aid);
+            state.finishAssistantMessage(aid);
+          }
           break;
+        }
 
-        case 'tool_call_start':
-          startToolCall(message.name, message.input);
+        case 'tool_call_start': {
+          const aid = message.agentId ?? state.guideAgentId;
+          if (aid !== null) state.startToolCall(message.name, message.input, aid);
           break;
+        }
 
-        case 'tool_call_end':
-          finishToolCall(message.name, message.result);
+        case 'tool_call_end': {
+          const aid = message.agentId ?? state.guideAgentId;
+          if (aid !== null) state.finishToolCall(message.name, message.result, aid);
           break;
+        }
 
-        case 'ready_for_input':
-          // Agent turn is fully complete - reset streaming state and process queue
-          useChatStore.getState().setStreaming(false);
-          setWaitingForResponse(false);
-          processNextQueuedMessage();
+        case 'ready_for_input': {
+          const aid = message.agentId ?? state.guideAgentId;
+          if (aid !== null) {
+            state.setStreaming(false, aid);
+            state.setWaitingForResponse(false, aid);
+            processNextQueuedMessage(aid);
+          }
           break;
+        }
 
-        case 'chat_history':
-          useChatStore.getState().loadHistory(message.messages);
+        case 'chat_history': {
+          const aid = message.agentId;
+          // First chat_history is for the Guide (on initial connect)
+          if (state.guideAgentId === null) {
+            state.setGuideAgentId(aid);
+            state.setActiveAgent(aid, 'guide');
+          }
+          state.loadHistory(message.messages, aid);
           break;
+        }
 
-        case 'user_message_broadcast':
-          // User message sent from another tab — use server's ID and timestamp
-          addUserMessage(message.content, message.id, message.timestamp);
+        case 'user_message_broadcast': {
+          const aid = message.agentId ?? state.guideAgentId;
+          if (aid !== null) {
+            state.addUserMessage(message.content, message.id, message.timestamp, aid);
+          }
           break;
+        }
 
-        case 'context_usage':
-          useChatStore.getState().setContextPercent(message.percent);
+        case 'context_usage': {
+          const aid = message.agentId ?? state.guideAgentId;
+          if (aid !== null) state.setContextPercent(message.percent, aid);
           break;
+        }
 
         case 'artifact': {
-          const store = useArtifactStore.getState();
+          const artifactStore = useArtifactStore.getState();
           if (message.filePath) {
-            const existingTab = store.tabs.find((t) => t.filePath === message.filePath);
+            const existingTab = artifactStore.tabs.find((t) => t.filePath === message.filePath);
             if (existingTab) {
-              store.reloadTab(message.filePath, message.url);
+              artifactStore.reloadTab(message.filePath, message.url);
             } else {
-              store.openArtifact(message.url, message.title, message.filePath);
+              artifactStore.openArtifact(message.url, message.title, message.filePath);
             }
           } else {
-            store.openArtifact(message.url, message.title);
+            artifactStore.openArtifact(message.url, message.title);
           }
           break;
         }
 
         case 'provider_info':
-          useChatStore.getState().setProvider(message.provider);
+          state.setProvider(message.provider);
           break;
 
         case 'provider_change':
-          useChatStore.getState().setProvider(message.provider);
-          useChatStore.getState().addSystemMessage(`Switched to ${message.provider}`);
+          state.setProvider(message.provider);
+          state.addSystemMessage(`Switched to ${message.provider}`);
           break;
 
-        case 'error':
+        case 'error': {
           console.error('Server error:', message.message);
-          setWaitingForResponse(false);
+          const aid = message.agentId ?? state.activeAgentId;
+          if (aid !== null) state.setWaitingForResponse(false, aid);
           break;
+        }
 
         default:
           console.log('Unknown message type:', message);
@@ -146,60 +195,51 @@ export function useWebSocket() {
 
     ws.onerror = (error) => {
       console.error('WebSocket error:', error);
-      setConnected(false);
-      setWaitingForResponse(false);
+      useChatStore.getState().setConnected(false);
     };
 
     ws.onclose = () => {
       console.log('WebSocket disconnected');
-      setConnected(false);
-      setWaitingForResponse(false);
+      useChatStore.getState().setConnected(false);
     };
 
     return () => {
       ws.close();
     };
-  }, [
-    addUserMessage,
-    appendAssistantChunk,
-    appendThinkingChunk,
-    finishAssistantMessage,
-    finishThinking,
-    finishToolCall,
-    processNextQueuedMessage,
-    setConnected,
-    setWaitingForResponse,
-    startAssistantMessage,
-    startThinking,
-    startToolCall,
-  ]);
+  }, [processNextQueuedMessage]);
 
   const sendMessage = useCallback((content: string) => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
-      const message: ClientMessage = {
+      const agentId = useChatStore.getState().activeAgentId;
+      const msg: ClientMessage = {
         type: 'user_message',
         content,
+        agentId: agentId ?? undefined,
       };
-      wsRef.current.send(JSON.stringify(message));
+      wsRef.current.send(JSON.stringify(msg));
     }
   }, []);
 
   const sendSteeringMessage = useCallback((content: string) => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
-      const message: ClientMessage = {
+      const agentId = useChatStore.getState().activeAgentId;
+      const msg: ClientMessage = {
         type: 'steering_message',
         content,
+        agentId: agentId ?? undefined,
       };
-      wsRef.current.send(JSON.stringify(message));
+      wsRef.current.send(JSON.stringify(msg));
     }
   }, []);
 
   const abort = useCallback(() => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
-      const message: ClientMessage = {
+      const agentId = useChatStore.getState().activeAgentId;
+      const msg: ClientMessage = {
         type: 'abort',
+        agentId: agentId ?? undefined,
       };
-      wsRef.current.send(JSON.stringify(message));
+      wsRef.current.send(JSON.stringify(msg));
     }
   }, []);
 

--- a/packages/ui/src/stores/chat.test.ts
+++ b/packages/ui/src/stores/chat.test.ts
@@ -126,6 +126,26 @@ describe('useChatStore', () => {
     });
   });
 
+  describe('clearAllStreamingState', () => {
+    it('resets streaming flags, thinking, currentAssistantMessage, and currentTurnEvents', () => {
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore.getState().startThinking(1);
+      useChatStore.getState().startToolCall('bash', '{}', 1);
+      useChatStore.getState().startAssistantMessage(1);
+      useChatStore.getState().setStreaming(true, 1);
+      useChatStore.getState().setWaitingForResponse(true, 1);
+
+      useChatStore.getState().clearAllStreamingState();
+
+      const state = useChatStore.getState().agentStates.get(1);
+      expect(state?.isStreaming).toBe(false);
+      expect(state?.isWaitingForResponse).toBe(false);
+      expect(state?.activeThinkingId).toBeNull();
+      expect(state?.currentAssistantMessage).toBeNull();
+      expect(state?.currentTurnEvents).toHaveLength(0);
+    });
+  });
+
   describe('provider (global state)', () => {
     it('setProvider updates global provider, not per-agent', () => {
       useChatStore.setState({ activeAgentId: 1 });

--- a/packages/ui/src/stores/chat.test.ts
+++ b/packages/ui/src/stores/chat.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Chat Store Tests
+ *
+ * Tests for per-agent state isolation, dequeue routing, and loadHistory resets.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useChatStore } from './chat';
+
+function resetStore() {
+  useChatStore.setState({
+    agentStates: new Map(),
+    activeAgentId: null,
+    activeAgentLabel: null,
+    activeAgentRole: null,
+    guideAgentId: null,
+    isConnected: false,
+    provider: null,
+  });
+}
+
+describe('useChatStore', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  describe('per-agent state isolation', () => {
+    it('updating agent A does not change agent B state reference', () => {
+      const store = useChatStore.getState();
+
+      // Initialize both agents
+      store.loadHistory([], 1);
+      store.loadHistory([], 2);
+
+      const beforeB = useChatStore.getState().agentStates.get(2);
+
+      // Update agent A only
+      useChatStore
+        .getState()
+        .loadHistory([{ id: 'm1', role: 'user', content: 'hi', timestamp: 1 }], 1);
+
+      const afterB = useChatStore.getState().agentStates.get(2);
+
+      // Agent B state object should be the same reference (not a new object)
+      expect(afterB).toBe(beforeB);
+    });
+
+    it('updating agent A does not affect agent B messages', () => {
+      const store = useChatStore.getState();
+
+      store.loadHistory([], 1);
+      store.loadHistory([{ id: 'b1', role: 'user', content: 'agent B message', timestamp: 1 }], 2);
+
+      useChatStore
+        .getState()
+        .loadHistory([{ id: 'a1', role: 'user', content: 'agent A message', timestamp: 2 }], 1);
+
+      const stateA = useChatStore.getState().agentStates.get(1);
+      const stateB = useChatStore.getState().agentStates.get(2);
+
+      expect(stateA?.messages).toHaveLength(1);
+      expect(stateA?.messages[0].content).toBe('agent A message');
+      expect(stateB?.messages).toHaveLength(1);
+      expect(stateB?.messages[0].content).toBe('agent B message');
+    });
+  });
+
+  describe('dequeueMessage', () => {
+    it('dequeues from the correct agent when agentId is provided explicitly', () => {
+      // Set active agent to 1
+      useChatStore.setState({ activeAgentId: 1 });
+
+      // Initialize both agents
+      useChatStore.getState().loadHistory([], 1);
+      useChatStore.getState().loadHistory([], 2);
+      const { agentStates } = useChatStore.getState();
+      const existingState = agentStates.get(2);
+      if (!existingState) throw new Error('agent 2 state not found');
+      const stateForTwo = { ...existingState };
+      stateForTwo.messageQueue = [
+        { id: 'q1', content: 'for agent 2', isSteering: false, timestamp: 1 },
+      ];
+      const next = new Map(agentStates);
+      next.set(2, stateForTwo);
+      useChatStore.setState({ agentStates: next });
+
+      // Dequeue explicitly from agent 2
+      const msg = useChatStore.getState().dequeueMessage(2);
+
+      expect(msg?.content).toBe('for agent 2');
+      // Active agent 1's queue is untouched
+      expect(useChatStore.getState().agentStates.get(1)?.messageQueue).toHaveLength(0);
+    });
+
+    it('returns undefined when queue is empty', () => {
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore.getState().loadHistory([], 1);
+
+      expect(useChatStore.getState().dequeueMessage(1)).toBeUndefined();
+    });
+
+    it('returns undefined when agentId is null and no active agent', () => {
+      expect(useChatStore.getState().dequeueMessage()).toBeUndefined();
+    });
+  });
+
+  describe('loadHistory', () => {
+    it('sets messages and resets streaming state', () => {
+      useChatStore.setState({ activeAgentId: 1 });
+
+      // Simulate an agent mid-stream
+      useChatStore.getState().startAssistantMessage(1);
+      useChatStore.getState().setStreaming(true, 1);
+
+      // Load history should reset all state
+      useChatStore
+        .getState()
+        .loadHistory([{ id: 'm1', role: 'assistant', content: 'past message', timestamp: 1 }], 1);
+
+      const state = useChatStore.getState().agentStates.get(1);
+      expect(state?.messages).toHaveLength(1);
+      expect(state?.isStreaming).toBe(false);
+      expect(state?.isWaitingForResponse).toBe(false);
+      expect(state?.activeThinkingId).toBeNull();
+      expect(state?.currentAssistantMessage).toBeNull();
+    });
+  });
+
+  describe('provider (global state)', () => {
+    it('setProvider updates global provider, not per-agent', () => {
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore.getState().loadHistory([], 1);
+
+      useChatStore.getState().setProvider('openai');
+
+      // Global provider is set
+      expect(useChatStore.getState().provider).toBe('openai');
+
+      // Switching activeAgentId does not affect provider
+      useChatStore.setState({ activeAgentId: 2 });
+      expect(useChatStore.getState().provider).toBe('openai');
+    });
+  });
+});

--- a/packages/ui/src/stores/chat.ts
+++ b/packages/ui/src/stores/chat.ts
@@ -2,7 +2,9 @@
  * Chat Store
  *
  * Zustand store for managing chat messages and connection state.
- * Tracks turn events (thinking, tool calls) in chronological order.
+ * Supports per-agent state: each agent has its own message history,
+ * streaming state, and message queue. The active agent determines
+ * which state is displayed in the UI.
  *
  * The server is the source of truth for message history.
  * On WebSocket connect, the server sends chat_history with recent messages.
@@ -26,56 +28,123 @@ export interface QueuedMessage {
   timestamp: number;
 }
 
-interface ChatState {
+/** Per-agent streaming and message state. */
+export interface PerAgentState {
   messages: Message[];
-  // Current turn state (while streaming)
   currentAssistantMessage: string | null;
   currentTurnEvents: TurnEvent[];
-  activeThinkingId: string | null; // ID of currently streaming thinking block
-  isConnected: boolean;
+  activeThinkingId: string | null;
   isStreaming: boolean;
-  isWaitingForResponse: boolean; // True after user sends, before first chunk arrives
-  // Message queue
+  isWaitingForResponse: boolean;
   messageQueue: QueuedMessage[];
-  // Context window usage
   contextPercent: number | null;
-  // Current LLM provider
+}
+
+function createDefaultAgentState(): PerAgentState {
+  return {
+    messages: [],
+    currentAssistantMessage: null,
+    currentTurnEvents: [],
+    activeThinkingId: null,
+    isStreaming: false,
+    isWaitingForResponse: false,
+    messageQueue: [],
+    contextPercent: null,
+  };
+}
+
+/** Stable default returned by selectors when no agent state exists yet. */
+export const EMPTY_AGENT_STATE = createDefaultAgentState();
+
+interface ChatState {
+  // Per-agent state keyed by agentId
+  agentStates: Map<number, PerAgentState>;
+  // Active agent being viewed
+  activeAgentId: number | null;
+  activeAgentLabel: string | null; // e.g., "guide_1"
+  activeAgentRole: string | null; // e.g., "Guide"
+  // Guide agent ID (set on first connect)
+  guideAgentId: number | null;
+  // Global connection and provider state
+  isConnected: boolean;
   provider: string | null;
 
-  addUserMessage: (content: string, id?: string, timestamp?: number) => void;
+  // Agent management
+  setActiveAgent: (agentId: number, role: string) => void;
+  setGuideAgentId: (id: number) => void;
+  getAgentState: (agentId: number) => PerAgentState;
+  getActiveState: () => PerAgentState;
+
+  // Actions (agentId optional, defaults to active agent)
+  addUserMessage: (content: string, id?: string, timestamp?: number, agentId?: number) => void;
   addSystemMessage: (content: string) => void;
-  loadHistory: (messages: Message[]) => void;
+  loadHistory: (messages: Message[], agentId: number) => void;
   queueMessage: (content: string, isSteering?: boolean) => void;
-  dequeueMessage: () => QueuedMessage | undefined;
+  dequeueMessage: (agentId?: number) => QueuedMessage | undefined;
   clearQueue: () => void;
-  startAssistantMessage: () => void;
-  appendAssistantChunk: (chunk: string) => void;
-  finishAssistantMessage: () => void;
-  startThinking: () => void;
-  appendThinkingChunk: (chunk: string) => void;
-  finishThinking: () => void;
-  startToolCall: (name: string, input?: string) => void;
-  finishToolCall: (name: string, result: string) => void;
+  startAssistantMessage: (agentId?: number) => void;
+  appendAssistantChunk: (chunk: string, agentId?: number) => void;
+  finishAssistantMessage: (agentId?: number) => void;
+  startThinking: (agentId?: number) => void;
+  appendThinkingChunk: (chunk: string, agentId?: number) => void;
+  finishThinking: (agentId?: number) => void;
+  startToolCall: (name: string, input?: string, agentId?: number) => void;
+  finishToolCall: (name: string, result: string, agentId?: number) => void;
   setConnected: (connected: boolean) => void;
-  setStreaming: (streaming: boolean) => void;
-  setWaitingForResponse: (waiting: boolean) => void;
-  setContextPercent: (percent: number | null) => void;
+  setStreaming: (streaming: boolean, agentId?: number) => void;
+  setWaitingForResponse: (waiting: boolean, agentId?: number) => void;
+  setContextPercent: (percent: number | null, agentId?: number) => void;
   setProvider: (provider: string) => void;
 }
 
+/** Immutably update a specific agent's state within the Map. */
+function updateAgentState(
+  states: Map<number, PerAgentState>,
+  agentId: number,
+  updater: (state: PerAgentState) => Partial<PerAgentState>
+): Map<number, PerAgentState> {
+  const current = states.get(agentId) ?? createDefaultAgentState();
+  const updated = { ...current, ...updater(current) };
+  const next = new Map(states);
+  next.set(agentId, updated);
+  return next;
+}
+
 export const useChatStore = create<ChatState>()((set, get) => ({
-  messages: [],
-  currentAssistantMessage: null,
-  currentTurnEvents: [],
-  activeThinkingId: null,
+  agentStates: new Map(),
+  activeAgentId: null,
+  activeAgentLabel: null,
+  activeAgentRole: null,
+  guideAgentId: null,
   isConnected: false,
-  isStreaming: false,
-  isWaitingForResponse: false,
-  messageQueue: [],
-  contextPercent: null,
   provider: null,
 
-  addUserMessage: (content: string, id?: string, timestamp?: number) => {
+  setActiveAgent: (agentId: number, role: string) => {
+    set({
+      activeAgentId: agentId,
+      activeAgentLabel: `${role}_${agentId}`,
+      activeAgentRole: role.charAt(0).toUpperCase() + role.slice(1),
+    });
+  },
+
+  setGuideAgentId: (id: number) => {
+    set({ guideAgentId: id });
+  },
+
+  getAgentState: (agentId: number) => {
+    return get().agentStates.get(agentId) ?? createDefaultAgentState();
+  },
+
+  getActiveState: () => {
+    const { activeAgentId, agentStates } = get();
+    if (activeAgentId === null) return createDefaultAgentState();
+    return agentStates.get(activeAgentId) ?? createDefaultAgentState();
+  },
+
+  addUserMessage: (content: string, id?: string, timestamp?: number, agentId?: number) => {
+    const targetId = agentId ?? get().activeAgentId;
+    if (targetId === null) return;
+
     const message: Message = {
       id: id ?? `msg-${Date.now()}`,
       role: 'user',
@@ -83,15 +152,19 @@ export const useChatStore = create<ChatState>()((set, get) => ({
       timestamp: timestamp ?? Date.now(),
     };
     set((state) => ({
-      messages: [...state.messages, message],
-      // Clear any lingering turn state when user sends new message
-      currentTurnEvents: [],
-      activeThinkingId: null,
-      isWaitingForResponse: true,
+      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+        messages: [...s.messages, message],
+        currentTurnEvents: [],
+        activeThinkingId: null,
+        isWaitingForResponse: true,
+      })),
     }));
   },
 
   addSystemMessage: (content: string) => {
+    const targetId = get().activeAgentId;
+    if (targetId === null) return;
+
     const message: Message = {
       id: `msg-${Date.now()}`,
       role: 'system',
@@ -99,76 +172,122 @@ export const useChatStore = create<ChatState>()((set, get) => ({
       timestamp: Date.now(),
     };
     set((state) => ({
-      messages: [...state.messages, message],
+      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+        messages: [...s.messages, message],
+      })),
     }));
   },
 
-  loadHistory: (messages: Message[]) => {
-    set({ messages });
+  loadHistory: (messages: Message[], agentId: number) => {
+    set((state) => ({
+      agentStates: updateAgentState(state.agentStates, agentId, () => ({
+        messages,
+        currentAssistantMessage: null,
+        currentTurnEvents: [],
+        activeThinkingId: null,
+        isStreaming: false,
+        isWaitingForResponse: false,
+      })),
+    }));
   },
 
   queueMessage: (content: string, isSteering = false) => {
+    const targetId = get().activeAgentId;
+    if (targetId === null) return;
+
     const queuedMsg: QueuedMessage = {
       id: `queued-${Date.now()}`,
       content,
       isSteering,
       timestamp: Date.now(),
     };
-    set((state) => {
-      // Steering messages go to the front of the queue
-      if (isSteering) {
-        return { messageQueue: [queuedMsg, ...state.messageQueue] };
-      }
-      return { messageQueue: [...state.messageQueue, queuedMsg] };
-    });
+    set((state) => ({
+      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+        messageQueue: isSteering ? [queuedMsg, ...s.messageQueue] : [...s.messageQueue, queuedMsg],
+      })),
+    }));
   },
 
-  dequeueMessage: () => {
-    const state = get();
-    if (state.messageQueue.length === 0) return undefined;
-    const [next, ...rest] = state.messageQueue;
-    set({ messageQueue: rest });
+  dequeueMessage: (agentId?: number) => {
+    const targetId = agentId ?? get().activeAgentId;
+    if (targetId === null) return undefined;
+
+    const agentState = get().agentStates.get(targetId);
+    if (!agentState || agentState.messageQueue.length === 0) return undefined;
+
+    const [next, ...rest] = agentState.messageQueue;
+    set((state) => ({
+      agentStates: updateAgentState(state.agentStates, targetId, () => ({
+        messageQueue: rest,
+      })),
+    }));
     return next;
   },
 
   clearQueue: () => {
-    set({ messageQueue: [] });
-  },
-
-  startAssistantMessage: () => {
-    set({ currentAssistantMessage: '', isStreaming: true, isWaitingForResponse: false });
-  },
-
-  appendAssistantChunk: (chunk: string) => {
+    const targetId = get().activeAgentId;
+    if (targetId === null) return;
     set((state) => ({
-      currentAssistantMessage: (state.currentAssistantMessage || '') + chunk,
+      agentStates: updateAgentState(state.agentStates, targetId, () => ({
+        messageQueue: [],
+      })),
     }));
   },
 
-  finishAssistantMessage: () => {
-    const state = get();
-    const content = state.currentAssistantMessage;
+  startAssistantMessage: (agentId?: number) => {
+    const targetId = agentId ?? get().activeAgentId;
+    if (targetId === null) return;
+    set((state) => ({
+      agentStates: updateAgentState(state.agentStates, targetId, () => ({
+        currentAssistantMessage: '',
+        isStreaming: true,
+        isWaitingForResponse: false,
+      })),
+    }));
+  },
+
+  appendAssistantChunk: (chunk: string, agentId?: number) => {
+    const targetId = agentId ?? get().activeAgentId;
+    if (targetId === null) return;
+    set((state) => ({
+      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+        currentAssistantMessage: (s.currentAssistantMessage || '') + chunk,
+      })),
+    }));
+  },
+
+  finishAssistantMessage: (agentId?: number) => {
+    const targetId = agentId ?? get().activeAgentId;
+    if (targetId === null) return;
+
+    const agentState = get().agentStates.get(targetId);
+    if (!agentState) return;
+
+    const content = agentState.currentAssistantMessage;
     if (content) {
       const message: Message = {
         id: `msg-${Date.now()}`,
         role: 'assistant',
         content,
         timestamp: Date.now(),
-        // Persist turn events in chronological order
-        turnEvents: state.currentTurnEvents.length > 0 ? [...state.currentTurnEvents] : undefined,
+        turnEvents:
+          agentState.currentTurnEvents.length > 0 ? [...agentState.currentTurnEvents] : undefined,
       };
-      // Note: isStreaming stays true — the agent may still have tool calls
-      // and more responses. It's set to false only on ready_for_input.
-      set({
-        messages: [...state.messages, message],
-        currentAssistantMessage: null,
-        currentTurnEvents: [],
-        activeThinkingId: null,
-      });
+      set((state) => ({
+        agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+          messages: [...s.messages, message],
+          currentAssistantMessage: null,
+          currentTurnEvents: [],
+          activeThinkingId: null,
+        })),
+      }));
     }
   },
 
-  startThinking: () => {
+  startThinking: (agentId?: number) => {
+    const targetId = agentId ?? get().activeAgentId;
+    if (targetId === null) return;
+
     const thinkingId = `thinking-${Date.now()}`;
     const thinkingBlock: ThinkingBlock = {
       id: thinkingId,
@@ -177,45 +296,62 @@ export const useChatStore = create<ChatState>()((set, get) => ({
       timestamp: Date.now(),
     };
     set((state) => ({
-      currentTurnEvents: [...state.currentTurnEvents, { type: 'thinking', data: thinkingBlock }],
-      activeThinkingId: thinkingId,
-      isStreaming: true,
-      isWaitingForResponse: false,
+      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+        currentTurnEvents: [...s.currentTurnEvents, { type: 'thinking', data: thinkingBlock }],
+        activeThinkingId: thinkingId,
+        isStreaming: true,
+        isWaitingForResponse: false,
+      })),
     }));
   },
 
-  appendThinkingChunk: (chunk: string) => {
-    const state = get();
-    if (!state.activeThinkingId) return;
+  appendThinkingChunk: (chunk: string, agentId?: number) => {
+    const targetId = agentId ?? get().activeAgentId;
+    if (targetId === null) return;
 
+    const agentState = get().agentStates.get(targetId);
+    if (!agentState?.activeThinkingId) return;
+
+    const activeId = agentState.activeThinkingId;
     set((state) => ({
-      currentTurnEvents: state.currentTurnEvents.map((event) =>
-        event.type === 'thinking' && event.data.id === state.activeThinkingId
-          ? { ...event, data: { ...event.data, content: event.data.content + chunk } }
-          : event
-      ),
+      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+        currentTurnEvents: s.currentTurnEvents.map((event) =>
+          event.type === 'thinking' && event.data.id === activeId
+            ? { ...event, data: { ...event.data, content: event.data.content + chunk } }
+            : event
+        ),
+      })),
     }));
   },
 
-  finishThinking: () => {
-    const state = get();
-    if (!state.activeThinkingId) return;
+  finishThinking: (agentId?: number) => {
+    const targetId = agentId ?? get().activeAgentId;
+    if (targetId === null) return;
 
+    const agentState = get().agentStates.get(targetId);
+    if (!agentState?.activeThinkingId) return;
+
+    const activeId = agentState.activeThinkingId;
     set((state) => ({
-      currentTurnEvents: state.currentTurnEvents.map((event) =>
-        event.type === 'thinking' && event.data.id === state.activeThinkingId
-          ? { ...event, data: { ...event.data, isStreaming: false } }
-          : event
-      ),
-      activeThinkingId: null,
+      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+        currentTurnEvents: s.currentTurnEvents.map((event) =>
+          event.type === 'thinking' && event.data.id === activeId
+            ? { ...event, data: { ...event.data, isStreaming: false } }
+            : event
+        ),
+        activeThinkingId: null,
+      })),
     }));
   },
 
-  startToolCall: (name: string, input?: string) => {
-    // If there's active thinking, finish it first (tool call interrupts thinking)
-    const state = get();
-    if (state.activeThinkingId) {
-      get().finishThinking();
+  startToolCall: (name: string, input?: string, agentId?: number) => {
+    const targetId = agentId ?? get().activeAgentId;
+    if (targetId === null) return;
+
+    // If there's active thinking, finish it first
+    const agentState = get().agentStates.get(targetId);
+    if (agentState?.activeThinkingId) {
+      get().finishThinking(targetId);
     }
 
     const toolCall: ToolCall = {
@@ -226,19 +362,25 @@ export const useChatStore = create<ChatState>()((set, get) => ({
       timestamp: Date.now(),
     };
     set((state) => ({
-      currentTurnEvents: [...state.currentTurnEvents, { type: 'tool_call', data: toolCall }],
-      isStreaming: true,
-      isWaitingForResponse: false,
+      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+        currentTurnEvents: [...s.currentTurnEvents, { type: 'tool_call', data: toolCall }],
+        isStreaming: true,
+        isWaitingForResponse: false,
+      })),
     }));
   },
 
-  finishToolCall: (name: string, result: string) => {
+  finishToolCall: (name: string, result: string, agentId?: number) => {
+    const targetId = agentId ?? get().activeAgentId;
+    if (targetId === null) return;
     set((state) => ({
-      currentTurnEvents: state.currentTurnEvents.map((event) =>
-        event.type === 'tool_call' && event.data.name === name && event.data.status === 'running'
-          ? { ...event, data: { ...event.data, status: 'completed' as const, result } }
-          : event
-      ),
+      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+        currentTurnEvents: s.currentTurnEvents.map((event) =>
+          event.type === 'tool_call' && event.data.name === name && event.data.status === 'running'
+            ? { ...event, data: { ...event.data, status: 'completed' as const, result } }
+            : event
+        ),
+      })),
     }));
   },
 
@@ -246,16 +388,34 @@ export const useChatStore = create<ChatState>()((set, get) => ({
     set({ isConnected: connected });
   },
 
-  setStreaming: (streaming: boolean) => {
-    set({ isStreaming: streaming });
+  setStreaming: (streaming: boolean, agentId?: number) => {
+    const targetId = agentId ?? get().activeAgentId;
+    if (targetId === null) return;
+    set((state) => ({
+      agentStates: updateAgentState(state.agentStates, targetId, () => ({
+        isStreaming: streaming,
+      })),
+    }));
   },
 
-  setWaitingForResponse: (waiting: boolean) => {
-    set({ isWaitingForResponse: waiting });
+  setWaitingForResponse: (waiting: boolean, agentId?: number) => {
+    const targetId = agentId ?? get().activeAgentId;
+    if (targetId === null) return;
+    set((state) => ({
+      agentStates: updateAgentState(state.agentStates, targetId, () => ({
+        isWaitingForResponse: waiting,
+      })),
+    }));
   },
 
-  setContextPercent: (percent: number | null) => {
-    set({ contextPercent: percent });
+  setContextPercent: (percent: number | null, agentId?: number) => {
+    const targetId = agentId ?? get().activeAgentId;
+    if (targetId === null) return;
+    set((state) => ({
+      agentStates: updateAgentState(state.agentStates, targetId, () => ({
+        contextPercent: percent,
+      })),
+    }));
   },
 
   setProvider: (provider: string) => {

--- a/packages/ui/src/stores/chat.ts
+++ b/packages/ui/src/stores/chat.ts
@@ -91,6 +91,7 @@ interface ChatState {
   startToolCall: (name: string, input?: string, agentId?: number) => void;
   finishToolCall: (name: string, result: string, agentId?: number) => void;
   setConnected: (connected: boolean) => void;
+  clearAllStreamingState: () => void;
   setStreaming: (streaming: boolean, agentId?: number) => void;
   setWaitingForResponse: (waiting: boolean, agentId?: number) => void;
   setContextPercent: (percent: number | null, agentId?: number) => void;
@@ -132,13 +133,13 @@ export const useChatStore = create<ChatState>()((set, get) => ({
   },
 
   getAgentState: (agentId: number) => {
-    return get().agentStates.get(agentId) ?? createDefaultAgentState();
+    return get().agentStates.get(agentId) ?? EMPTY_AGENT_STATE;
   },
 
   getActiveState: () => {
     const { activeAgentId, agentStates } = get();
-    if (activeAgentId === null) return createDefaultAgentState();
-    return agentStates.get(activeAgentId) ?? createDefaultAgentState();
+    if (activeAgentId === null) return EMPTY_AGENT_STATE;
+    return agentStates.get(activeAgentId) ?? EMPTY_AGENT_STATE;
   },
 
   addUserMessage: (content: string, id?: string, timestamp?: number, agentId?: number) => {
@@ -386,6 +387,29 @@ export const useChatStore = create<ChatState>()((set, get) => ({
 
   setConnected: (connected: boolean) => {
     set({ isConnected: connected });
+  },
+
+  clearAllStreamingState: () => {
+    set((state) => {
+      const next = new Map(state.agentStates);
+      for (const [id, s] of next) {
+        if (
+          s.isStreaming ||
+          s.isWaitingForResponse ||
+          s.activeThinkingId ||
+          s.currentAssistantMessage
+        ) {
+          next.set(id, {
+            ...s,
+            isStreaming: false,
+            isWaitingForResponse: false,
+            activeThinkingId: null,
+            currentAssistantMessage: null,
+          });
+        }
+      }
+      return { agentStates: next };
+    });
   },
 
   setStreaming: (streaming: boolean, agentId?: number) => {

--- a/packages/ui/src/stores/chat.ts
+++ b/packages/ui/src/stores/chat.ts
@@ -405,6 +405,7 @@ export const useChatStore = create<ChatState>()((set, get) => ({
             isWaitingForResponse: false,
             activeThinkingId: null,
             currentAssistantMessage: null,
+            currentTurnEvents: [],
           });
         }
       }


### PR DESCRIPTION
## Summary

- **Multi-agent architecture:** Guide, Conductor, Narrator, Reviewer roles. Users can switch the active chat to any agent via AgentPane. Each agent has its own per-agent `MessageHistory` (chat cache) stored at `~/.system2/sessions/{role}_{id}/chat-cache.json`.

- **Inter-agent messaging:** `deliverMessage` now captures incoming messages as `role='user'` in the receiving agent's chat cache, so the full conversation context (including what prompted a reply) is visible when the user switches to that agent.

- **Tool access by role:** `ORCHESTRATOR_ROLES = new Set(['guide', 'conductor'])` is the single source of truth in `buildTools()`. Guide and Conductors get spawn/terminate/trigger/resurrect tools. All agents get `show_artifact` (previously Guide-only). Reviewers never get orchestration tools even though the callbacks are passed — `buildTools()` gates access, not callback presence.

- **WebSocket multi-agent routing:** All server messages carry `agentId`. `switch_agent` re-subscribes the handler to the new agent's events and sends its chat history + context usage. `isThinking` flag tracks thinking state per connection and emits `thinking_end` explicitly on transitions (thinking→text, thinking→tool, thinking→message_end).

- **Provider as global state:** `provider_info`/`provider_change` carry no `agentId` — the provider is server-global. Moved from `PerAgentState` to global `ChatState` so switching agents never shows `null`.

- **Thinking spinner fixes:** `finishThinking` backstop on `assistant_end` covers pure-thinking and aborted turns. `thinking_end` is now emitted explicitly by the server at all three transition points.

- **ConversationSummarizer:** When a user directly messages a non-Guide agent, a non-resetting 1-minute timer fires a one-shot LLM summary delivered to the Guide. Keeps Guide informed without requiring the user to relay context.

- **`llm/oneshot.ts`:** Lightweight one-shot LLM utility used by the summarizer.

- **Tests:** 28 new tests — `ConversationSummarizer` (14), `AgentHost` chatCache + deliverMessage (7, merged with PR#24's additions), per-agent chat store (7).

- **Docs:** `agents.md` tool access matrix updated, `websocket-protocol.md` multi-agent routing + `thinking_end` emission documented, `ui.md` global vs per-agent state clarified.

## Test plan

- [ ] Switch to a Conductor; send a message from Guide via `message_agent` tool → incoming message visible in Conductor's history when switched
- [ ] Ask a Conductor to call `show_artifact` → artifact panel opens
- [ ] Trigger a tool-only agent turn (no text response) → no stuck thinking spinner
- [ ] Switch between agents while one is streaming → provider indicator stays correct, no stale thinking state
- [ ] Send a user message while a non-Guide agent is responding → ConversationSummarizer delivers summary to Guide after ~1 minute

Closes #20