### PR TITLE
feat(tools): add append mode to the edit tool

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -45,19 +45,29 @@ Returns the file contents as a string.
 
 ### `edit`
 
-Edit a file by replacing an exact string match. The `old_string` must appear exactly once in the file.
+Edit a file by replacing an exact string match, or append content to a file.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `path` | string | Absolute path or `~/` relative path |
-| `old_string` | string | Exact text to find (must be unique in the file) |
-| `new_string` | string | Replacement text |
+| `old_string` | string? | Exact text to find (must be unique in the file). Required unless `append` is true. |
+| `new_string` | string | Replacement text (replace mode) or content to append (append mode) |
+| `append` | boolean? | If true, append `new_string` to the end of the file instead of replacing `old_string` |
 | `commit_message` | string? | If provided and path is inside `~/.system2/`, git-commits the file with this message |
+
+**Replace mode** (default, `append` not set):
 
 - **Uniqueness check:** if `old_string` appears 0 or >1 times, the edit fails with an error instructing the agent to add more context
 - **Insertions:** use surrounding context as `old_string` and embed new content in `new_string`
 - **Preferred over `write`** for modifying existing files: only changes what is specified
-- For bulk operations where `edit` is inconvenient, use `bash` with `sed`, `awk`, `>>`, etc.
+- For bulk operations (e.g., find-and-replace across many lines), use `bash` with `sed`, `awk`, or similar
+
+**Append mode** (`append: true`):
+
+- Appends `new_string` to the end of the file
+- Creates the file (and parent directories) if it does not exist
+- Adds a newline separator if the existing content does not end with one
+- Preferred for adding entries to logs, memory files, and similar append-only patterns
 
 ### `write`
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -39,7 +39,7 @@ Read file contents from the filesystem.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `file_path` | string | Absolute path or `~/` relative path |
+| `path` | string | Absolute path or `~/` relative path |
 
 Returns the file contents as a string.
 
@@ -75,7 +75,7 @@ Write or create files on the filesystem. Overwrites the entire file.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `file_path` | string | Absolute path or `~/` relative path |
+| `path` | string | Absolute path or `~/` relative path |
 | `content` | string | File content to write |
 | `commit_message` | string? | If provided and path is inside `~/.system2/`, git-commits the file with this message |
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -79,7 +79,7 @@ Write or create files on the filesystem. Overwrites the entire file.
 | `content` | string | File content to write |
 | `commit_message` | string? | If provided and path is inside `~/.system2/`, git-commits the file with this message |
 
-Auto-creates parent directories if they don't exist. Use for creating new files or complete rewrites. For modifying specific parts of an existing file, prefer `edit`. For operations where neither is convenient, use `bash`.
+Auto-creates parent directories if they don't exist. Use for creating new files or complete rewrites. For modifying specific parts of an existing file, prefer `edit`. For appending content, use `edit` with `append: true`. For operations where none of the above fit, use `bash`.
 
 **Auto-commit (`edit` and `write`):** When `commit_message` is provided, the tool runs `git add <file> && git commit -m <message>` in `~/.system2/` after the file operation. Git failure is non-fatal: the file change still succeeds. This is the primary mechanism for version-tracking knowledge and project files.
 

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -51,7 +51,7 @@ You are a professional data expert. Accuracy is non-negotiable.
 |------|-------------|--------------|
 | `bash` | Execute shell commands (120s timeout, 10MB buffer, streaming output). Set `run_in_background` for long-running commands. Uses PowerShell on Windows, default shell on macOS/Linux. | All agents |
 | `read` | Read file contents (absolute or `~/` relative paths) | All agents |
-| `edit` | Edit a file by replacing an exact string match. Preferred over `write` for modifying existing files. | All agents |
+| `edit` | Edit a file by replacing an exact string match (`old_string` → `new_string`), or append content to a file (`append: true`). Preferred over `write` for modifying existing files. | All agents |
 | `write` | Write or create files. Auto-creates parent directories. Use for new files or complete rewrites. | All agents |
 | `read_system2_db` | Query `~/.system2/app.db` with SELECT. Returns rows as JSON. | All agents |
 | `write_system2_db` | Create/update records in `~/.system2/app.db` via named operations. | All agents |
