### PR TITLE
Add network guard integration tests and update docs

### DIFF
--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -80,10 +80,15 @@ The Narrator synthesizes each section into narrative summaries, avoiding repetit
 
 Croner does **not** catch up missed jobs after laptop sleep or server shutdown. The server handles this explicitly in `checkNarratorCatchUp()`:
 
-1. **Daily summary**: resolve the last daily summary timestamp. If stale by more than `intervalMinutes`, queue `buildAndDeliverDailySummary()`
-2. **Memory update**: read `last_narrator_update_ts` from `memory.md`. If stale by more than 24 hours, queue `buildAndDeliverMemoryUpdate()`
+1. **Network guard**: check `isNetworkAvailable()`. If the network is unreachable, skip all catch-up entirely.
+2. **Daily summary**: resolve the last daily summary timestamp. If stale by more than `intervalMinutes`, queue `buildAndDeliverDailySummary()`
+3. **Memory update**: read `last_narrator_update_ts` from `memory.md`. If stale by more than 24 hours, queue `buildAndDeliverMemoryUpdate()`
 
 This runs once at server start, after agent sessions are initialized.
+
+Both checks use `last_narrator_update_ts` as a cursor. This timestamp only advances when the Narrator successfully processes the delivered message and writes it back to the file's frontmatter. If a job is skipped (network down) or fails, the cursor stays stale and the next restart will re-trigger catch-up.
+
+**Within a single server lifecycle:** if the server starts without network, catch-up is skipped entirely. The `daily-summary` job self-recovers within one cron interval (default 30 min) once the network is back, because its staleness check runs on every cron tick. The `memory-update` catch-up is lost until its next scheduled run (daily at 11 AM), since the cron handler only fires once per day. A server restart recovers both.
 
 ## See Also
 

--- a/packages/server/src/scheduler/jobs.test.ts
+++ b/packages/server/src/scheduler/jobs.test.ts
@@ -1,18 +1,29 @@
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { AgentHost } from '../agents/host.js';
+import type { DatabaseClient } from '../db/client.js';
 import {
   buildAndDeliverMemoryUpdate,
   collectAgentActivity,
   formatMarkdownTable,
   readFrontmatterField,
   readTailChars,
+  registerNarratorJobs,
   resolveDailySummaryTimestamp,
   stripSessionEntry,
 } from './jobs.js';
