### PR TITLE
feat(ui): persist agents pane and active agent selection across refreshes

### DIFF
--- a/docs/packages/ui.md
+++ b/docs/packages/ui.md
@@ -79,7 +79,7 @@ Auto-growing textarea (1-10 lines, then scrolls). Shows the current LLM provider
 
 Tabbed artifact display. Tabs are either **iframe tabs** (sandboxed HTML artifacts) or **native tabs** (React components rendered directly). Tab bar at top shows title and close button for each open artifact; clicking a tab activates it. Empty state shown when no tabs are open.
 
-Native tabs are not persisted to localStorage across page reloads. Currently the only native tab is the Kanban board.
+The only native tab is the Kanban board. Its open/closed state is persisted via `kanbanOpen` in the artifact store, so the board reopens automatically after a page refresh. Only the visibility flag is stored — the tab content is re-rendered fresh on mount.
 
 Supports a `postMessage` bridge for iframe dashboards that need database access:
 
@@ -150,7 +150,7 @@ Three [Zustand](https://github.com/pmndrs/zustand) stores with no Redux or Conte
 
 ### `useChatStore` (Primary)
 
-Supports multi-agent chat via per-agent state. Each agent has its own message history, streaming state, and message queue stored in a `Map<number, PerAgentState>`. The `activeAgentId` determines which agent's state is displayed in the UI.
+Supports multi-agent chat via per-agent state. Each agent has its own message history, streaming state, and message queue stored in a `Map<number, PerAgentState>`. The `activeAgentId` determines which agent's state is displayed in the UI. `activeAgentId`, `activeAgentLabel`, and `activeAgentRole` are persisted via the Zustand `persist` middleware (key: `system2:chat-store`) so the selected agent survives page refreshes.
 
 **Global state:**
 
@@ -180,14 +180,15 @@ Components read the active agent's state via selectors (e.g., `useChatStore(s =>
 
 ### `useArtifactStore`
 
-Tab-based artifact state with localStorage persistence (`system2:artifact-tabs`). Each `ArtifactTab` has a `type` discriminant: `'iframe'` for sandboxed HTML artifacts, `'native'` for React components rendered directly. Native tabs are not persisted across page reloads.
+Tab-based artifact state persisted via the Zustand `persist` middleware (key: `system2:artifact-store`). Each `ArtifactTab` has a `type` discriminant: `'iframe'` for sandboxed HTML artifacts, `'native'` for React components rendered directly.
 
 | State | Type | Description |
 |-------|------|-------------|
 | `tabs` | `ArtifactTab[]` | Open artifact tabs (id, type, url, filePath, title) |
 | `activeTabId` | `string \| null` | Currently active tab |
-| `catalogOpen` | `boolean` | Whether the catalog panel is visible |
-| `agentsOpen` | `boolean` | Whether the agents panel is visible |
+| `catalogOpen` | `boolean` | Whether the catalog panel is visible (not persisted) |
+| `agentsOpen` | `boolean` | Whether the agents panel is visible (persisted) |
+| `kanbanOpen` | `boolean` | Whether the kanban board tab is open (persisted) |
 
 Key behaviors:
 

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -62,11 +62,10 @@ export function Layout() {
   const { accent } = useAccentColors();
   const catalogOpen = useArtifactStore((s) => s.catalogOpen);
   const agentsOpen = useArtifactStore((s) => s.agentsOpen);
-  const tabs = useArtifactStore((s) => s.tabs);
+  const kanbanOpen = useArtifactStore((s) => s.kanbanOpen);
   const toggleCatalog = useArtifactStore((s) => s.toggleCatalog);
   const toggleAgents = useArtifactStore((s) => s.toggleAgents);
   const toggleKanbanTab = useArtifactStore((s) => s.toggleKanbanTab);
-  const kanbanOpen = tabs.some((t) => t.component === 'kanban');
   const sideDrawerOpen = catalogOpen || agentsOpen;
 
   const handleMouseDown = useCallback(() => {

--- a/packages/ui/src/stores/artifact.test.ts
+++ b/packages/ui/src/stores/artifact.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Artifact Store Tests
+ *
+ * Tests for kanban tab open/close/toggle behavior and kanbanOpen flag sync.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useArtifactStore } from './artifact';
+
+function resetStore() {
+  useArtifactStore.setState({
+    tabs: [],
+    activeTabId: null,
+    catalogOpen: false,
+    agentsOpen: false,
+    kanbanOpen: false,
+  });
+}
+
+describe('useArtifactStore', () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  describe('openKanbanTab', () => {
+    it('adds kanban tab and sets kanbanOpen to true', () => {
+      useArtifactStore.getState().openKanbanTab();
+
+      const state = useArtifactStore.getState();
+      expect(state.kanbanOpen).toBe(true);
+      expect(state.tabs.some((t) => t.component === 'kanban')).toBe(true);
+      expect(state.activeTabId).toBe('kanban');
+    });
+
+    it('does not add a second kanban tab if already open', () => {
+      useArtifactStore.getState().openKanbanTab();
+      useArtifactStore.getState().openKanbanTab();
+
+      const state = useArtifactStore.getState();
+      expect(state.tabs.filter((t) => t.component === 'kanban')).toHaveLength(1);
+    });
+
+    it('activates the existing kanban tab if already open', () => {
+      useArtifactStore.getState().openKanbanTab();
+      // Open another tab and make it active
+      useArtifactStore.setState({ activeTabId: 'other' });
+
+      useArtifactStore.getState().openKanbanTab();
+
+      expect(useArtifactStore.getState().activeTabId).toBe('kanban');
+    });
+  });
+
+  describe('closeTab (kanban)', () => {
+    it('sets kanbanOpen to false when the kanban tab is closed', () => {
+      useArtifactStore.getState().openKanbanTab();
+      expect(useArtifactStore.getState().kanbanOpen).toBe(true);
+
+      useArtifactStore.getState().closeTab('kanban');
+
+      expect(useArtifactStore.getState().kanbanOpen).toBe(false);
+      expect(useArtifactStore.getState().tabs.some((t) => t.component === 'kanban')).toBe(false);
+    });
+
+    it('does not set kanbanOpen to false when closing a non-kanban tab', () => {
+      useArtifactStore.getState().openKanbanTab();
+      useArtifactStore.setState({
+        tabs: [
+          ...useArtifactStore.getState().tabs,
+          { id: 'tab-1', type: 'iframe', url: '/api/artifact?path=foo', filePath: 'foo', title: 'Foo' },
+        ],
+      });
+
+      useArtifactStore.getState().closeTab('tab-1');
+
+      expect(useArtifactStore.getState().kanbanOpen).toBe(true);
+    });
+  });
+
+  describe('toggleKanbanTab', () => {
+    it('opens kanban when it is closed', () => {
+      useArtifactStore.getState().toggleKanbanTab();
+
+      expect(useArtifactStore.getState().kanbanOpen).toBe(true);
+    });
+
+    it('closes kanban when it is open', () => {
+      useArtifactStore.getState().openKanbanTab();
+      useArtifactStore.getState().toggleKanbanTab();
+
+      expect(useArtifactStore.getState().kanbanOpen).toBe(false);
+    });
+  });
+});

--- a/packages/ui/src/stores/artifact.test.ts
+++ b/packages/ui/src/stores/artifact.test.ts
@@ -4,7 +4,7 @@
  * Tests for kanban tab open/close/toggle behavior and kanbanOpen flag sync.
  */
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { useArtifactStore } from './artifact';
 
 function resetStore() {
@@ -95,6 +95,81 @@ describe('useArtifactStore', () => {
       useArtifactStore.getState().toggleKanbanTab();
 
       expect(useArtifactStore.getState().kanbanOpen).toBe(false);
+    });
+  });
+
+  describe('persist merge (rehydration)', () => {
+    const STORE_KEY = 'system2:artifact-store';
+
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    afterEach(() => {
+      localStorage.clear();
+    });
+
+    it('reconstructs the kanban tab when kanbanOpen is true', async () => {
+      localStorage.setItem(
+        STORE_KEY,
+        JSON.stringify({
+          state: { tabs: [], activeTabId: 'kanban', agentsOpen: false, kanbanOpen: true },
+          version: 0,
+        })
+      );
+
+      await useArtifactStore.persist.rehydrate();
+
+      const state = useArtifactStore.getState();
+      expect(state.kanbanOpen).toBe(true);
+      expect(state.tabs.some((t) => t.component === 'kanban')).toBe(true);
+      expect(state.activeTabId).toBe('kanban');
+    });
+
+    it('does not add a kanban tab when kanbanOpen is false', async () => {
+      localStorage.setItem(
+        STORE_KEY,
+        JSON.stringify({
+          state: { tabs: [], activeTabId: null, agentsOpen: false, kanbanOpen: false },
+          version: 0,
+        })
+      );
+
+      await useArtifactStore.persist.rehydrate();
+
+      const state = useArtifactStore.getState();
+      expect(state.kanbanOpen).toBe(false);
+      expect(state.tabs.some((t) => t.component === 'kanban')).toBe(false);
+    });
+
+    it('prepends kanban tab before persisted iframe tabs', async () => {
+      localStorage.setItem(
+        STORE_KEY,
+        JSON.stringify({
+          state: {
+            tabs: [
+              {
+                id: 'tab-1',
+                type: 'iframe',
+                url: '/api/artifact?path=foo',
+                filePath: 'foo',
+                title: 'Foo',
+              },
+            ],
+            activeTabId: 'kanban',
+            agentsOpen: false,
+            kanbanOpen: true,
+          },
+          version: 0,
+        })
+      );
+
+      await useArtifactStore.persist.rehydrate();
+
+      const state = useArtifactStore.getState();
+      expect(state.tabs).toHaveLength(2);
+      expect(state.tabs[0].component).toBe('kanban');
+      expect(state.tabs[1].filePath).toBe('foo');
     });
   });
 });