@@ -65,7 +65,9 @@ You are a professional data expert. Accuracy is non-negotiable.
 | `web_search` | Search the web via Brave Search API | All agents (when configured) |
 
 **Notes:**
-- For modifying existing files, prefer `edit` (exact string replacement) over `write` (full overwrite). For bulk operations where neither is convenient, use `bash` with `sed`, `awk`, `>>`, or similar.
+
+- **File editing priority:** always reach for `edit` or `write` first. `edit` handles targeted replacements and appending (`append: true` — creates the file if needed); `write` handles new files and full rewrites. Only use `bash` for file editing when it genuinely handles the task better (e.g. multi-pattern transformations, binary files, or operations spanning many unrelated locations). Do not fall back to `bash echo`, `sed`, `awk`, or `>>` out of convenience when `edit` or `write` would do the job.
+- **Git commit when using `bash` to write files in `~/.system2/`:** `edit` and `write` handle git auto-commit automatically via `commit_message`. If you use `bash` to write or modify any file inside `~/.system2/`, you must commit it manually: `cd ~/.system2 && git add <file> && git commit -m "<message>"`. Skipping this breaks the version history that other agents and the Narrator depend on.
 - `bash` streams output as the command runs. Set `run_in_background` to true for long-running commands — you will receive the result as a follow-up message when the command finishes.
 - `spawn_agent`, `terminate_agent`, and `trigger_project_story` are only available to agents that receive a spawner callback (Guide and Conductors). Narrator and Reviewer cannot spawn, terminate, or trigger project stories.
 - `resurrect_agent` is Guide-only. The Guide receives a resurrector callback; no other agent can resurrect.

--- a/packages/server/src/agents/tools/edit.test.ts
+++ b/packages/server/src/agents/tools/edit.test.ts
@@ -185,5 +185,25 @@ describe('edit tool', () => {
 
       expect((result.content[0] as { text: string }).text).toContain('2 line(s)');
     });
+
+    it('does not double newline when new_string starts with CRLF', async () => {
+      const dir = trackDir(makeTmpDir());
+      const file = join(dir, 'test.txt');
+      writeFileSync(file, 'existing content');
+
+      await exec({ path: file, new_string: '\r\nnew line', append: true });
+
+      expect(readFileSync(file, 'utf-8')).toBe('existing content\r\nnew line');
+    });
+
+    it('reports 0 lines appended when new_string is empty', async () => {
+      const dir = trackDir(makeTmpDir());
+      const file = join(dir, 'test.txt');
+      writeFileSync(file, 'existing content');
+
+      const result = await exec({ path: file, new_string: '', append: true });
+
+      expect((result.content[0] as { text: string }).text).toContain('0 line(s)');
+    });
   });
 });

--- a/packages/server/src/agents/tools/edit.test.ts
+++ b/packages/server/src/agents/tools/edit.test.ts
@@ -112,4 +112,58 @@ describe('edit tool', () => {
     expect((result.content[0] as { text: string }).text).toBe('Edit aborted.');
     expect(result.details).toHaveProperty('error', 'aborted');
   });
