### PR TITLE
fix(scheduler): skip daily-summary only on fresh activity

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,7 +135,6 @@ See [Agents](agents.md#authresolver-auth-resolverts) for implementation details.
 ├── .git/                  # Version control for text files
 ├── config.toml            # Settings and credentials (0600)
 ├── app.db                 # SQLite database
-├── chat-history.json      # Chat message ring buffer (max 1000)
 ├── server.pid             # PID file when server is running
 ├── knowledge/
 │   ├── infrastructure.md  # Data stack details (Guide)

--- a/docs/knowledge-system.md
+++ b/docs/knowledge-system.md
@@ -240,7 +240,7 @@ See [Scheduler](scheduler.md) for the pipeline that produces project logs and da
 
 **How commits happen:** The `write` and `edit` tools accept an optional `commit_message` parameter. When provided and the target path is inside `~/.system2/`, the tool auto-commits the file after the operation. Agents provide descriptive messages (e.g., `"daily summary: 2024-01-16 14:30"`). If an agent modifies a tracked file via `bash` instead, it must commit manually.
 
-**Gitignored:** `app.db` (and WAL/SHM), `sessions/`, `logs/`, `*.log`, `server.pid`, `config.toml` (contains API keys), `chat-history.json` (UI state).
+**Gitignored:** `app.db` (and WAL/SHM), `sessions/` (JSONL files and per-agent chat caches), `logs/`, `*.log`, `server.pid`, `config.toml` (contains API keys).
 
 **Backup:** The CLI creates timestamped full copies (`~/.system2-auto-backup-*`) on every `system2 start` (24h cooldown, 5 max retention). This covers everything git ignores (database, sessions, config). See [CLI](packages/cli.md) and [Configuration](configuration.md).
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -20,10 +20,10 @@ class Scheduler {
 
 ## Registered Jobs
 
-| Job              | Schedule                       | Description                                                          |
-|------------------|--------------------------------|----------------------------------------------------------------------|
-| `daily-summary`  | Every N minutes (default: 30)  | Collect activity, deliver project logs and daily summary to Narrator |
-| `memory-update`  | Daily at 11 AM                 | Send daily summaries list to Narrator for memory consolidation       |
+| Job              | Schedule                       | Description                                                                |
+|------------------|--------------------------------|----------------------------------------------------------------------------|
+| `daily-summary`  | Every N minutes (default: 30)  | Collect activity, deliver project logs and daily summary to Narrator       |
+| `memory-update`  | Daily at 11 AM                 | Embed daily summary content and send to Narrator for memory consolidation  |
 
 The `daily-summary` interval is configurable via `[scheduler].daily_summary_interval_minutes` in config.toml.
 
@@ -59,10 +59,10 @@ Each project log is a single continuous file per project lifetime (unlike daily 
    - Most recent daily summary frontmatter (by filename sort)
    - `memory.md` frontmatter
    - Fall back to `intervalMinutes` ago
-4. **Build message** with two sections:
-   - **Project Activity:** per-project sections with project-scoped agent JSONL and project DB changes (reused from Phase 1)
-   - **Non-Project Activity:** Guide JSONL (via `dailySummarySystemAgents`, which excludes Narrator to prevent recursive embedding of its own `custom_message` injections) and DB changes not tied to any active project.
-5. **Check for activity:** skip delivery if neither project activity (agent JSONL entries or DB changes) nor non-project activity is detected in the time window. Existing file content does not influence the skip decision: even if the file already has a narrative from an earlier run, a new delivery only happens when fresh activity arrives.
+4. **Check for activity:** skip delivery if neither project activity (agent JSONL entries or DB changes) nor non-project activity is detected in the time window. Existing file content does not influence the skip decision: even if the file already has a narrative from an earlier run, a new delivery only happens when fresh activity arrives.
+5. **Build message** with only the sections that have activity:
+   - **Project Activity:** included only for projects that have agent JSONL entries or DB changes in the window; inactive projects are omitted entirely. The entire section is omitted when no project has changes.
+   - **Non-Project Activity:** Guide JSONL (via `dailySummarySystemAgents`, which excludes Narrator to prevent recursive embedding of its own `custom_message` injections) and DB changes not tied to any active project. Omitted when there is no non-project activity.
 6. **Deliver:** send to Narrator via `deliverMessage()` with `sender: 0` (system sentinel)
 
 The Narrator synthesizes each section into narrative summaries, avoiding repetition of project-specific content already covered in project-log entries (which are processed first).
@@ -72,9 +72,10 @@ The Narrator synthesizes each section into narrative summaries, avoiding repetit
 `buildAndDeliverMemoryUpdate()` runs daily at 11 AM:
 
 1. Read `last_narrator_update_ts` from `memory.md`
-2. List daily summary files since that date
-3. Send file paths to Narrator via `deliverMessage()`
-4. Narrator reads summaries, incorporates into `memory.md`, clears processed Notes
+2. List daily summary files since that date (lexicographic `>=` comparison, inclusive)
+3. Read each file and embed its content inline in the message
+4. Deliver to Narrator via `deliverMessage()` with all summary content included
+5. Narrator incorporates summaries into `memory.md`, clears processed Notes
 
 ## Catch-Up on Startup
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -62,7 +62,7 @@ Each project log is a single continuous file per project lifetime (unlike daily 
 4. **Build message** with two sections:
    - **Project Activity:** per-project sections with project-scoped agent JSONL and project DB changes (reused from Phase 1)
    - **Non-Project Activity:** Guide JSONL (via `dailySummarySystemAgents`, which excludes Narrator to prevent recursive embedding of its own `custom_message` injections) and DB changes not tied to any active project.
-5. **Check for activity:** skip delivery if there's no meaningful activity
+5. **Check for activity:** skip delivery if neither project activity (agent JSONL entries or DB changes) nor non-project activity is detected in the time window. Existing file content does not influence the skip decision: even if the file already has a narrative from an earlier run, a new delivery only happens when fresh activity arrives.
 6. **Deliver:** send to Narrator via `deliverMessage()` with `sender: 0` (system sentinel)
 
 The Narrator synthesizes each section into narrative summaries, avoiding repetition of project-specific content already covered in project-log entries (which are processed first).

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -387,7 +387,7 @@ All System2 data lives in `~/.system2/`:
 ```text
 ~/.system2/
 ├── .git/                  # Git tracking for text files
-├── .gitignore             # Excludes app.db, sessions, logs, config.toml, chat-history.json
+├── .gitignore             # Excludes app.db, sessions, logs, config.toml
 ├── config.toml            # Settings and credentials
 ├── app.db                 # SQLite database (projects, tasks, agents)
 ├── server.pid             # PID file when server is running

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -387,7 +387,7 @@ All System2 data lives in `~/.system2/`:
 ```text
 ~/.system2/
 ├── .git/                  # Git tracking for text files
-├── .gitignore             # Excludes app.db, sessions, logs, config.toml
+├── .gitignore             # Git ignore rules for database, sessions, logs, config, PID, and other generated files
 ├── config.toml            # Settings and credentials
 ├── app.db                 # SQLite database (projects, tasks, agents)
 ├── server.pid             # PID file when server is running

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -464,6 +464,29 @@ describe('AgentHost', () => {
 
       expect(host.chatCache).toBe(mockCache);
     });
+
+    it('preserves existing instance across reinitialize', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as { _chatCache: object; initialize: () => Promise<void> };
+      const originalCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
+      internal._chatCache = originalCache;
+
+      // Calling initialize() again (as reinitializeWithProvider does) should
+      // keep the existing chat cache instance, not replace it.
+      try {
+        await internal.initialize();
+      } catch {
+        // initialize() may throw due to missing agent DB record; that's fine
+      }
+
+      expect(internal._chatCache).toBe(originalCache);
+    });
   });
 
   describe('deliverMessage', () => {

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -181,11 +181,15 @@ export class AgentHost {
     // Store session dir for rotation checks
     this._sessionDir = agentSessionDir;
 
-    // Initialize per-agent chat cache (ring buffer persisted to JSON)
-    this._chatCache = new MessageHistory(
-      join(agentSessionDir, 'chat-cache.json'),
-      this.chatMaxMessages
-    );
+    // Initialize per-agent chat cache (ring buffer persisted to JSON).
+    // Only create on first init; reinitialization (failover) preserves the
+    // existing instance to prevent losing entries pushed between file loads.
+    if (!this._chatCache) {
+      this._chatCache = new MessageHistory(
+        join(agentSessionDir, 'chat-cache.json'),
+        this.chatMaxMessages
+      );
+    }
 
     // Rotate session file if it exceeds size threshold (10MB)
     const rotated = rotateSessionIfNeeded(agentSessionDir, SYSTEM2_DIR);

--- a/packages/server/src/agents/library/narrator.md
+++ b/packages/server/src/agents/library/narrator.md
@@ -110,19 +110,17 @@ Your job is to synthesize each section into a concise but comprehensive narrativ
 
 **Goal:** Restructure `memory.md` into a coherent long-term memory document incorporating recent daily summaries.
 
-The message contains the memory file path, timestamps, and a list of daily summary files to incorporate.
+The message contains the memory file path, timestamps, and the full content of each daily summary file to incorporate (embedded inline, no need to read them separately).
 
 **Workflow:**
 
-1. **Parse metadata:** Extract `memory_file`, `last_narrator_update_ts`, `new_run_ts`, and the list of daily summary file paths.
+1. **Parse metadata:** Extract `memory_file`, `last_narrator_update_ts`, `new_run_ts`, and the embedded daily summary content from the `## Daily summaries to incorporate` section.
 
 2. **Read memory.md:** Read the full document including any items in the `## Latest Learnings` section that other agents may have written.
 
-3. **Read daily summaries:** Read each listed daily summary file.
+3. **Restructure:** Blend new insights from the daily summaries (provided in the message) into the document body. Consolidate items from the `## Latest Learnings` section into appropriate sections. Remove consolidated items from Latest Learnings. Maintain a coherent, well-organized document that reads naturally.
 
-4. **Restructure:** Blend new insights from daily summaries into the document body. Consolidate items from the `## Latest Learnings` section into appropriate sections. Remove consolidated items from Latest Learnings. Maintain a coherent, well-organized document that reads naturally.
-
-5. **Write updated memory.md:** Use `write` with `commit_message: "memory update"` to overwrite with the restructured content. Set `last_narrator_update_ts` to `new_run_ts` (UTC ISO 8601 format, e.g. `2026-03-13T16:00:00.002Z`) inside the file's existing frontmatter block. The file must have exactly one frontmatter block at the top (see **Frontmatter Rules** below).
+4. **Write updated memory.md:** Use `write` with `commit_message: "memory update"` to overwrite with the restructured content. Set `last_narrator_update_ts` to `new_run_ts` (UTC ISO 8601 format, e.g. `2026-03-13T16:00:00.002Z`) inside the file's existing frontmatter block. The file must have exactly one frontmatter block at the top (see **Frontmatter Rules** below).
 
 **CRITICAL: you MUST update `last_narrator_update_ts` to `new_run_ts` in the frontmatter. If you skip this, the next scheduled job will re-collect the same time window, producing duplicate data that grows with every run. This is the mechanism that advances the cursor: no update means unbounded re-processing.**
 

--- a/packages/server/src/knowledge/git.ts
+++ b/packages/server/src/knowledge/git.ts
@@ -22,10 +22,7 @@ server.pid
 logs/
 *.log
 
-# UI state
-chat-history.json
-
-# Session files (large, binary-like JSONL)
+# Session files (JSONL + per-agent chat caches)
 sessions/
 `;
 

--- a/packages/server/src/scheduler/jobs.test.ts
+++ b/packages/server/src/scheduler/jobs.test.ts
@@ -2,10 +2,11 @@ import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AgentHost } from '../agents/host.js';
 import type { DatabaseClient } from '../db/client.js';
 import {
+  buildAndDeliverDailySummary,
   buildAndDeliverMemoryUpdate,
   collectAgentActivity,
   formatMarkdownTable,
@@ -630,9 +631,8 @@ describe('registerNarratorJobs (network guard)', () => {
     // buildAndDeliverDailySummary was reached: it creates today's summary file
     const today = new Date().toISOString().slice(0, 10);
     expect(existsSync(join(dir, 'knowledge', 'daily_summaries', `${today}.md`))).toBe(true);
-    // With no agents/projects the daily summary still delivers (file has content)
-    expect(host.calls.length).toBeGreaterThanOrEqual(1);
-    expect(host.calls[0].content).toContain('[Scheduled task: daily-summary]');
+    // With no agents/projects and no activity, delivery is correctly skipped
+    expect(host.calls).toHaveLength(0);
   });
 
   it('proceeds with memory-update when network is available', async () => {
@@ -651,5 +651,268 @@ describe('registerNarratorJobs (network guard)', () => {
     await scheduler.handlers['memory-update']();
     expect(host.calls).toHaveLength(1);
     expect(host.calls[0].content).toContain('[Scheduled task: memory-update]');
+  });
+});
+
+describe('buildAndDeliverDailySummary', () => {
+  const FIXED_NOW = new Date('2026-03-15T14:00:00.000Z');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function mockHost(): AgentHost & { calls: Array<{ content: string; details: unknown }> } {
+    const calls: Array<{ content: string; details: unknown }> = [];
+    return {
+      calls,
+      deliverMessage(content: string, details: unknown) {
+        calls.push({ content, details });
+      },
+    } as unknown as AgentHost & { calls: Array<{ content: string; details: unknown }> };
+  }
+
+  function mockDb(
+    agents: Array<{ id: number; role: string; project_name: string | null }>,
+    projects: Array<{ id: number; name: string }> = []
+  ): DatabaseClient {
+    return {
+      query(sql: string) {
+        if (sql.includes('FROM agent')) return agents;
+        if (sql.includes('FROM project p')) return projects;
+        return [];
+      },
+    } as unknown as DatabaseClient;
+  }
+
+  it('skips when file has content but no new activity', () => {
+    const dir = trackTmpDir(makeTmpDir());
+    const summariesDir = join(dir, 'knowledge', 'daily_summaries');
+    mkdirSync(summariesDir, { recursive: true });
+
+    writeFileSync(
+      join(summariesDir, '2026-03-15.md'),
+      '---\nlast_narrator_update_ts: 2020-01-01T00:00:00Z\n---\n# Daily Summary — 2026-03-15\n\n## 09:00\nSome prior narrative.'
+    );
+
+    const host = mockHost();
+    const db = mockDb([{ id: 1, role: 'guide', project_name: null }]);
+    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+    expect(host.calls).toHaveLength(0);
+  });
+
+  it('skips on first run with no activity', () => {
+    const dir = trackTmpDir(makeTmpDir());
+
+    const host = mockHost();
+    const db = mockDb([{ id: 1, role: 'guide', project_name: null }]);
+    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+    expect(host.calls).toHaveLength(0);
+  });
+
+  it('delivers when non-project agent has JSONL activity', () => {
+    const dir = trackTmpDir(makeTmpDir());
+    const summariesDir = join(dir, 'knowledge', 'daily_summaries');
+    const sessionDir = join(dir, 'sessions', 'guide_1');
+    mkdirSync(summariesDir, { recursive: true });
+    mkdirSync(sessionDir, { recursive: true });
+
+    // Set lastRunTs to 10 minutes ago, entry timestamp to 5 minutes ago
+    const lastRunTs = new Date(Date.now() - 10 * 60_000).toISOString();
+    const entryTs = new Date(Date.now() - 5 * 60_000).toISOString();
+    writeFileSync(
+      join(summariesDir, '2026-03-15.md'),
+      `---\nlast_narrator_update_ts: ${lastRunTs}\n---\n# Daily Summary — 2026-03-15\n`
+    );
+
+    const entry = JSON.stringify({
+      type: 'message',
+      timestamp: entryTs,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'hello from guide' }] },
+    });
+    writeFileSync(join(sessionDir, 'session.jsonl'), entry);
+
+    const host = mockHost();
+    const db = mockDb([{ id: 1, role: 'guide', project_name: null }]);
+    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+
+    expect(host.calls).toHaveLength(1);
+    expect(host.calls[0].content).toContain('[Scheduled task: daily-summary]');
+  });
+
+  it('delivers when project has DB changes', () => {
+    const dir = trackTmpDir(makeTmpDir());
+
+    const host = mockHost();
+    const db = {
+      query(sql: string) {
+        if (sql.includes('FROM agent')) {
+          return [
+            { id: 1, role: 'guide', project_name: null },
+            { id: 2, role: 'conductor', project_name: 'TestProject' },
+          ];
+        }
+        if (sql.includes('FROM project p')) {
+          return [{ id: 1, name: 'TestProject' }];
+        }
+        // Return task rows only for project-scoped queries (not non-project)
+        if (sql.includes('project = 1') || sql.includes('t.project = 1')) {
+          return [{ id: 10, title: 'A task', status: 'done', project: 1 }];
+        }
+        return [];
+      },
+    } as unknown as DatabaseClient;
+
+    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+
+    expect(host.calls.length).toBeGreaterThanOrEqual(1);
+    const messages = host.calls.map((c) => c.content);
+    expect(messages.some((m) => m.includes('[Scheduled task: daily-summary]'))).toBe(true);
+  });
+
+  it('includes existing file content in the delivered message', () => {
+    const dir = trackTmpDir(makeTmpDir());
+    const summariesDir = join(dir, 'knowledge', 'daily_summaries');
+    const sessionDir = join(dir, 'sessions', 'guide_1');
+    mkdirSync(summariesDir, { recursive: true });
+    mkdirSync(sessionDir, { recursive: true });
+
+    const lastRunTs = new Date(Date.now() - 10 * 60_000).toISOString();
+    const entryTs = new Date(Date.now() - 5 * 60_000).toISOString();
+    writeFileSync(
+      join(summariesDir, '2026-03-15.md'),
+      `---\nlast_narrator_update_ts: ${lastRunTs}\n---\n# Daily Summary — 2026-03-15\n\n## 09:00\nPrior narrative here.`
+    );
+
+    const entry = JSON.stringify({
+      type: 'message',
+      timestamp: entryTs,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'guide activity' }] },
+    });
+    writeFileSync(join(sessionDir, 'session.jsonl'), entry);
+
+    const host = mockHost();
+    const db = mockDb([{ id: 1, role: 'guide', project_name: null }]);
+    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+
+    expect(host.calls).toHaveLength(1);
+    expect(host.calls[0].content).toContain('Prior narrative here.');
+  });
+
+  it('excludes inactive projects from the message', () => {
+    const dir = trackTmpDir(makeTmpDir());
+    const sessionDir = join(dir, 'sessions', 'guide_1');
+    mkdirSync(sessionDir, { recursive: true });
+
+    const lastRunTs = new Date(Date.now() - 10 * 60_000).toISOString();
+    const entryTs = new Date(Date.now() - 5 * 60_000).toISOString();
+
+    // Guide has activity (so the message gets delivered), but the project has none
+    const entry = JSON.stringify({
+      type: 'message',
+      timestamp: entryTs,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'guide work' }] },
+    });
+    writeFileSync(join(sessionDir, 'session.jsonl'), entry);
+
+    const summariesDir = join(dir, 'knowledge', 'daily_summaries');
+    mkdirSync(summariesDir, { recursive: true });
+    const today = new Date().toISOString().slice(0, 10);
+    writeFileSync(
+      join(summariesDir, `${today}.md`),
+      `---\nlast_narrator_update_ts: ${lastRunTs}\n---\n# Daily Summary\n`
+    );
+
+    const host = mockHost();
+    const db = mockDb(
+      [
+        { id: 1, role: 'guide', project_name: null },
+        { id: 2, role: 'conductor', project_name: 'InactiveProject' },
+      ],
+      [{ id: 1, name: 'InactiveProject' }]
+    );
+    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+
+    const dailySummaryMsg = host.calls
+      .map((c) => c.content)
+      .find((m) => m.includes('[Scheduled task: daily-summary]'));
+    expect(dailySummaryMsg).toBeDefined();
+    expect(dailySummaryMsg).not.toContain('## Project Activity');
+    expect(dailySummaryMsg).not.toContain('InactiveProject');
+    expect(dailySummaryMsg).toContain('## Non-Project Activity');
+  });
+
+  it('includes only active projects when multiple exist', () => {
+    const dir = trackTmpDir(makeTmpDir());
+
+    const host = mockHost();
+    const db = {
+      query(sql: string) {
+        if (sql.includes('FROM agent')) {
+          return [
+            { id: 1, role: 'guide', project_name: null },
+            { id: 2, role: 'conductor', project_name: 'ActiveProject' },
+            { id: 3, role: 'conductor', project_name: 'IdleProject' },
+          ];
+        }
+        if (sql.includes('FROM project p')) {
+          return [
+            { id: 1, name: 'ActiveProject' },
+            { id: 2, name: 'IdleProject' },
+          ];
+        }
+        // Return task rows only for project 1 (ActiveProject)
+        if (sql.includes('project = 1') || sql.includes('t.project = 1')) {
+          return [{ id: 10, title: 'A task', status: 'done', project: 1 }];
+        }
+        return [];
+      },
+    } as unknown as DatabaseClient;
+
+    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+
+    const dailySummaryMsg = host.calls
+      .map((c) => c.content)
+      .find((m) => m.includes('[Scheduled task: daily-summary]'));
+    expect(dailySummaryMsg).toBeDefined();
+    expect(dailySummaryMsg).toContain('ActiveProject');
+    expect(dailySummaryMsg).not.toContain('IdleProject');
+  });
+
+  it('omits Non-Project Activity section when only projects have changes', () => {
+    const dir = trackTmpDir(makeTmpDir());
+
+    const host = mockHost();
+    const db = {
+      query(sql: string) {
+        if (sql.includes('FROM agent')) {
+          return [
+            { id: 1, role: 'guide', project_name: null },
+            { id: 2, role: 'conductor', project_name: 'TestProject' },
+          ];
+        }
+        if (sql.includes('FROM project p')) {
+          return [{ id: 1, name: 'TestProject' }];
+        }
+        // Return task rows only for project-scoped queries (not non-project)
+        if (sql.includes('project = 1') || sql.includes('t.project = 1')) {
+          return [{ id: 10, title: 'A task', status: 'done', project: 1 }];
+        }
+        return [];
+      },
+    } as unknown as DatabaseClient;
+
+    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+
+    const dailySummaryMsg = host.calls
+      .map((c) => c.content)
+      .find((m) => m.includes('[Scheduled task: daily-summary]'));
+    expect(dailySummaryMsg).toBeDefined();
+    expect(dailySummaryMsg).toContain('## Project Activity');
+    expect(dailySummaryMsg).not.toContain('## Non-Project Activity');
   });
 });