--- a/packages/ui/src/stores/artifact.test.ts
+++ b/packages/ui/src/stores/artifact.test.ts
@@ -67,7 +67,13 @@ describe('useArtifactStore', () => {
       useArtifactStore.setState({
         tabs: [
           ...useArtifactStore.getState().tabs,
-          { id: 'tab-1', type: 'iframe', url: '/api/artifact?path=foo', filePath: 'foo', title: 'Foo' },
+          {
+            id: 'tab-1',
+            type: 'iframe',
+            url: '/api/artifact?path=foo',
+            filePath: 'foo',
+            title: 'Foo',
+          },
         ],
       });
 

--- a/packages/ui/src/stores/artifact.ts
+++ b/packages/ui/src/stores/artifact.ts
@@ -55,7 +55,7 @@ function loadPanelState(): { agentsOpen: boolean } {
     const stored = localStorage.getItem(PANEL_STATE_KEY);
     if (stored) {
       const data = JSON.parse(stored);
-      return { agentsOpen: Boolean(data.agentsOpen) };
+      return { agentsOpen: typeof data.agentsOpen === 'boolean' && data.agentsOpen };
     }
   } catch {
     // ignore
@@ -64,7 +64,11 @@ function loadPanelState(): { agentsOpen: boolean } {
 }
 
 function persistPanelState(agentsOpen: boolean): void {
-  localStorage.setItem(PANEL_STATE_KEY, JSON.stringify({ agentsOpen }));
+  try {
+    localStorage.setItem(PANEL_STATE_KEY, JSON.stringify({ agentsOpen }));
+  } catch {
+    // ignore — persistence is best-effort
+  }
 }
 
 function loadTabs(): { tabs: ArtifactTab[]; activeTabId: string | null } {

--- a/packages/ui/src/stores/artifact.ts
+++ b/packages/ui/src/stores/artifact.ts
@@ -8,6 +8,7 @@
 import { create } from 'zustand';
 
 const STORAGE_KEY = 'system2:artifact-tabs';
+const PANEL_STATE_KEY = 'system2:panel-state';
 
 interface ArtifactTab {
   id: string;
@@ -49,6 +50,23 @@ function extractTitle(url: string): string {
   return parts[parts.length - 1] || 'Untitled';
 }
 
+function loadPanelState(): { agentsOpen: boolean } {
+  try {
+    const stored = localStorage.getItem(PANEL_STATE_KEY);
+    if (stored) {
+      const data = JSON.parse(stored);
+      return { agentsOpen: Boolean(data.agentsOpen) };
+    }
+  } catch {
+    // ignore
+  }
+  return { agentsOpen: false };
+}
+
+function persistPanelState(agentsOpen: boolean): void {
+  localStorage.setItem(PANEL_STATE_KEY, JSON.stringify({ agentsOpen }));
+}
+
 function loadTabs(): { tabs: ArtifactTab[]; activeTabId: string | null } {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -80,12 +98,13 @@ function persistTabs(tabs: ArtifactTab[], activeTabId: string | null): void {
 }
 
 const initial = loadTabs();
+const initialPanel = loadPanelState();
 
 export const useArtifactStore = create<ArtifactState>((set, get) => ({
   tabs: initial.tabs,
   activeTabId: initial.activeTabId,
   catalogOpen: false,
-  agentsOpen: false,
+  agentsOpen: initialPanel.agentsOpen,
 
   openArtifact: (url: string, title?: string, filePath?: string) => {
     const state = get();
@@ -149,11 +168,18 @@ export const useArtifactStore = create<ArtifactState>((set, get) => ({
   },
 
   toggleCatalog: () => {
-    set((state) => ({ catalogOpen: !state.catalogOpen, agentsOpen: false }));
+    set((state) => {
+      persistPanelState(false);
+      return { catalogOpen: !state.catalogOpen, agentsOpen: false };
+    });
   },
 
   toggleAgents: () => {
-    set((state) => ({ agentsOpen: !state.agentsOpen, catalogOpen: false }));
+    set((state) => {
+      const agentsOpen = !state.agentsOpen;
+      persistPanelState(agentsOpen);
+      return { agentsOpen, catalogOpen: false };
+    });
   },
 
   openKanbanTab: () => {

--- a/packages/ui/src/stores/artifact.ts
+++ b/packages/ui/src/stores/artifact.ts
@@ -2,13 +2,12 @@
  * Artifact Store
  *
  * Zustand store for managing tabbed artifact display state.
- * Persists open tabs to localStorage so they survive page refreshes.
+ * Persists open tabs, panel state, and board visibility to localStorage
+ * via the Zustand persist middleware.
  */
 
 import { create } from 'zustand';
-
-const STORAGE_KEY = 'system2:artifact-tabs';
-const PANEL_STATE_KEY = 'system2:panel-state';
+import { persist } from 'zustand/middleware';
 
 interface ArtifactTab {
   id: string;
@@ -24,6 +23,7 @@ interface ArtifactState {
   activeTabId: string | null;
   catalogOpen: boolean;
   agentsOpen: boolean;
+  kanbanOpen: boolean;
   openArtifact: (url: string, title?: string, filePath?: string) => void;
   closeTab: (tabId: string) => void;
   setActiveTab: (tabId: string) => void;
@@ -50,167 +50,131 @@ function extractTitle(url: string): string {
   return parts[parts.length - 1] || 'Untitled';
 }
 
-function loadPanelState(): { agentsOpen: boolean } {
-  try {
-    const stored = localStorage.getItem(PANEL_STATE_KEY);
-    if (stored) {
-      const data = JSON.parse(stored);
-      return { agentsOpen: typeof data.agentsOpen === 'boolean' && data.agentsOpen };
+const KANBAN_TAB: ArtifactTab = {
+  id: 'kanban',
+  type: 'native',
+  component: 'kanban',
+  url: '',
+  filePath: '__kanban__',
+  title: 'Board',
+};
+
+export const useArtifactStore = create<ArtifactState>()(
+  persist(
+    (set, get) => ({
+      tabs: [],
+      activeTabId: null,
+      catalogOpen: false,
+      agentsOpen: false,
+      kanbanOpen: false,
+
+      openArtifact: (url: string, title?: string, filePath?: string) => {
+        const state = get();
+        const fp = filePath || extractFilePath(url);
+
+        // If tab with same filePath exists, activate it and update URL
+        const existing = state.tabs.find((t) => t.filePath === fp);
+        if (existing) {
+          set({
+            tabs: state.tabs.map((t) => (t.id === existing.id ? { ...t, url } : t)),
+            activeTabId: existing.id,
+          });
+          return;
+        }
+
+        // Create new tab
+        const tab: ArtifactTab = {
+          id: `tab-${Date.now()}`,
+          type: 'iframe',
+          url,
+          filePath: fp,
+          title: title || extractTitle(url),
+        };
+        set({ tabs: [...state.tabs, tab], activeTabId: tab.id });
+      },
+
+      closeTab: (tabId: string) => {
+        const state = get();
+        const idx = state.tabs.findIndex((t) => t.id === tabId);
+        if (idx === -1) return;
+
+        const tabs = state.tabs.filter((t) => t.id !== tabId);
+        let activeTabId = state.activeTabId;
+
+        if (activeTabId === tabId) {
+          // Activate adjacent tab
+          if (tabs.length === 0) {
+            activeTabId = null;
+          } else if (idx < tabs.length) {
+            activeTabId = tabs[idx].id;
+          } else {
+            activeTabId = tabs[tabs.length - 1].id;
+          }
+        }
+
+        if (tabId === 'kanban') {
+          set({ tabs, activeTabId, kanbanOpen: false });
+        } else {
+          set({ tabs, activeTabId });
+        }
+      },
+
+      setActiveTab: (tabId: string) => {
+        set({ activeTabId: tabId });
+      },
+
+      reloadTab: (filePath: string, newUrl: string) => {
+        const state = get();
+        const tabs = state.tabs.map((t) => (t.filePath === filePath ? { ...t, url: newUrl } : t));
+        set({ tabs });
+      },
+
+      toggleCatalog: () => {
+        set((state) => ({ catalogOpen: !state.catalogOpen, agentsOpen: false }));
+      },
+
+      toggleAgents: () => {
+        set((state) => ({ agentsOpen: !state.agentsOpen, catalogOpen: false }));
+      },
+
+      openKanbanTab: () => {
+        const state = get();
+        if (state.kanbanOpen) {
+          set({ activeTabId: 'kanban' });
+          return;
+        }
+        set({ tabs: [KANBAN_TAB, ...state.tabs], activeTabId: 'kanban', kanbanOpen: true });
+      },
+
+      toggleKanbanTab: () => {
+        const state = get();
+        if (state.kanbanOpen) {
+          state.closeTab('kanban');
+        } else {
+          state.openKanbanTab();
+        }
+      },
+    }),
+    {
+      name: 'system2:artifact-store',
+      partialize: (state) => ({
+        // Exclude native tabs (kanban is reconstructed via kanbanOpen on load)
+        tabs: state.tabs
+          .filter((t) => t.type !== 'native')
+          .map((t) => ({ ...t, url: `/api/artifact?path=${encodeURIComponent(t.filePath)}` })),
+        activeTabId: state.activeTabId,
+        agentsOpen: state.agentsOpen,
+        kanbanOpen: state.kanbanOpen,
+      }),
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as Partial<ArtifactState>;
+        const merged = { ...currentState, ...persisted };
+        // Re-add the kanban tab to the tabs array if it was open
+        if (persisted.kanbanOpen) {
+          merged.tabs = [KANBAN_TAB, ...(persisted.tabs ?? [])];
+        }
+        return merged;
+      },
     }
-  } catch {
-    // ignore
-  }
-  return { agentsOpen: false };
-}
-
-function persistPanelState(agentsOpen: boolean): void {
-  try {
-    localStorage.setItem(PANEL_STATE_KEY, JSON.stringify({ agentsOpen }));
-  } catch {
-    // ignore — persistence is best-effort
-  }
-}
-
-function loadTabs(): { tabs: ArtifactTab[]; activeTabId: string | null } {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      const data = JSON.parse(stored);
-      if (Array.isArray(data.tabs) && data.tabs.length > 0) {
-        const tabs = data.tabs.map((t: ArtifactTab) => ({
-          ...t,
-          type: (t.type ?? 'iframe') as 'iframe' | 'native',
-        }));
-        return { tabs, activeTabId: data.activeTabId || tabs[0].id };
-      }
-    }
-  } catch {
-    // ignore
-  }
-  return { tabs: [], activeTabId: null };
-}
-
-function persistTabs(tabs: ArtifactTab[], activeTabId: string | null): void {
-  // Skip native tabs (transient — not persisted across page loads)
-  const toSave = tabs.filter((t) => (t.type ?? 'iframe') !== 'native');
-  // Reconstruct clean URLs from filePath (strips cache-bust params while preserving ?path=)
-  const cleaned = toSave.map((t) => ({
-    ...t,
-    url: `/api/artifact?path=${encodeURIComponent(t.filePath)}`,
-  }));
-  localStorage.setItem(STORAGE_KEY, JSON.stringify({ tabs: cleaned, activeTabId }));
-}
-
-const initial = loadTabs();
-const initialPanel = loadPanelState();
-
-export const useArtifactStore = create<ArtifactState>((set, get) => ({
-  tabs: initial.tabs,
-  activeTabId: initial.activeTabId,
-  catalogOpen: false,
-  agentsOpen: initialPanel.agentsOpen,
-
-  openArtifact: (url: string, title?: string, filePath?: string) => {
-    const state = get();
-    const fp = filePath || extractFilePath(url);
-
-    // If tab with same filePath exists, activate it and update URL
-    const existing = state.tabs.find((t) => t.filePath === fp);
-    if (existing) {
-      const tabs = state.tabs.map((t) => (t.id === existing.id ? { ...t, url } : t));
-      persistTabs(tabs, existing.id);
-      set({ tabs, activeTabId: existing.id });
-      return;
-    }
-
-    // Create new tab
-    const tab: ArtifactTab = {
-      id: `tab-${Date.now()}`,
-      type: 'iframe',
-      url,
-      filePath: fp,
-      title: title || extractTitle(url),
-    };
-    const tabs = [...state.tabs, tab];
-    persistTabs(tabs, tab.id);
-    set({ tabs, activeTabId: tab.id });
-  },
-
-  closeTab: (tabId: string) => {
-    const state = get();
-    const idx = state.tabs.findIndex((t) => t.id === tabId);
-    if (idx === -1) return;
-
-    const tabs = state.tabs.filter((t) => t.id !== tabId);
-    let activeTabId = state.activeTabId;
-
-    if (activeTabId === tabId) {
-      // Activate adjacent tab
-      if (tabs.length === 0) {
-        activeTabId = null;
-      } else if (idx < tabs.length) {
-        activeTabId = tabs[idx].id;
-      } else {
-        activeTabId = tabs[tabs.length - 1].id;
-      }
-    }
-
-    persistTabs(tabs, activeTabId);
-    set({ tabs, activeTabId });
-  },
-
-  setActiveTab: (tabId: string) => {
-    const state = get();
-    persistTabs(state.tabs, tabId);
-    set({ activeTabId: tabId });
-  },
-
-  reloadTab: (filePath: string, newUrl: string) => {
-    const state = get();
-    const tabs = state.tabs.map((t) => (t.filePath === filePath ? { ...t, url: newUrl } : t));
-    set({ tabs });
-  },
-
-  toggleCatalog: () => {
-    set((state) => {
-      persistPanelState(false);
-      return { catalogOpen: !state.catalogOpen, agentsOpen: false };
-    });
-  },
-
-  toggleAgents: () => {
-    set((state) => {
-      const agentsOpen = !state.agentsOpen;
-      persistPanelState(agentsOpen);
-      return { agentsOpen, catalogOpen: false };
-    });
-  },
-
-  openKanbanTab: () => {
-    const state = get();
-    const existing = state.tabs.find((t) => t.component === 'kanban');
-    if (existing) {
-      set({ activeTabId: existing.id });
-      return;
-    }
-    const tab: ArtifactTab = {
-      id: 'kanban',
-      type: 'native',
-      component: 'kanban',
-      url: '',
-      filePath: '__kanban__',
-      title: 'Board',
-    };
-    set({ tabs: [tab, ...state.tabs], activeTabId: 'kanban' });
-  },
-
-  toggleKanbanTab: () => {
-    const state = get();
-    const existing = state.tabs.find((t) => t.component === 'kanban');
-    if (existing) {
-      state.closeTab(existing.id);
-    } else {
-      state.openKanbanTab();
-    }
-  },
-}));
+  )
+);

--- a/packages/ui/src/stores/chat.test.ts
+++ b/packages/ui/src/stores/chat.test.ts
@@ -4,7 +4,7 @@
  * Tests for per-agent state isolation, dequeue routing, and loadHistory resets.
  */
 
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChatStore } from './chat';
 
 function resetStore() {
@@ -147,6 +147,10 @@ describe('useChatStore', () => {
   });
 
   describe('localStorage persistence', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
     function makeMockStorage() {
       const store: Record<string, string> = {};
       return {
@@ -169,7 +173,6 @@ describe('useChatStore', () => {
         'system2:active-agent',
         JSON.stringify({ id: 1, label: 'guide_1', role: 'Guide' })
       );
-      vi.unstubAllGlobals();
     });
 
     it('setActiveAgent overwrites a previously persisted agent', () => {
@@ -181,7 +184,6 @@ describe('useChatStore', () => {
         'system2:active-agent',
         JSON.stringify({ id: 5, label: 'conductor_5', role: 'Conductor' })
       );
-      vi.unstubAllGlobals();
     });
 
     it('setActiveAgent does not throw when localStorage write fails', () => {
@@ -191,7 +193,6 @@ describe('useChatStore', () => {
       });
       vi.stubGlobal('localStorage', mock);
       expect(() => useChatStore.getState().setActiveAgent(1, 'guide')).not.toThrow();
-      vi.unstubAllGlobals();
     });
   });
 

--- a/packages/ui/src/stores/chat.test.ts
+++ b/packages/ui/src/stores/chat.test.ts
@@ -147,33 +147,51 @@ describe('useChatStore', () => {
   });
 
   describe('localStorage persistence', () => {
+    function makeMockStorage() {
+      const store: Record<string, string> = {};
+      return {
+        getItem: (k: string) => store[k] ?? null,
+        setItem: vi.fn((k: string, v: string) => {
+          store[k] = v;
+        }),
+        removeItem: (k: string) => {
+          delete store[k];
+        },
+        store,
+      };
+    }
+
     it('setActiveAgent writes id, label, and role to localStorage', () => {
-      const spy = vi.spyOn(localStorage, 'setItem');
+      const mock = makeMockStorage();
+      vi.stubGlobal('localStorage', mock);
       useChatStore.getState().setActiveAgent(1, 'guide');
-      expect(spy).toHaveBeenCalledWith(
+      expect(mock.setItem).toHaveBeenCalledWith(
         'system2:active-agent',
         JSON.stringify({ id: 1, label: 'guide_1', role: 'Guide' })
       );
-      spy.mockRestore();
+      vi.unstubAllGlobals();
     });
 
     it('setActiveAgent overwrites a previously persisted agent', () => {
-      const spy = vi.spyOn(localStorage, 'setItem');
+      const mock = makeMockStorage();
+      vi.stubGlobal('localStorage', mock);
       useChatStore.getState().setActiveAgent(1, 'guide');
       useChatStore.getState().setActiveAgent(5, 'conductor');
-      expect(spy).toHaveBeenLastCalledWith(
+      expect(mock.setItem).toHaveBeenLastCalledWith(
         'system2:active-agent',
         JSON.stringify({ id: 5, label: 'conductor_5', role: 'Conductor' })
       );
-      spy.mockRestore();
+      vi.unstubAllGlobals();
     });
 
     it('setActiveAgent does not throw when localStorage write fails', () => {
-      const spy = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+      const mock = makeMockStorage();
+      mock.setItem.mockImplementation(() => {
         throw new Error('QuotaExceededError');
       });
+      vi.stubGlobal('localStorage', mock);
       expect(() => useChatStore.getState().setActiveAgent(1, 'guide')).not.toThrow();
-      spy.mockRestore();
+      vi.unstubAllGlobals();
     });
   });
 

--- a/packages/ui/src/stores/chat.test.ts
+++ b/packages/ui/src/stores/chat.test.ts
@@ -4,7 +4,7 @@
  * Tests for per-agent state isolation, dequeue routing, and loadHistory resets.
  */
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useChatStore } from './chat';
 
 function resetStore() {
@@ -143,6 +143,37 @@ describe('useChatStore', () => {
       expect(state?.activeThinkingId).toBeNull();
       expect(state?.currentAssistantMessage).toBeNull();
       expect(state?.currentTurnEvents).toHaveLength(0);
+    });
+  });
+
+  describe('localStorage persistence', () => {
+    it('setActiveAgent writes id, label, and role to localStorage', () => {
+      const spy = vi.spyOn(localStorage, 'setItem');
+      useChatStore.getState().setActiveAgent(1, 'guide');
+      expect(spy).toHaveBeenCalledWith(
+        'system2:active-agent',
+        JSON.stringify({ id: 1, label: 'guide_1', role: 'Guide' })
+      );
+      spy.mockRestore();
+    });
+
+    it('setActiveAgent overwrites a previously persisted agent', () => {
+      const spy = vi.spyOn(localStorage, 'setItem');
+      useChatStore.getState().setActiveAgent(1, 'guide');
+      useChatStore.getState().setActiveAgent(5, 'conductor');
+      expect(spy).toHaveBeenLastCalledWith(
+        'system2:active-agent',
+        JSON.stringify({ id: 5, label: 'conductor_5', role: 'Conductor' })
+      );
+      spy.mockRestore();
+    });
+
+    it('setActiveAgent does not throw when localStorage write fails', () => {
+      const spy = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
+        throw new Error('QuotaExceededError');
+      });
+      expect(() => useChatStore.getState().setActiveAgent(1, 'guide')).not.toThrow();
+      spy.mockRestore();
     });
   });
 

--- a/packages/ui/src/stores/chat.test.ts
+++ b/packages/ui/src/stores/chat.test.ts
@@ -4,7 +4,7 @@
  * Tests for per-agent state isolation, dequeue routing, and loadHistory resets.
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { useChatStore } from './chat';
 
 function resetStore() {
@@ -143,56 +143,6 @@ describe('useChatStore', () => {
       expect(state?.activeThinkingId).toBeNull();
       expect(state?.currentAssistantMessage).toBeNull();
       expect(state?.currentTurnEvents).toHaveLength(0);
-    });
-  });
-
-  describe('localStorage persistence', () => {
-    afterEach(() => {
-      vi.unstubAllGlobals();
-    });
-
-    function makeMockStorage() {
-      const store: Record<string, string> = {};
-      return {
-        getItem: (k: string) => store[k] ?? null,
-        setItem: vi.fn((k: string, v: string) => {
-          store[k] = v;
-        }),
-        removeItem: (k: string) => {
-          delete store[k];
-        },
-        store,
-      };
-    }
-
-    it('setActiveAgent writes id, label, and role to localStorage', () => {
-      const mock = makeMockStorage();
-      vi.stubGlobal('localStorage', mock);
-      useChatStore.getState().setActiveAgent(1, 'guide');
-      expect(mock.setItem).toHaveBeenCalledWith(
-        'system2:active-agent',
-        JSON.stringify({ id: 1, label: 'guide_1', role: 'Guide' })
-      );
-    });
-
-    it('setActiveAgent overwrites a previously persisted agent', () => {
-      const mock = makeMockStorage();
-      vi.stubGlobal('localStorage', mock);
-      useChatStore.getState().setActiveAgent(1, 'guide');
-      useChatStore.getState().setActiveAgent(5, 'conductor');
-      expect(mock.setItem).toHaveBeenLastCalledWith(
-        'system2:active-agent',
-        JSON.stringify({ id: 5, label: 'conductor_5', role: 'Conductor' })
-      );
-    });
-
-    it('setActiveAgent does not throw when localStorage write fails', () => {
-      const mock = makeMockStorage();
-      mock.setItem.mockImplementation(() => {
-        throw new Error('QuotaExceededError');
-      });
-      vi.stubGlobal('localStorage', mock);
-      expect(() => useChatStore.getState().setActiveAgent(1, 'guide')).not.toThrow();
     });
   });
 

--- a/packages/ui/src/stores/chat.ts
+++ b/packages/ui/src/stores/chat.ts
@@ -28,8 +28,8 @@ function loadActiveAgent(): {
       if (typeof data.id === 'number') {
         return {
           activeAgentId: data.id,
-          activeAgentLabel: data.label ?? null,
-          activeAgentRole: data.role ?? null,
+          activeAgentLabel: typeof data.label === 'string' ? data.label : null,
+          activeAgentRole: typeof data.role === 'string' ? data.role : null,
         };
       }
     }
@@ -40,7 +40,11 @@ function loadActiveAgent(): {
 }
 
 function persistActiveAgent(id: number, label: string, role: string): void {
-  localStorage.setItem(ACTIVE_AGENT_KEY, JSON.stringify({ id, label, role }));
+  try {
+    localStorage.setItem(ACTIVE_AGENT_KEY, JSON.stringify({ id, label, role }));
+  } catch {
+    // ignore — persistence is best-effort
+  }
 }
 
 // Re-export shared types under the names UI components expect

--- a/packages/ui/src/stores/chat.ts
+++ b/packages/ui/src/stores/chat.ts
@@ -8,11 +8,40 @@
  *
  * The server is the source of truth for message history.
  * On WebSocket connect, the server sends chat_history with recent messages.
- * No localStorage persistence — the UI state is ephemeral.
+ * Active agent selection is persisted to localStorage so it survives refreshes.
  */
 
 import type { ChatMessage, ChatThinkingBlock, ChatToolCall, ChatTurnEvent } from '@system2/shared';
 import { create } from 'zustand';
+
+const ACTIVE_AGENT_KEY = 'system2:active-agent';
+
+function loadActiveAgent(): {
+  activeAgentId: number | null;
+  activeAgentLabel: string | null;
+  activeAgentRole: string | null;
+} {
+  try {
+    const stored = localStorage.getItem(ACTIVE_AGENT_KEY);
+    if (stored) {
+      const data = JSON.parse(stored);
+      if (typeof data.id === 'number') {
+        return {
+          activeAgentId: data.id,
+          activeAgentLabel: data.label ?? null,
+          activeAgentRole: data.role ?? null,
+        };
+      }
+    }
+  } catch {
+    // ignore
+  }
+  return { activeAgentId: null, activeAgentLabel: null, activeAgentRole: null };
+}
+
+function persistActiveAgent(id: number, label: string, role: string): void {
+  localStorage.setItem(ACTIVE_AGENT_KEY, JSON.stringify({ id, label, role }));
+}
 
 // Re-export shared types under the names UI components expect
 export type Message = ChatMessage;
@@ -111,20 +140,25 @@ function updateAgentState(
   return next;
 }
 
+const savedAgent = loadActiveAgent();
+
 export const useChatStore = create<ChatState>()((set, get) => ({
   agentStates: new Map(),
-  activeAgentId: null,
-  activeAgentLabel: null,
-  activeAgentRole: null,
+  activeAgentId: savedAgent.activeAgentId,
+  activeAgentLabel: savedAgent.activeAgentLabel,
+  activeAgentRole: savedAgent.activeAgentRole,
   guideAgentId: null,
   isConnected: false,
   provider: null,
 
   setActiveAgent: (agentId: number, role: string) => {
+    const label = `${role}_${agentId}`;
+    const displayRole = role.charAt(0).toUpperCase() + role.slice(1);
+    persistActiveAgent(agentId, label, displayRole);
     set({
       activeAgentId: agentId,
-      activeAgentLabel: `${role}_${agentId}`,
-      activeAgentRole: role.charAt(0).toUpperCase() + role.slice(1),
+      activeAgentLabel: label,
+      activeAgentRole: displayRole,
     });
   },
 

--- a/packages/ui/src/stores/chat.ts
+++ b/packages/ui/src/stores/chat.ts
@@ -13,39 +13,7 @@
 
 import type { ChatMessage, ChatThinkingBlock, ChatToolCall, ChatTurnEvent } from '@system2/shared';
 import { create } from 'zustand';
-
-const ACTIVE_AGENT_KEY = 'system2:active-agent';
-
-function loadActiveAgent(): {
-  activeAgentId: number | null;
-  activeAgentLabel: string | null;
-  activeAgentRole: string | null;
-} {
-  try {
-    const stored = localStorage.getItem(ACTIVE_AGENT_KEY);
-    if (stored) {
-      const data = JSON.parse(stored);
-      if (typeof data.id === 'number') {
-        return {
-          activeAgentId: data.id,
-          activeAgentLabel: typeof data.label === 'string' ? data.label : null,
-          activeAgentRole: typeof data.role === 'string' ? data.role : null,
-        };
-      }
-    }
-  } catch {
-    // ignore
-  }
-  return { activeAgentId: null, activeAgentLabel: null, activeAgentRole: null };
-}
-
-function persistActiveAgent(id: number, label: string, role: string): void {
-  try {
-    localStorage.setItem(ACTIVE_AGENT_KEY, JSON.stringify({ id, label, role }));
-  } catch {
-    // ignore — persistence is best-effort
-  }
-}
+import { persist } from 'zustand/middleware';
 
 // Re-export shared types under the names UI components expect
 export type Message = ChatMessage;
@@ -144,344 +112,359 @@ function updateAgentState(
   return next;
 }
 
-const savedAgent = loadActiveAgent();
+export const useChatStore = create<ChatState>()(
+  persist(
+    (set, get) => ({
+      agentStates: new Map(),
+      activeAgentId: null,
+      activeAgentLabel: null,
+      activeAgentRole: null,
+      guideAgentId: null,
+      isConnected: false,
+      provider: null,
 
-export const useChatStore = create<ChatState>()((set, get) => ({
-  agentStates: new Map(),
-  activeAgentId: savedAgent.activeAgentId,
-  activeAgentLabel: savedAgent.activeAgentLabel,
-  activeAgentRole: savedAgent.activeAgentRole,
-  guideAgentId: null,
-  isConnected: false,
-  provider: null,
+      setActiveAgent: (agentId: number, role: string) => {
+        const label = `${role}_${agentId}`;
+        const displayRole = role.charAt(0).toUpperCase() + role.slice(1);
+        set({
+          activeAgentId: agentId,
+          activeAgentLabel: label,
+          activeAgentRole: displayRole,
+        });
+      },
 
-  setActiveAgent: (agentId: number, role: string) => {
-    const label = `${role}_${agentId}`;
-    const displayRole = role.charAt(0).toUpperCase() + role.slice(1);
-    persistActiveAgent(agentId, label, displayRole);
-    set({
-      activeAgentId: agentId,
-      activeAgentLabel: label,
-      activeAgentRole: displayRole,
-    });
-  },
+      setGuideAgentId: (id: number) => {
+        set({ guideAgentId: id });
+      },
 
-  setGuideAgentId: (id: number) => {
-    set({ guideAgentId: id });
-  },
+      getAgentState: (agentId: number) => {
+        return get().agentStates.get(agentId) ?? EMPTY_AGENT_STATE;
+      },
 
-  getAgentState: (agentId: number) => {
-    return get().agentStates.get(agentId) ?? EMPTY_AGENT_STATE;
-  },
+      getActiveState: () => {
+        const { activeAgentId, agentStates } = get();
+        if (activeAgentId === null) return EMPTY_AGENT_STATE;
+        return agentStates.get(activeAgentId) ?? EMPTY_AGENT_STATE;
+      },
 
-  getActiveState: () => {
-    const { activeAgentId, agentStates } = get();
-    if (activeAgentId === null) return EMPTY_AGENT_STATE;
-    return agentStates.get(activeAgentId) ?? EMPTY_AGENT_STATE;
-  },
+      addUserMessage: (content: string, id?: string, timestamp?: number, agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
 
-  addUserMessage: (content: string, id?: string, timestamp?: number, agentId?: number) => {
-    const targetId = agentId ?? get().activeAgentId;
-    if (targetId === null) return;
-
-    const message: Message = {
-      id: id ?? `msg-${Date.now()}`,
-      role: 'user',
-      content,
-      timestamp: timestamp ?? Date.now(),
-    };
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
-        messages: [...s.messages, message],
-        currentTurnEvents: [],
-        activeThinkingId: null,
-        isWaitingForResponse: true,
-      })),
-    }));
-  },
-
-  addSystemMessage: (content: string) => {
-    const targetId = get().activeAgentId;
-    if (targetId === null) return;
-
-    const message: Message = {
-      id: `msg-${Date.now()}`,
-      role: 'system',
-      content,
-      timestamp: Date.now(),
-    };
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
-        messages: [...s.messages, message],
-      })),
-    }));
-  },
-
-  loadHistory: (messages: Message[], agentId: number) => {
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, agentId, () => ({
-        messages,
-        currentAssistantMessage: null,
-        currentTurnEvents: [],
-        activeThinkingId: null,
-        isStreaming: false,
-        isWaitingForResponse: false,
-      })),
-    }));
-  },
-
-  queueMessage: (content: string, isSteering = false) => {
-    const targetId = get().activeAgentId;
-    if (targetId === null) return;
-
-    const queuedMsg: QueuedMessage = {
-      id: `queued-${Date.now()}`,
-      content,
-      isSteering,
-      timestamp: Date.now(),
-    };
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
-        messageQueue: isSteering ? [queuedMsg, ...s.messageQueue] : [...s.messageQueue, queuedMsg],
-      })),
-    }));
-  },
-
-  dequeueMessage: (agentId?: number) => {
-    const targetId = agentId ?? get().activeAgentId;
-    if (targetId === null) return undefined;
-
-    const agentState = get().agentStates.get(targetId);
-    if (!agentState || agentState.messageQueue.length === 0) return undefined;
-
-    const [next, ...rest] = agentState.messageQueue;
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, () => ({
-        messageQueue: rest,
-      })),
-    }));
-    return next;
-  },
-
-  clearQueue: () => {
-    const targetId = get().activeAgentId;
-    if (targetId === null) return;
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, () => ({
-        messageQueue: [],
-      })),
-    }));
-  },
-
-  startAssistantMessage: (agentId?: number) => {
-    const targetId = agentId ?? get().activeAgentId;
-    if (targetId === null) return;
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, () => ({
-        currentAssistantMessage: '',
-        isStreaming: true,
-        isWaitingForResponse: false,
-      })),
-    }));
-  },
-
-  appendAssistantChunk: (chunk: string, agentId?: number) => {
-    const targetId = agentId ?? get().activeAgentId;
-    if (targetId === null) return;
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
-        currentAssistantMessage: (s.currentAssistantMessage || '') + chunk,
-      })),
-    }));
-  },
-
-  finishAssistantMessage: (agentId?: number) => {
-    const targetId = agentId ?? get().activeAgentId;
-    if (targetId === null) return;
-
-    const agentState = get().agentStates.get(targetId);
-    if (!agentState) return;
-
-    const content = agentState.currentAssistantMessage;
-    if (content) {
-      const message: Message = {
-        id: `msg-${Date.now()}`,
-        role: 'assistant',
-        content,
-        timestamp: Date.now(),
-        turnEvents:
-          agentState.currentTurnEvents.length > 0 ? [...agentState.currentTurnEvents] : undefined,
-      };
-      set((state) => ({
-        agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
-          messages: [...s.messages, message],
-          currentAssistantMessage: null,
-          currentTurnEvents: [],
-          activeThinkingId: null,
-        })),
-      }));
-    }
-  },
-
-  startThinking: (agentId?: number) => {
-    const targetId = agentId ?? get().activeAgentId;
-    if (targetId === null) return;
-
-    const thinkingId = `thinking-${Date.now()}`;
-    const thinkingBlock: ThinkingBlock = {
-      id: thinkingId,
-      content: '',
-      isStreaming: true,
-      timestamp: Date.now(),
-    };
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
-        currentTurnEvents: [...s.currentTurnEvents, { type: 'thinking', data: thinkingBlock }],
-        activeThinkingId: thinkingId,
-        isStreaming: true,
-        isWaitingForResponse: false,
-      })),
-    }));
-  },
-
-  appendThinkingChunk: (chunk: string, agentId?: number) => {
-    const targetId = agentId ?? get().activeAgentId;
-    if (targetId === null) return;
-
-    const agentState = get().agentStates.get(targetId);
-    if (!agentState?.activeThinkingId) return;
-
-    const activeId = agentState.activeThinkingId;
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
-        currentTurnEvents: s.currentTurnEvents.map((event) =>
-          event.type === 'thinking' && event.data.id === activeId
-            ? { ...event, data: { ...event.data, content: event.data.content + chunk } }
-            : event
-        ),
-      })),
-    }));
-  },
-
-  finishThinking: (agentId?: number) => {
-    const targetId = agentId ?? get().activeAgentId;
-    if (targetId === null) return;
-
-    const agentState = get().agentStates.get(targetId);
-    if (!agentState?.activeThinkingId) return;
-
-    const activeId = agentState.activeThinkingId;
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
-        currentTurnEvents: s.currentTurnEvents.map((event) =>
-          event.type === 'thinking' && event.data.id === activeId
-            ? { ...event, data: { ...event.data, isStreaming: false } }
-            : event
-        ),
-        activeThinkingId: null,
-      })),
-    }));
-  },
-
-  startToolCall: (name: string, input?: string, agentId?: number) => {
-    const targetId = agentId ?? get().activeAgentId;
-    if (targetId === null) return;
-
-    // If there's active thinking, finish it first
-    const agentState = get().agentStates.get(targetId);
-    if (agentState?.activeThinkingId) {
-      get().finishThinking(targetId);
-    }
-
-    const toolCall: ToolCall = {
-      id: `tool-${Date.now()}`,
-      name,
-      input,
-      status: 'running',
-      timestamp: Date.now(),
-    };
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
-        currentTurnEvents: [...s.currentTurnEvents, { type: 'tool_call', data: toolCall }],
-        isStreaming: true,
-        isWaitingForResponse: false,
-      })),
-    }));
-  },
-
-  finishToolCall: (name: string, result: string, agentId?: number) => {
-    const targetId = agentId ?? get().activeAgentId;
-    if (targetId === null) return;
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
-        currentTurnEvents: s.currentTurnEvents.map((event) =>
-          event.type === 'tool_call' && event.data.name === name && event.data.status === 'running'
-            ? { ...event, data: { ...event.data, status: 'completed' as const, result } }
-            : event
-        ),
-      })),
-    }));
-  },
-
-  setConnected: (connected: boolean) => {
-    set({ isConnected: connected });
-  },
-
-  clearAllStreamingState: () => {
-    set((state) => {
-      const next = new Map(state.agentStates);
-      for (const [id, s] of next) {
-        if (
-          s.isStreaming ||
-          s.isWaitingForResponse ||
-          s.activeThinkingId ||
-          s.currentAssistantMessage
-        ) {
-          next.set(id, {
-            ...s,
-            isStreaming: false,
-            isWaitingForResponse: false,
+        const message: Message = {
+          id: id ?? `msg-${Date.now()}`,
+          role: 'user',
+          content,
+          timestamp: timestamp ?? Date.now(),
+        };
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+            messages: [...s.messages, message],
+            currentTurnEvents: [],
             activeThinkingId: null,
+            isWaitingForResponse: true,
+          })),
+        }));
+      },
+
+      addSystemMessage: (content: string) => {
+        const targetId = get().activeAgentId;
+        if (targetId === null) return;
+
+        const message: Message = {
+          id: `msg-${Date.now()}`,
+          role: 'system',
+          content,
+          timestamp: Date.now(),
+        };
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+            messages: [...s.messages, message],
+          })),
+        }));
+      },
+
+      loadHistory: (messages: Message[], agentId: number) => {
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, agentId, () => ({
+            messages,
             currentAssistantMessage: null,
             currentTurnEvents: [],
-          });
+            activeThinkingId: null,
+            isStreaming: false,
+            isWaitingForResponse: false,
+          })),
+        }));
+      },
+
+      queueMessage: (content: string, isSteering = false) => {
+        const targetId = get().activeAgentId;
+        if (targetId === null) return;
+
+        const queuedMsg: QueuedMessage = {
+          id: `queued-${Date.now()}`,
+          content,
+          isSteering,
+          timestamp: Date.now(),
+        };
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+            messageQueue: isSteering
+              ? [queuedMsg, ...s.messageQueue]
+              : [...s.messageQueue, queuedMsg],
+          })),
+        }));
+      },
+
+      dequeueMessage: (agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return undefined;
+
+        const agentState = get().agentStates.get(targetId);
+        if (!agentState || agentState.messageQueue.length === 0) return undefined;
+
+        const [next, ...rest] = agentState.messageQueue;
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, () => ({
+            messageQueue: rest,
+          })),
+        }));
+        return next;
+      },
+
+      clearQueue: () => {
+        const targetId = get().activeAgentId;
+        if (targetId === null) return;
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, () => ({
+            messageQueue: [],
+          })),
+        }));
+      },
+
+      startAssistantMessage: (agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, () => ({
+            currentAssistantMessage: '',
+            isStreaming: true,
+            isWaitingForResponse: false,
+          })),
+        }));
+      },
+
+      appendAssistantChunk: (chunk: string, agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+            currentAssistantMessage: (s.currentAssistantMessage || '') + chunk,
+          })),
+        }));
+      },
+
+      finishAssistantMessage: (agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
+
+        const agentState = get().agentStates.get(targetId);
+        if (!agentState) return;
+
+        const content = agentState.currentAssistantMessage;
+        if (content) {
+          const message: Message = {
+            id: `msg-${Date.now()}`,
+            role: 'assistant',
+            content,
+            timestamp: Date.now(),
+            turnEvents:
+              agentState.currentTurnEvents.length > 0
+                ? [...agentState.currentTurnEvents]
+                : undefined,
+          };
+          set((state) => ({
+            agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+              messages: [...s.messages, message],
+              currentAssistantMessage: null,
+              currentTurnEvents: [],
+              activeThinkingId: null,
+            })),
+          }));
         }
