### PR TITLE
fix(knowledge): rename "Notes" section to "Latest Learnings" in memory.md

### DIFF
--- a/docs/knowledge-system.md
+++ b/docs/knowledge-system.md
@@ -63,7 +63,7 @@ Project-scoped files live outside `knowledge/`:
 | `infrastructure.md` | Guide | During onboarding and as infrastructure evolves |
 | `user.md` | Guide | During onboarding and ongoing interactions |
 | `memory.md` | Narrator | Daily at 11 AM (memory-update job) |
-| `memory.md ## Notes` | Any agent | Anytime: agents write important facts here |
+| `memory.md ## Latest Learnings` | Any agent | Anytime: agents write important facts here |
 | `{role}.md` | Agent of that role (any agent may contribute) | As role-specific lessons and patterns accumulate |
 | `daily_summaries/*.md` | Narrator | Every 30 minutes (configurable) |
 | `projects/{id}_{name}/log.md` | Narrator | Every 30 minutes (same cron as daily summary) |
@@ -170,12 +170,12 @@ last_narrator_update_ts: 2024-01-16T04:00:00.000Z
 
 Consolidated knowledge about the system, user, and project history.
 
-## Notes
+## Latest Learnings
 
 Agents write important facts here for the Narrator to incorporate.
 ```
 
-The **## Notes** section is a scratchpad: any agent can append notes. During the daily memory-update job (11 AM), the Narrator reads all recent daily summaries, incorporates new information into the memory document, and clears processed notes.
+The **## Latest Learnings** section is a scratchpad: any agent can append notes. During the daily memory-update job (11 AM), the Narrator reads all recent daily summaries, incorporates new information into the memory document, and clears processed notes.
 
 ## Project Logs
 

--- a/docs/knowledge-system.md
+++ b/docs/knowledge-system.md
@@ -175,7 +175,7 @@ Consolidated knowledge about the system, user, and project history.
 Agents write important facts here for the Narrator to incorporate.
 ```
 
-The **## Latest Learnings** section is a scratchpad: any agent can append notes. During the daily memory-update job (11 AM), the Narrator reads all recent daily summaries, incorporates new information into the memory document, and clears processed notes.
+The **## Latest Learnings** section captures durable, cross-project insights: any agent can append important facts here. During the daily memory-update job (11 AM), the Narrator reads all recent daily summaries, incorporates new information into the memory document, and consolidates entries from this section.
 
 ## Project Logs
 

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -267,7 +267,7 @@ System2 maintains persistent knowledge in `~/.system2/knowledge/`. These files a
 |------|---------|------------|
 | `infrastructure.md` | Data stack details (databases, orchestrator, repos, tools) | Guide |
 | `user.md` | Facts about the user for personalized assistance | Guide |
-| `memory.md` | Long-term memory synthesized from daily summaries and agent notes | Narrator (body), any agent (`## Notes` section) |
+| `memory.md` | Long-term memory synthesized from daily summaries and agent notes | Narrator (body), any agent (`## Latest Learnings` section) |
 | `daily_summaries/YYYY-MM-DD.md` | Daily activity summary | Narrator (append-only) |
 | `projects/{id}_{name}/log.md` | Continuous project log — append-only narrative of project work | Narrator |
 | `projects/{id}_{name}/project_story.md` | Final narrative account of a completed project | Narrator |
@@ -282,7 +282,7 @@ All agents receive `infrastructure.md`, `user.md`, and `memory.md`. Additional c
 Do not rely on your context surviving. Decisions, results, and observations must be persisted as they happen:
 
 - **app.db is the primary record.** Task comments, task status updates, and task links are where work gets recorded. If you made a decision, found a result, or hit a blocker — write a task comment immediately. Your context may be compacted at any time; the database persists.
-- **knowledge/memory.md `## Notes` section** is for cross-project or system-level observations: user preferences, infrastructure facts, patterns that apply beyond a single project. The Narrator consolidates notes into the main document during memory updates.
+- **knowledge/memory.md `## Latest Learnings` section** is for cross-project or system-level observations: user preferences, infrastructure facts, patterns that apply beyond a single project. The Narrator consolidates these into the main document during memory updates.
 
 ### Sessions and Context
 