+import type { Scheduler } from './scheduler.js';
+
+vi.mock('./network.js', () => ({
+  isNetworkAvailable: vi.fn(),
+}));
+
+import { isNetworkAvailable } from './network.js';
+
+const mockIsNetworkAvailable = vi.mocked(isNetworkAvailable);
 
 function makeTmpDir(): string {
   const dir = join(tmpdir(), `system2-test-${randomUUID().slice(0, 8)}`);
@@ -26,11 +37,22 @@ function trackTmpDir(dir: string): string {
   return dir;
 }
 
+function mockNarratorHost(): AgentHost & { calls: Array<{ content: string; details: unknown }> } {
+  const calls: Array<{ content: string; details: unknown }> = [];
+  return {
+    calls,
+    deliverMessage(content: string, details: unknown) {
+      calls.push({ content, details });
+    },
+  } as unknown as AgentHost & { calls: Array<{ content: string; details: unknown }> };
+}
+
 afterEach(() => {
   for (const dir of tmpDirs) {
     rmSync(dir, { recursive: true, force: true });
   }
   tmpDirs.length = 0;
+  mockIsNetworkAvailable.mockReset();
 });
 
 describe('readFrontmatterField', () => {
@@ -182,16 +204,6 @@ describe('collectAgentActivity', () => {
 });
 
 describe('buildAndDeliverMemoryUpdate', () => {
-  function mockNarratorHost(): AgentHost & { calls: Array<{ content: string; details: unknown }> } {
-    const calls: Array<{ content: string; details: unknown }> = [];
-    return {
-      calls,
-      deliverMessage(content: string, details: unknown) {
-        calls.push({ content, details });
-      },
-    } as unknown as AgentHost & { calls: Array<{ content: string; details: unknown }> };
-  }
-
   it('skips delivery when no daily summary files exist', () => {
     const dir = trackTmpDir(makeTmpDir());
     const knowledgeDir = join(dir, 'knowledge');
@@ -561,5 +573,83 @@ describe('stripSessionEntry', () => {
       const result = stripSessionEntry(entry) as Record<string, Record<string, unknown>>;
       expect(result.message.content).toBe('short');
     });
+  });
+});
+
+describe('registerNarratorJobs (network guard)', () => {
+  /** Fake Scheduler that captures registered handlers by name. */
+  function mockScheduler() {
+    const handlers: Record<string, () => Promise<void>> = {};
+    return {
+      schedule(name: string, _pattern: string, handler: () => Promise<void>) {
+        handlers[name] = handler;
+      },
+      handlers,
+    };
+  }
+
+  it('skips daily-summary when network is unavailable', async () => {
+    mockIsNetworkAvailable.mockResolvedValueOnce(false);
+    const scheduler = mockScheduler();
+    const host = mockNarratorHost();
+    const dir = trackTmpDir(makeTmpDir());
+
+    registerNarratorJobs(scheduler as unknown as Scheduler, host, 2, {} as DatabaseClient, dir, 30);
+
+    await scheduler.handlers['daily-summary']();
+    expect(host.calls).toHaveLength(0);
+    expect(mockIsNetworkAvailable).toHaveBeenCalledOnce();
+  });
+
+  it('skips memory-update when network is unavailable', async () => {
+    mockIsNetworkAvailable.mockResolvedValueOnce(false);
+    const scheduler = mockScheduler();
+    const host = mockNarratorHost();
+    const dir = trackTmpDir(makeTmpDir());
+
+    registerNarratorJobs(scheduler as unknown as Scheduler, host, 2, {} as DatabaseClient, dir, 30);
+
+    await scheduler.handlers['memory-update']();
+    expect(host.calls).toHaveLength(0);
+    expect(mockIsNetworkAvailable).toHaveBeenCalledOnce();
+  });
+
+  it('proceeds with daily-summary when network is available', async () => {
+    mockIsNetworkAvailable.mockResolvedValueOnce(true);
+    const scheduler = mockScheduler();
+    const host = mockNarratorHost();
+    const dir = trackTmpDir(makeTmpDir());
+    mkdirSync(join(dir, 'knowledge', 'daily_summaries'), { recursive: true });
+
+    const mockDb = { query: () => [] } as unknown as DatabaseClient;
+
+    registerNarratorJobs(scheduler as unknown as Scheduler, host, 2, mockDb, dir, 30);
+
+    await scheduler.handlers['daily-summary']();
+
+    // buildAndDeliverDailySummary was reached: it creates today's summary file
+    const today = new Date().toISOString().slice(0, 10);
+    expect(existsSync(join(dir, 'knowledge', 'daily_summaries', `${today}.md`))).toBe(true);
+    // With no agents/projects the daily summary still delivers (file has content)
+    expect(host.calls.length).toBeGreaterThanOrEqual(1);
+    expect(host.calls[0].content).toContain('[Scheduled task: daily-summary]');
+  });
+
+  it('proceeds with memory-update when network is available', async () => {
+    mockIsNetworkAvailable.mockResolvedValueOnce(true);
+    const scheduler = mockScheduler();
+    const host = mockNarratorHost();
+    const dir = trackTmpDir(makeTmpDir());
+    const knowledgeDir = join(dir, 'knowledge');
+    const summariesDir = join(knowledgeDir, 'daily_summaries');
+    mkdirSync(summariesDir, { recursive: true });
+    writeFileSync(join(knowledgeDir, 'memory.md'), '---\nlast_narrator_update_ts:\n---\n');
+    writeFileSync(join(summariesDir, '2026-03-24.md'), '---\n---\n# Summary');
+
+    registerNarratorJobs(scheduler as unknown as Scheduler, host, 2, {} as DatabaseClient, dir, 30);
+
+    await scheduler.handlers['memory-update']();
+    expect(host.calls).toHaveLength(1);
+    expect(host.calls[0].content).toContain('[Scheduled task: memory-update]');
   });
 });


### PR DESCRIPTION
## Summary

- Add 4 integration tests for `registerNarratorJobs` verifying handlers call `isNetworkAvailable` and skip/proceed correctly (both daily-summary and memory-update)
- Extract `mockNarratorHost` to module level for reuse across test suites
- Update scheduler docs: document network guard in catch-up on startup, explain cursor self-healing mechanism (`last_narrator_update_ts` only advances on Narrator success), add timing caveat for within-lifecycle vs cross-restart recovery

Follows up on 2a65e27 which added the network guard implementation.

## Test plan

- [x] All 367 tests pass (4 new)
- [x] `pnpm check` clean
- [x] `pnpm typecheck` clean
- [x] Pre-push hooks pass