-      }
-      return { agentStates: next };
-    });
-  },
+      },
 
-  setStreaming: (streaming: boolean, agentId?: number) => {
-    const targetId = agentId ?? get().activeAgentId;
-    if (targetId === null) return;
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, () => ({
-        isStreaming: streaming,
-      })),
-    }));
-  },
+      startThinking: (agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
 
-  setWaitingForResponse: (waiting: boolean, agentId?: number) => {
-    const targetId = agentId ?? get().activeAgentId;
-    if (targetId === null) return;
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, () => ({
-        isWaitingForResponse: waiting,
-      })),
-    }));
-  },
+        const thinkingId = `thinking-${Date.now()}`;
+        const thinkingBlock: ThinkingBlock = {
+          id: thinkingId,
+          content: '',
+          isStreaming: true,
+          timestamp: Date.now(),
+        };
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+            currentTurnEvents: [...s.currentTurnEvents, { type: 'thinking', data: thinkingBlock }],
+            activeThinkingId: thinkingId,
+            isStreaming: true,
+            isWaitingForResponse: false,
+          })),
+        }));
+      },
 
-  setContextPercent: (percent: number | null, agentId?: number) => {
-    const targetId = agentId ?? get().activeAgentId;
-    if (targetId === null) return;
-    set((state) => ({
-      agentStates: updateAgentState(state.agentStates, targetId, () => ({
-        contextPercent: percent,
-      })),
-    }));
-  },
+      appendThinkingChunk: (chunk: string, agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
 
-  setProvider: (provider: string) => {
-    set({ provider });
-  },
-}));
+        const agentState = get().agentStates.get(targetId);
+        if (!agentState?.activeThinkingId) return;
+
+        const activeId = agentState.activeThinkingId;
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+            currentTurnEvents: s.currentTurnEvents.map((event) =>
+              event.type === 'thinking' && event.data.id === activeId
+                ? { ...event, data: { ...event.data, content: event.data.content + chunk } }
+                : event
+            ),
+          })),
+        }));
+      },
+
+      finishThinking: (agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
+
+        const agentState = get().agentStates.get(targetId);
+        if (!agentState?.activeThinkingId) return;
+
+        const activeId = agentState.activeThinkingId;
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+            currentTurnEvents: s.currentTurnEvents.map((event) =>
+              event.type === 'thinking' && event.data.id === activeId
+                ? { ...event, data: { ...event.data, isStreaming: false } }
+                : event
+            ),
+            activeThinkingId: null,
+          })),
+        }));
+      },
+
+      startToolCall: (name: string, input?: string, agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
+
+        // If there's active thinking, finish it first
+        const agentState = get().agentStates.get(targetId);
+        if (agentState?.activeThinkingId) {
+          get().finishThinking(targetId);
+        }
+
+        const toolCall: ToolCall = {
+          id: `tool-${Date.now()}`,
+          name,
+          input,
+          status: 'running',
+          timestamp: Date.now(),
+        };
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+            currentTurnEvents: [...s.currentTurnEvents, { type: 'tool_call', data: toolCall }],
+            isStreaming: true,
+            isWaitingForResponse: false,
+          })),
+        }));
+      },
+
+      finishToolCall: (name: string, result: string, agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+            currentTurnEvents: s.currentTurnEvents.map((event) =>
+              event.type === 'tool_call' &&
+              event.data.name === name &&
+              event.data.status === 'running'
+                ? { ...event, data: { ...event.data, status: 'completed' as const, result } }
+                : event
+            ),
+          })),
+        }));
+      },
+
+      setConnected: (connected: boolean) => {
+        set({ isConnected: connected });
+      },
+
+      clearAllStreamingState: () => {
+        set((state) => {
+          const next = new Map(state.agentStates);
+          for (const [id, s] of next) {
+            if (
+              s.isStreaming ||
+              s.isWaitingForResponse ||
+              s.activeThinkingId ||
+              s.currentAssistantMessage
+            ) {
+              next.set(id, {
+                ...s,
+                isStreaming: false,
+                isWaitingForResponse: false,
+                activeThinkingId: null,
+                currentAssistantMessage: null,
+                currentTurnEvents: [],
+              });
+            }
+          }
+          return { agentStates: next };
+        });
+      },
+
+      setStreaming: (streaming: boolean, agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, () => ({
+            isStreaming: streaming,
+          })),
+        }));
+      },
+
+      setWaitingForResponse: (waiting: boolean, agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, () => ({
+            isWaitingForResponse: waiting,
+          })),
+        }));
+      },
+
+      setContextPercent: (percent: number | null, agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, () => ({
+            contextPercent: percent,
+          })),
+        }));
+      },
+
+      setProvider: (provider: string) => {
+        set({ provider });
+      },
+    }),
+    {
+      name: 'system2:chat-store',
+      partialize: (state) => ({
+        activeAgentId: state.activeAgentId,
+        activeAgentLabel: state.activeAgentLabel,
+        activeAgentRole: state.activeAgentRole,
+      }),
+    }
+  )
+);