+
+  it('errors when old_string is missing and append is not set', async () => {
+    const dir = trackDir(makeTmpDir());
+    const file = join(dir, 'test.txt');
+    writeFileSync(file, 'content');
+
+    const result = await exec({ path: file, new_string: 'x' });
+
+    expect((result.content[0] as { text: string }).text).toContain('old_string');
+    expect(result.details).toHaveProperty('error', 'missing_old_string');
+  });
+
+  describe('append mode', () => {
+    it('appends to an existing file with trailing newline', async () => {
+      const dir = trackDir(makeTmpDir());
+      const file = join(dir, 'test.txt');
+      writeFileSync(file, 'existing content\n');
+
+      const result = await exec({ path: file, new_string: 'new line\n', append: true });
+
+      expect((result.content[0] as { text: string }).text).toContain('Appended');
+      expect(readFileSync(file, 'utf-8')).toBe('existing content\nnew line\n');
+    });
+
+    it('adds newline separator when existing content lacks trailing newline', async () => {
+      const dir = trackDir(makeTmpDir());
+      const file = join(dir, 'test.txt');
+      writeFileSync(file, 'existing content');
+
+      await exec({ path: file, new_string: 'new line', append: true });
+
+      expect(readFileSync(file, 'utf-8')).toBe('existing content\nnew line');
+    });
+
+    it('appends to an empty file without adding a separator', async () => {
+      const dir = trackDir(makeTmpDir());
+      const file = join(dir, 'test.txt');
+      writeFileSync(file, '');
+
+      await exec({ path: file, new_string: 'content', append: true });
+
+      expect(readFileSync(file, 'utf-8')).toBe('content');
+    });
+
+    it('creates file and parent directories if they do not exist', async () => {
+      const dir = trackDir(makeTmpDir());
+      const file = join(dir, 'subdir', 'nested', 'test.txt');
+
+      const result = await exec({ path: file, new_string: 'hello', append: true });
+
+      expect((result.content[0] as { text: string }).text).toContain('Appended');
+      expect(readFileSync(file, 'utf-8')).toBe('hello');
+    });
+  });
 });

--- a/packages/server/src/agents/tools/edit.test.ts
+++ b/packages/server/src/agents/tools/edit.test.ts
@@ -165,5 +165,25 @@ describe('edit tool', () => {
       expect((result.content[0] as { text: string }).text).toContain('Appended');
       expect(readFileSync(file, 'utf-8')).toBe('hello');
     });
+
+    it('does not double newline when new_string starts with newline', async () => {
+      const dir = trackDir(makeTmpDir());
+      const file = join(dir, 'test.txt');
+      writeFileSync(file, 'existing content');
+
+      await exec({ path: file, new_string: '\nnew line', append: true });
+
+      expect(readFileSync(file, 'utf-8')).toBe('existing content\nnew line');
+    });
+
+    it('reports correct line count when new_string has trailing newline', async () => {
+      const dir = trackDir(makeTmpDir());
+      const file = join(dir, 'test.txt');
+      writeFileSync(file, '');
+
+      const result = await exec({ path: file, new_string: 'line one\nline two\n', append: true });
+
+      expect((result.content[0] as { text: string }).text).toContain('2 line(s)');
+    });
   });
 });

--- a/packages/server/src/agents/tools/edit.ts
+++ b/packages/server/src/agents/tools/edit.ts
@@ -1,13 +1,20 @@
 /**
  * Edit Tool
  *
- * Performs exact string replacement in files. Finds `old_string` in the file,
- * verifies it appears exactly once (uniqueness check), and replaces it with
- * `new_string`. For insertions, use surrounding context as `old_string` and
- * embed the new content in `new_string`.
+ * Performs exact string replacement in files, or appends content to a file.
+ *
+ * Replace mode (default): finds `old_string` in the file, verifies it appears
+ * exactly once (uniqueness check), and replaces it with `new_string`. For
+ * insertions, use surrounding context as `old_string` and embed the new content
+ * in `new_string`.
+ *
+ * Append mode (`append: true`): appends `new_string` to the end of the file.
+ * Creates the file (and parent directories) if it does not exist. Adds a
+ * newline separator if the existing content does not end with one.
  */
 