--- a/packages/server/src/agents/library/conductor.md
+++ b/packages/server/src/agents/library/conductor.md
@@ -147,7 +147,7 @@ Do NOT terminate yourself or the Reviewer. The Guide handles agent termination a
 ## Knowledge Management
 
 - **Infrastructure** (`~/.system2/knowledge/infrastructure.md`): Already in your system prompt via the Knowledge Base. Consult it during planning to understand available systems and ground technology decisions in the existing stack. Update when you discover configuration relevant to all agents.
-- **Long-term memory**: Write role-agnostic cross-project observations to the `## Notes` section of `~/.system2/knowledge/memory.md`.
+- **Long-term memory**: Write role-agnostic cross-project observations to the `## Latest Learnings` section of `~/.system2/knowledge/memory.md`.
 - **Role notes** (`~/.system2/knowledge/conductor.md`): Curate this file with knowledge specific to the Conductor role — effective task breakdown patterns, common pitfalls by project type, review coordination lessons, and execution heuristics. Always read the full file first; restructure rather than append. Prefer the shared files above when information is useful to multiple roles. The Guide or Reviewer may also contribute Conductor-specific observations here.
 
 ## Infrastructure and Dependencies

--- a/packages/server/src/agents/library/guide.md
+++ b/packages/server/src/agents/library/guide.md
@@ -213,7 +213,7 @@ After every update, ask yourself whether the document structure is still optimal
 
 - **Infrastructure** (`~/.system2/knowledge/infrastructure.md`): databases, orchestrators, cloud services, installed tools, repo locations, credentials setup, and any environment-specific configuration
 - **User profile** (`~/.system2/knowledge/user.md`): background, technical level, domain expertise, goals, communication preferences, and recurring patterns in how they work
-- **Long-term memory**: write important long-term facts to the `## Notes` section of `~/.system2/knowledge/memory.md`. The Narrator will consolidate these during its scheduled updates.
+- **Long-term memory**: write important long-term facts to the `## Latest Learnings` section of `~/.system2/knowledge/memory.md`. The Narrator will consolidate these during its scheduled updates.
 - **Role notes** (`~/.system2/knowledge/guide.md`): Curate this file with patterns specific to the Guide role — orchestration preferences, delegation heuristics, recurring user interaction patterns, and lessons about project scoping. Always read the full file first; restructure rather than append. Prefer the shared files above when information is useful to multiple roles. Other agents may also contribute Guide-specific observations here.
 
 ## Behavior Guidelines

--- a/packages/server/src/agents/library/narrator.md
+++ b/packages/server/src/agents/library/narrator.md
@@ -116,11 +116,11 @@ The message contains the memory file path, timestamps, and a list of daily summa
 
 1. **Parse metadata:** Extract `memory_file`, `last_narrator_update_ts`, `new_run_ts`, and the list of daily summary file paths.
 
-2. **Read memory.md:** Read the full document including any items in the `## Notes` section that other agents may have written.
+2. **Read memory.md:** Read the full document including any items in the `## Latest Learnings` section that other agents may have written.
 
 3. **Read daily summaries:** Read each listed daily summary file.
 
-4. **Restructure:** Blend new insights from daily summaries into the document body. Consolidate items from the `## Notes` section into appropriate sections. Remove consolidated items from Notes. Maintain a coherent, well-organized document that reads naturally.
+4. **Restructure:** Blend new insights from daily summaries into the document body. Consolidate items from the `## Latest Learnings` section into appropriate sections. Remove consolidated items from Latest Learnings. Maintain a coherent, well-organized document that reads naturally.
 
 5. **Write updated memory.md:** Use `write` with `commit_message: "memory update"` to overwrite with the restructured content. Set `last_narrator_update_ts` to `new_run_ts` (UTC ISO 8601 format, e.g. `2026-03-13T16:00:00.002Z`) in the frontmatter.
 

--- a/packages/server/src/knowledge/templates.ts
+++ b/packages/server/src/knowledge/templates.ts
@@ -103,7 +103,7 @@ last_narrator_update_ts: ${now}
 > Long-term memory of System2. Synthesized from daily logs, project narrations, and important notes.
 > Periodically restructured by the Narrator for coherence.
 
-## Notes
+## Latest Learnings
 
 > Other agents write important facts here during work. The Narrator consolidates these into the document during restructuring and removes them from this section.
 


### PR DESCRIPTION
## Summary

- Rename the `## Notes` section heading in the `memory.md` template to `## Latest Learnings`
- Update all agent system prompts that reference the section by name: narrator, conductor, guide
- Update `docs/knowledge-system.md` (table entry, example template, and prose description)

Closes #6