--- a/packages/server/src/scheduler/jobs.test.ts
+++ b/packages/server/src/scheduler/jobs.test.ts
@@ -235,7 +235,7 @@ describe('buildAndDeliverMemoryUpdate', () => {
     expect(host.calls).toHaveLength(0);
   });
 
-  it('delivers message with summary files since last update', () => {
+  it('delivers message with embedded summary content since last update', () => {
     const dir = trackTmpDir(makeTmpDir());
     const knowledgeDir = join(dir, 'knowledge');
     const summariesDir = join(knowledgeDir, 'daily_summaries');
@@ -244,9 +244,15 @@ describe('buildAndDeliverMemoryUpdate', () => {
       join(knowledgeDir, 'memory.md'),
       '---\nlast_narrator_update_ts: 2026-03-10T00:00:00Z\n---\n# Memory'
     );
-    writeFileSync(join(summariesDir, '2026-03-10.md'), '---\n---\n# Summary 10');
-    writeFileSync(join(summariesDir, '2026-03-11.md'), '---\n---\n# Summary 11');
-    writeFileSync(join(summariesDir, '2026-03-09.md'), '---\n---\n# Before');
+    writeFileSync(
+      join(summariesDir, '2026-03-10.md'),
+      '---\n---\n# Summary 10\nDay ten narrative.'
+    );
+    writeFileSync(
+      join(summariesDir, '2026-03-11.md'),
+      '---\n---\n# Summary 11\nDay eleven narrative.'
+    );
+    writeFileSync(join(summariesDir, '2026-03-09.md'), '---\n---\n# Before\nOld narrative.');
 
     const host = mockNarratorHost();
     buildAndDeliverMemoryUpdate(host, 2, dir);
@@ -254,8 +260,11 @@ describe('buildAndDeliverMemoryUpdate', () => {
 
     const msg = host.calls[0].content;
     expect(msg).toContain('[Scheduled task: memory-update]');
-    expect(msg).toContain('2026-03-10.md');
-    expect(msg).toContain('2026-03-11.md');
+    // Content is embedded inline (not just file paths)
+    expect(msg).toContain('Day ten narrative.');
+    expect(msg).toContain('Day eleven narrative.');
+    // Older summary excluded entirely
+    expect(msg).not.toContain('Old narrative.');
     expect(msg).not.toContain('2026-03-09.md');
     expect(msg).toContain('IMPORTANT');
     expect(msg).toContain('UTC ISO 8601');
@@ -267,12 +276,12 @@ describe('buildAndDeliverMemoryUpdate', () => {
     const summariesDir = join(knowledgeDir, 'daily_summaries');
     mkdirSync(summariesDir, { recursive: true });
     writeFileSync(join(knowledgeDir, 'memory.md'), '---\nlast_narrator_update_ts:\n---\n# Memory');
-    writeFileSync(join(summariesDir, '2026-03-10.md'), '---\n---\n# Summary');
+    writeFileSync(join(summariesDir, '2026-03-10.md'), '---\n---\n# Summary\nNarrative content.');
 
     const host = mockNarratorHost();
     buildAndDeliverMemoryUpdate(host, 2, dir);
     expect(host.calls).toHaveLength(1);
-    expect(host.calls[0].content).toContain('2026-03-10.md');
+    expect(host.calls[0].content).toContain('Narrative content.');
   });
 });
 

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -9,7 +9,7 @@
  */
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import type { AgentHost } from '../agents/host.js';
 import type { DatabaseClient } from '../db/client.js';
 import { isNetworkAvailable } from './network.js';
@@ -297,6 +297,7 @@ interface ProjectActivityData {
   projectName: string;
   agentActivity: string;
   dbChanges: string;
+  hasChanges: boolean;
 }
 
 type AgentRow = { id: number; role: string; project_name: string | null };
@@ -546,6 +547,7 @@ export function buildAndDeliverDailySummary(
       projectName: project.name,
       agentActivity: projectScopedActivity,
       dbChanges: projectDbChanges,
+      hasChanges: hasActivity(projectScopedActivity, projectDbChanges),
     });
 
     // Deliver project-log message (with all agents including Guide)
@@ -591,7 +593,16 @@ ${projectDbChanges}`;
   );
   const nonProjectDbChanges = collectNonProjectDbChanges(db, activeProjectIds, lastRunTs, newRunTs);
 
-  // 7. Assemble daily summary message
+  // 7. Check for any activity at all
+  const hasProjectChanges = projectDataList.some((pd) => pd.hasChanges);
+  const hasNonProjectChanges = hasActivity(nonProjectAgentActivity, nonProjectDbChanges);
+
+  if (!hasProjectChanges && !hasNonProjectChanges) {
+    console.log('[Scheduler] No activity since last run, skipping daily-summary');
+    return;
+  }
+
+  // 8. Assemble daily summary message (only sections with activity)
   const messageParts: string[] = [
     `[Scheduled task: daily-summary]
 
@@ -606,29 +617,21 @@ IMPORTANT: After writing the summary, you MUST set last_narrator_update_ts to ex
 ${dailySummaryContent}`,
   ];
 
-  if (projectDataList.length > 0) {
-    const projectParts: string[] = [];
-    for (const pd of projectDataList) {
-      projectParts.push(
-        `### Project: ${pd.projectName} (#${pd.projectId})\n\n#### Agent Activity\n\n${pd.agentActivity}\n#### Database Changes\n\n${pd.dbChanges}`
-      );
-    }
-    messageParts.push(`## Project Activity\n\n${projectParts.join('\n')}`);
+  const activeProjectParts: string[] = [];
+  for (const pd of projectDataList) {
+    if (!pd.hasChanges) continue;
+    activeProjectParts.push(
+      `### Project: ${pd.projectName} (#${pd.projectId})\n\n#### Agent Activity\n\n${pd.agentActivity}\n#### Database Changes\n\n${pd.dbChanges}`
+    );
+  }
+  if (activeProjectParts.length > 0) {
+    messageParts.push(`## Project Activity\n\n${activeProjectParts.join('\n')}`);
   }
 
-  messageParts.push(
-    `## Non-Project Activity\n\n#### Agent Activity\n\n${nonProjectAgentActivity}\n#### Database Changes\n\n${nonProjectDbChanges}`
-  );
-
-  // 8. Check for any activity at all
-  const hasProjectChanges = projectDataList.some((pd) =>
-    hasActivity(pd.agentActivity, pd.dbChanges)
-  );
-  const hasNonProjectChanges = hasActivity(nonProjectAgentActivity, nonProjectDbChanges);
-
-  if (!hasProjectChanges && !hasNonProjectChanges) {
-    console.log('[Scheduler] No activity since last run, skipping daily-summary');
-    return;
+  if (hasNonProjectChanges) {
+    messageParts.push(
+      `## Non-Project Activity\n\n#### Agent Activity\n\n${nonProjectAgentActivity}\n#### Database Changes\n\n${nonProjectDbChanges}`
+    );
   }
 
   // 9. Deliver daily summary
@@ -704,6 +707,13 @@ export function buildAndDeliverMemoryUpdate(
     return;
   }
 
+  // Embed summary content inline so the Narrator doesn't need read tool calls
+  const summaryEntries = summaryFiles.map((f) => {
+    const content = readFileSync(f, 'utf-8');
+    const filename = basename(f);
+    return `### ${filename}\n\n${content}`;
+  });
+
   const message = `[Scheduled task: memory-update]
 
 memory_file: ${memoryFile}
@@ -712,8 +722,9 @@ new_run_ts: ${newRunTs}
 
 IMPORTANT: After writing memory.md, you MUST set last_narrator_update_ts to exactly "${newRunTs}" (UTC ISO 8601) in the frontmatter of ${memoryFile}. This advances the cursor for the next run.
 
-Daily summaries to incorporate:
-${summaryFiles.map((f) => `- ${f}`).join('\n')}`;
+## Daily summaries to incorporate
+
+${summaryEntries.join('\n\n')}`;
 
   narratorHost.deliverMessage(message, {
     sender: 0,

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -625,9 +625,8 @@ ${dailySummaryContent}`,
     hasActivity(pd.agentActivity, pd.dbChanges)
   );
   const hasNonProjectChanges = hasActivity(nonProjectAgentActivity, nonProjectDbChanges);
-  const hasDailySummaryContent = dailySummaryContent !== '(none)';
 
-  if (!hasProjectChanges && !hasNonProjectChanges && !hasDailySummaryContent) {
+  if (!hasProjectChanges && !hasNonProjectChanges) {
     console.log('[Scheduler] No activity since last run, skipping daily-summary');
     return;
   }


### PR DESCRIPTION
## Summary
- **Fixed daily-summary skip guard**: delivery is now skipped only when no fresh activity (agent JSONL entries or DB changes) exists in the time window. Previously, any existing file content (even just frontmatter from file creation) caused the guard to pass, delivering empty-window messages that the narrator would overwrite with skeleton content.
- **Embed daily summary content in memory-update messages**: `buildAndDeliverMemoryUpdate` now reads each daily summary file and embeds its content inline in the message, so the narrator can incorporate summaries without needing to read files separately.
- **Preserve chat cache across provider reinit**: added `if (!this._chatCache)` guard in `host.ts` `initialize()` to prevent the chat message history from being discarded during `reinitializeWithProvider`.
- **Filter inactive projects**: skip projects whose conductor is archived when building daily-summary project sections.
- **Updated scheduler docs**: precise description of the skip behavior and memory-update content embedding.
- **Updated narrator prompt**: memory-update workflow reflects that daily summary content arrives embedded in the message.
- Removed stale `chat-history.json` references from the gitignore template and docs.
- Fixed `.gitignore` tree comment in `agents.md`.

## Test plan
- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (376 tests, including new daily-summary skip guard and chat cache preservation tests)