-import { readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { Type } from '@sinclair/typebox';
 import { commitIfStateDir } from './git-commit.js';
@@ -18,14 +25,22 @@ export function createEditTool() {
     path: Type.String({
       description: 'Path to the file to edit (absolute or relative to home directory)',
     }),
-    old_string: Type.String({
-      description:
-        'The exact text to find in the file. Must appear exactly once. Include enough surrounding context to make it unique.',
-    }),
+    old_string: Type.Optional(
+      Type.String({
+        description:
+          'The exact text to find in the file. Must appear exactly once. Include enough surrounding context to make it unique. Required unless append is true.',
+      })
+    ),
     new_string: Type.String({
       description:
-        'The replacement text. For insertions, include the original context with new content added in the right position.',
+        'The replacement text (replace mode) or content to append (append mode). For insertions in replace mode, include the original context with new content added in the right position.',
     }),
+    append: Type.Optional(
+      Type.Boolean({
+        description:
+          'If true, append new_string to the end of the file instead of replacing old_string. Creates the file (and parent directories) if it does not exist.',
+      })
+    ),
     commit_message: Type.Optional(
       Type.String({
         description:
@@ -38,7 +53,7 @@ export function createEditTool() {
     name: 'edit',
     label: 'Edit File',
     description:
-      'Edit a file by replacing an exact string match. The old_string must appear exactly once in the file (include more context if not unique). Prefer this over `write` for modifying existing files — it only changes what you specify. Use `write` for creating new files or complete rewrites. For bulk operations where `edit` is inconvenient (e.g., find-and-replace across many lines, appending), use `bash` with `sed`, `awk`, `>>`, or similar.',
+      'Edit a file by replacing an exact string match, or append content to a file. When append is true, appends new_string to the end of the file (creating it if needed) — use this for adding entries to logs, memory files, and similar. When append is not set, old_string must appear exactly once in the file (include more context if not unique). Prefer this over `write` for modifying existing files. Use `write` for creating new files or complete rewrites. For bulk operations (e.g., find-and-replace across many lines), use `bash` with `sed`, `awk`, or similar.',
     parameters: params,
     execute: async (_toolCallId, params, signal, _onUpdate) => {
       try {
@@ -50,6 +65,49 @@ export function createEditTool() {
         }
 
         const filePath = resolvePath(params.path);
+
+        if (params.append) {
+          await mkdir(dirname(filePath), { recursive: true });
+
+          let existingContent = '';
+          try {
+            existingContent = await readFile(filePath, 'utf-8');
+          } catch (err) {
+            const e = err as { code?: string };
+            if (e.code !== 'ENOENT') throw err;
+          }
+
+          const separator =
+            existingContent.length > 0 && !existingContent.endsWith('\n') ? '\n' : '';
+          const newContent = existingContent + separator + params.new_string;
+
+          await writeFile(filePath, newContent, 'utf-8');
+
+          if (params.commit_message) {
+            commitIfStateDir(filePath, params.commit_message);
+          }
+
+          const linesAppended = params.new_string.split('\n').length;
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Appended ${linesAppended} line(s) to ${params.path}.`,
+              },
+            ],
+            details: { path: filePath, linesAppended },
+          };
+        }
+
+        // Replace mode: old_string is required
+        if (params.old_string === undefined) {
+          return {
+            content: [
+              { type: 'text', text: 'Error: old_string is required when append is not true.' },
+            ],
+            details: { error: 'missing_old_string' },
+          };
+        }
 
         const content = await readFile(filePath, 'utf-8');
 

--- a/packages/server/src/agents/tools/edit.ts
+++ b/packages/server/src/agents/tools/edit.ts
@@ -13,7 +13,7 @@
  * newline separator if the existing content does not end with one.
  */
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, open, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { Type } from '@sinclair/typebox';
@@ -69,25 +69,44 @@ export function createEditTool() {
         if (params.append) {
           await mkdir(dirname(filePath), { recursive: true });
 
-          let existingContent = '';
-          try {
-            existingContent = await readFile(filePath, 'utf-8');
-          } catch (err) {
-            const e = err as { code?: string };
-            if (e.code !== 'ENOENT') throw err;
+          // Determine separator by reading only the last byte — avoids loading the
+          // entire file and also prevents a double newline when new_string already
+          // starts with one.
+          let separator = '';
+          if (!params.new_string.startsWith('\n')) {
+            try {
+              const fileStat = await stat(filePath);
+              if (fileStat.size > 0) {
+                const fh = await open(filePath, 'r');
+                try {
+                  const buf = Buffer.alloc(1);
+                  await fh.read(buf, 0, 1, fileStat.size - 1);
+                  if (buf[0] !== 0x0a) separator = '\n';
+                } finally {
+                  await fh.close();
+                }
+              }
+            } catch (err) {
+              const e = err as { code?: string };
+              if (e.code !== 'ENOENT') throw err;
+            }
           }
 
-          const separator =
-            existingContent.length > 0 && !existingContent.endsWith('\n') ? '\n' : '';
-          const newContent = existingContent + separator + params.new_string;
+          if (signal?.aborted) {
+            return {
+              content: [{ type: 'text', text: 'Edit aborted.' }],
+              details: { error: 'aborted' },
+            };
+          }
 
-          await writeFile(filePath, newContent, 'utf-8');
+          await appendFile(filePath, separator + params.new_string, 'utf-8');
 
           if (params.commit_message) {
             commitIfStateDir(filePath, params.commit_message);
           }
 
-          const linesAppended = params.new_string.split('\n').length;
+          const linesAppended =
+            params.new_string.split('\n').length - (params.new_string.endsWith('\n') ? 1 : 0);
           return {
             content: [
               {

--- a/packages/server/src/agents/tools/edit.ts
+++ b/packages/server/src/agents/tools/edit.ts
@@ -71,9 +71,9 @@ export function createEditTool() {
 
           // Determine separator by reading only the last byte — avoids loading the
           // entire file and also prevents a double newline when new_string already
-          // starts with one.
+          // starts with one (LF or CRLF).
           let separator = '';
-          if (!params.new_string.startsWith('\n')) {
+          if (!params.new_string.startsWith('\n') && !params.new_string.startsWith('\r')) {
             try {
               const fileStat = await stat(filePath);
               if (fileStat.size > 0) {
@@ -106,7 +106,9 @@ export function createEditTool() {
           }
 
           const linesAppended =
-            params.new_string.split('\n').length - (params.new_string.endsWith('\n') ? 1 : 0);
+            params.new_string === ''
+              ? 0
+              : params.new_string.split('\n').length - (params.new_string.endsWith('\n') ? 1 : 0);
           return {
             content: [
               {

--- a/packages/server/src/agents/tools/write.ts
+++ b/packages/server/src/agents/tools/write.ts
@@ -31,7 +31,7 @@ export function createWriteTool() {
     name: 'write',
     label: 'Write File',
     description:
-      'Write content to a file. Creates parent directories if needed. Overwrites the entire file. Use this for creating new files or complete rewrites. For modifying specific parts of an existing file, prefer the `edit` tool. For operations where neither `edit` nor `write` is convenient (bulk replacements, appending, etc.), use `bash` with `sed`, `awk`, or `>>`.',
+      'Write content to a file. Creates parent directories if needed. Overwrites the entire file. Use this for creating new files or complete rewrites. For modifying specific parts of an existing file, prefer the `edit` tool. For appending content, use `edit` with `append: true`. For bulk replacements and similar operations, use `bash` with `sed`, `awk`, or similar.',
     parameters: params,
     execute: async (_toolCallId, params, _signal, _onUpdate) => {
       try {


### PR DESCRIPTION
## Summary

- Add optional `append: true` parameter to the `edit` tool: appends `new_string` to the end of the file, creates the file and parent directories if missing, and inserts a newline separator when the existing content doesn't end with one
- Make `old_string` optional in the schema (required only in replace mode, validated at runtime)
- Update `write` tool description to point agents toward `edit` with `append: true` instead of `bash >>`
- Add 5 new tests covering append to existing file, newline separator insertion, empty file, file+directory creation, and missing `old_string` error
- Update `docs/tools.md` to document the new parameter and both modes

Fixes #5