--- a/packages/ui/src/test-setup.ts
+++ b/packages/ui/src/test-setup.ts
@@ -1,3 +1,25 @@
+// Polyfill localStorage for Node v25+, which adds a minimal global localStorage
+// without the full Storage interface (no setItem, getItem, removeItem, clear, etc.)
+if (typeof globalThis.localStorage?.setItem !== 'function') {
+  const store: Record<string, string> = {};
+  (globalThis as Record<string, unknown>).localStorage = {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      for (const k of Object.keys(store)) delete store[k];
+    },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+    get length() {
+      return Object.keys(store).length;
+    },
+  };
+}
+
 // Polyfill CSS.supports for jsdom (used by @primer/react at module scope)
 if (typeof globalThis.CSS === 'undefined') {
   (globalThis as Record<string, unknown>).CSS = { supports: () => false };


### PR DESCRIPTION
Saves `agentsOpen` and `activeAgentId` to localStorage so both survive browser refreshes.

## Changes

- `stores/artifact.ts`: adds `system2:panel-state` key to persist `agentsOpen`; loaded on startup, updated on every toggle
- `stores/chat.ts`: adds `system2:active-agent` key to persist `activeAgentId`, `activeAgentLabel`, `activeAgentRole`; loaded on startup, updated on every agent switch

The WebSocket handler already handles a pre-populated `activeAgentId` on reconnect: if one is set when the first `chat_history` arrives, it sends `switch_agent` to the server to load the right agent's history instead of defaulting to guide.

Fixes #32