### PR TITLE
docs(agents): embed cross-doc links inline and remove See Also section

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -14,7 +14,7 @@ System2's agents are built on the [pi-coding-agent](https://github.com/badlogic/
 | Agent | Role | Lifecycle | Models |
 | --- | --- | --- | --- |
 | **Guide** | Primary user-facing agent. Helps brainstorm and plan, starts projects, interfaces with the multi-agent system, and relays updates. Users may also interact directly with other active agents; Guide mediation is preferred in most cases. | Singleton, persistent | claude-opus-4-6, gpt-4o, gemini-3.1-pro |
-| **Narrator** | Maintains long-term memory: appends project logs and daily summaries, writes project stories on completion. Schedule-driven. | Singleton, persistent | claude-haiku-4-5-20251001, gpt-4o-mini, gemini-2.0-flash |
+| **Narrator** | Maintains long-term memory: appends project logs and daily summaries, writes project stories on completion. Schedule-driven (see [Scheduler](scheduler.md)). | Singleton, persistent | claude-haiku-4-5-20251001, gpt-4o-mini, gemini-2.0-flash |
 | **Conductor** | Orchestrates and executes work within a project: breaks it into tasks, spawns specialist agents or executes directly, and coordinates with the Reviewer before reporting completion. | Per-project, ephemeral | claude-opus-4-6, gpt-4o, gemini-3.1-pro |
 | **Reviewer** | Critically assesses work before it is considered complete. | Per-project, ephemeral | claude-opus-4-6, gpt-4o, gemini-3.1-pro |
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -60,7 +60,7 @@ The static layers are concatenated into `staticPrompt`. The dynamic layers are l
 
 Empty files are skipped.
 
-Prompt caching (where supported by the provider) optimizes the static prefix: only the refreshed knowledge portion is reprocessed on each call.
+Prompt caching (where supported by the provider) optimizes the static prefix: only the refreshed knowledge portion is reprocessed on each call. See [Knowledge System](knowledge-system.md) for the structure and update semantics of each knowledge file.
 
 ## AgentHost (`host.ts`)
 
@@ -132,7 +132,7 @@ A simple `Map<number, AgentHost>` that maps agent database IDs to active AgentHo
 
 ## AuthResolver (`auth-resolver.ts`)
 
-Manages API key rotation and multi-provider failover:
+Manages API key rotation and multi-provider failover. Providers and API keys are defined in [Configuration](configuration.md):
 
 ### Key Rotation
 
@@ -174,7 +174,6 @@ Exponential backoff with jitter: `min(baseDelay * 2^attempt + jitter, maxDelay)`
 | `rate_limit` (429) | Up to 3x | After retries exhausted |
 | `transient` (500/503/timeout) | Up to 2x | After retries exhausted |
 | `client` (400) | Never | Never (surface error) |
-
 **Context overflow recovery:** a `client` (400) error whose message contains both a size keyword (`exceed`, `maximum`, `limit`, `too long`, `too large`, `too many`) and a context/token keyword (`token`, `context`, `input`, `prompt`) is treated as a context overflow. This detection is provider-agnostic (covers Anthropic, OpenAI, Gemini, and others) and is gated on the `client` error category to avoid false positives on rate-limit errors. This can happen when a single large delivery (e.g., a scheduled Narrator job) causes the context to jump past the auto-compaction threshold in one step. Recovery is one-shot: the guard is armed on the first overflow and re-arms only after recovery completes (successfully or as a no-op). It does not reset on provider failover or re-initialization, so the guard stays active throughout the entire recovery sequence:
 
 1. Find the last JSONL message entry where `entry.message.usage.input < contextWindow * 0.90` (message entries store token usage under `entry.message.usage`)
@@ -445,13 +444,3 @@ DataAgent-Extract, DataAgent-Analyze, and Reviewer work through their tasks in d
 8. Guide terminates Conductor (#2) and Reviewer (#4), sets project #1 to `done`.
 9. Guide informs user with final summary, artifact location, and story path (`~/.system2/projects/1_linkedin-campaign/project_story.md`).
 
----
-
-## See Also
-
-- [Tools](tools.md): all tools available to agents, including spawn_agent, terminate_agent, and resurrect_agent
-- [Knowledge System](knowledge-system.md): knowledge files injected into system prompts
-- [Database](database.md): app.db schema (projects, tasks, agents, task_links, task_comments)
-- [Scheduler](scheduler.md): how scheduled jobs deliver messages to Narrator
-- [Configuration](configuration.md): LLM provider and failover configuration
-- [WebSocket Protocol](websocket-protocol.md): how agent events stream to the UI

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -14,7 +14,7 @@ System2's agents are built on the [pi-coding-agent](https://github.com/badlogic/
 | Agent | Role | Lifecycle | Models |
 | --- | --- | --- | --- |
 | **Guide** | Primary user-facing agent. Helps brainstorm and plan, starts projects, interfaces with the multi-agent system, and relays updates. Users may also interact directly with other active agents; Guide mediation is preferred in most cases. | Singleton, persistent | claude-opus-4-6, gpt-4o, gemini-3.1-pro |
-| **Narrator** | Maintains long-term memory: appends project logs and daily summaries, writes project stories on completion. Schedule-driven (see [Scheduler](scheduler.md)). | Singleton, persistent | claude-haiku-4-5-20251001, gpt-4o-mini, gemini-2.0-flash |
+| **Narrator** | Maintains long-term memory: appends project logs and daily summaries, writes project stories on completion. [Schedule-driven](scheduler.md). | Singleton, persistent | claude-haiku-4-5-20251001, gpt-4o-mini, gemini-2.0-flash |
 | **Conductor** | Orchestrates and executes work within a project: breaks it into tasks, spawns specialist agents or executes directly, and coordinates with the Reviewer before reporting completion. | Per-project, ephemeral | claude-opus-4-6, gpt-4o, gemini-3.1-pro |
 | **Reviewer** | Critically assesses work before it is considered complete. | Per-project, ephemeral | claude-opus-4-6, gpt-4o, gemini-3.1-pro |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-System2 is a TypeScript monorepo built on [pi-coding-agent](https://github.com/badlogic/pi-mono), a SDK for building LLM-powered coding agents. The SDK provides the core agent loop, tool execution, session management (JSONL persistence), and auto-compaction. System2 adds multi-agent orchestration, LLM failover, a knowledge/memory system, custom tools, a scheduler, and a web UI.
+System2 is a TypeScript monorepo built on [pi-coding-agent](https://github.com/badlogic/pi-mono), a SDK for building LLM-powered coding agents. The SDK provides the core agent loop, tool execution, session management (JSONL persistence), and auto-compaction. System2 adds multi-agent orchestration, LLM failover, a knowledge/memory system, custom tools, a [scheduler](scheduler.md), and a web UI.
 
 ## Key Design Decisions
 


### PR DESCRIPTION
## Summary

- In the Agent Roles table, link "Schedule-driven" in the Narrator row to `scheduler.md`
- In the System Prompt Construction section, link "Knowledge System" at the end of the dynamic layers explanation
- In the AuthResolver section, link "Configuration" in the intro line
- Remove the `## See Also` section at the bottom (all links are now embedded in context)