### PR TITLE
feat: configure private npm org publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: 'https://registry.npmjs.org'
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - run: pnpm check
+
+      - run: pnpm test
+
+      - run: pnpm -r publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
 
       - run: pnpm test
 
+      - run: for pkg in packages/*/; do cp LICENSE "$pkg"; done
+
       - run: pnpm -r publish --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
 name: Release
 
 on:
-  push:
-    tags: ['v*']
+  release:
+    types: [published]
 
 jobs:
   publish:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,8 @@ pnpm test:watch           # Run tests in watch mode
 Build individual packages:
 
 ```bash
-pnpm --filter @system2/server build
-pnpm --filter @system2/cli build
+pnpm --filter @dscarabelli/server build
+pnpm --filter @dscarabelli/cli build
 ```
 
 ## Before Committing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Before submitting a PR, ensure:
 
 - Node.js >= 20
 - pnpm >= 8
-- System2 installed globally (`npm install -g @system2/cli`) and onboarded (`system2 onboard`)
+- System2 installed globally (`npm install -g @dscarabelli/cli`) and onboarded (`system2 onboard`)
 
 ### Initial Setup
 
@@ -158,7 +158,7 @@ This starts Vite on `http://localhost:3001`. Open this URL in your browser.
 |--------|------------|------------|
 | UI components (`packages/ui/src/`) | Yes | Saves automatically reflect in the browser |
 | Server code (`packages/server/src/`) | No | Rebuild and restart: `pnpm build && system2 stop && system2 start` |
-| CLI code (`packages/cli/src/`) | No | Rebuild: `pnpm --filter @system2/cli build` |
+| CLI code (`packages/cli/src/`) | No | Rebuild: `pnpm --filter @dscarabelli/cli build` |
 | Shared types (`packages/shared/src/`) | No | Rebuild: `pnpm build` (all packages depend on it) |
 
 ### Commands Reference
@@ -195,8 +195,8 @@ Build order: `shared` → `server` + `ui` (parallel) → `cli`
 ### Building Individual Packages
 
 ```bash
-pnpm --filter @system2/server build   # Build only server
-pnpm --filter @system2/cli build      # Build only CLI
+pnpm --filter @dscarabelli/server build   # Build only server
+pnpm --filter @dscarabelli/cli build      # Build only CLI
 ```
 
 ## Code Quality

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,7 @@ Thank you for your interest in contributing to System2! This document provides g
   - [Commands](#commands)
   - [Formatting Rules](#formatting-rules)
 - [Testing](#testing)
+- [Releasing](#releasing)
 - [Before Committing](#before-committing)
 - [Commit Messages](#commit-messages)
 - [Code Review Process](#code-review-process)
@@ -259,6 +260,27 @@ When adding new functionality, add tests for any exported logic — especially p
 ### CI
 
 A GitHub Actions workflow runs on every push and PR. It executes `pnpm check`, `pnpm typecheck`, `pnpm build`, and `pnpm test`. A local pre-push git hook runs the same checks before code leaves your machine.
+
+## Releasing
+
+Packages are published to npm under the `@dscarabelli` scope (private, restricted access). Publishing is automated via GitHub Actions.
+
+### How to release
+
+1. Bump the `version` field in all four `packages/*/package.json` files to the same version.
+2. Commit the version bump: `git commit -m "chore: bump version to 0.2.0"`
+3. Push to `main`.
+4. Go to **GitHub > Releases > Create a new release**.
+5. Create a new tag matching the version (e.g., `v0.2.0`), write release notes, and click **Publish release**.
+6. The `release.yml` workflow runs automatically: builds, tests, and publishes all packages to npm.
+
+### Adding users
+
+To grant someone install access without exposing source code:
+
+1. Go to **npmjs.com > Your org > Members**.
+2. Invite them as a **read-only** member.
+3. They run `npm login`, then `npm install -g @dscarabelli/cli`.
 
 ## Before Committing
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Copyright (c) 2024-2026 Diego Scarabelli. All rights reserved.
+
+This software and associated documentation files (the "Software") are proprietary
+and confidential. Unauthorized copying, distribution, modification, or use of this
+Software, via any medium, is strictly prohibited.
+
+The Software is provided under a commercial license. Use of the Software requires
+a valid license agreement. Contact the copyright holder for licensing information.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,10 +10,10 @@ For installation and usage, see the [project README](../README.md).
 
 ## Packages
 
-- [@system2/shared](packages/shared.md): The TypeScript types and interfaces that all other packages depend on.
-- [@system2/server](packages/server.md): The main runtime, hosting agents, serving the UI over HTTP and WebSocket, and running scheduled jobs.
-- [@system2/cli](packages/cli.md): Command-line tool for managing the server (initial setup, starting, stopping, checking status).
-- [@system2/ui](packages/ui.md): The browser-based chat interface where you interact with the Guide agent and view artifacts.
+- [@dscarabelli/shared](packages/shared.md): The TypeScript types and interfaces that all other packages depend on.
+- [@dscarabelli/server](packages/server.md): The main runtime, hosting agents, serving the UI over HTTP and WebSocket, and running scheduled jobs.
+- [@dscarabelli/cli](packages/cli.md): Command-line tool for managing the server (initial setup, starting, stopping, checking status).
+- [@dscarabelli/ui](packages/ui.md): The browser-based chat interface where you interact with the Guide agent and view artifacts.
 
 ## Core Systems
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -61,10 +61,10 @@ All runtime state lives in `~/.system2/`. See [Configuration](configuration.md) 
 ```
 system2/
 ├── packages/
-│   ├── shared/    @system2/shared    Shared TypeScript types
-│   ├── server/    @system2/server    HTTP/WS server + agent runtime
-│   ├── ui/        @system2/ui        React chat interface
-│   └── cli/       @system2/cli       CLI entry point
+│   ├── shared/    @dscarabelli/shared    Shared TypeScript types
+│   ├── server/    @dscarabelli/server    HTTP/WS server + agent runtime
+│   ├── ui/        @dscarabelli/ui        React chat interface
+│   └── cli/       @dscarabelli/cli       CLI entry point
 ├── docs/                              Developer documentation
 ├── biome.json                         Formatting/linting config
 ├── tsconfig.json                      Root TypeScript config

--- a/docs/packages/cli.md
+++ b/docs/packages/cli.md
@@ -1,4 +1,4 @@
-# @system2/cli
+# @dscarabelli/cli
 
 Command-line interface for managing the System2 server lifecycle. Provides interactive onboarding, daemon management, and status reporting.
 

--- a/docs/packages/server.md
+++ b/docs/packages/server.md
@@ -1,4 +1,4 @@
-# @system2/server
+# @dscarabelli/server
 
 HTTP + WebSocket server that hosts all agents (Guide and Narrator at startup, others spawned dynamically), serves the UI, and runs the scheduler.
 

--- a/docs/packages/shared.md
+++ b/docs/packages/shared.md
@@ -1,10 +1,10 @@
-# @system2/shared
+# @dscarabelli/shared
 
 Shared TypeScript type definitions used by all other System2 packages. This package has no runtime dependencies: it exports only types.
 
 **Source:** `packages/shared/src/`
 **Build:** [tsup](https://tsup.egoist.dev/) -> `dist/index.js`
-**Import:** `import { ChatMessage, LlmConfig, ... } from '@system2/shared'`
+**Import:** `import { ChatMessage, LlmConfig, ... } from '@dscarabelli/shared'`
 
 ## Type Modules
 

--- a/docs/packages/ui.md
+++ b/docs/packages/ui.md
@@ -1,4 +1,4 @@
-# @system2/ui
+# @dscarabelli/ui
 
 React web interface providing a real-time chat experience with artifact display. Chat history is managed server-side: the UI is stateless and receives history on WebSocket connect.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@system2/cli",
+  "name": "@dscarabelli/cli",
   "version": "0.1.0",
   "license": "SEE LICENSE IN LICENSE",
   "publishConfig": {
@@ -21,9 +21,9 @@
   "dependencies": {
     "@clack/prompts": "^1.0.1",
     "@iarna/toml": "^2.2.5",
-    "@system2/server": "workspace:*",
-    "@system2/shared": "workspace:*",
-    "@system2/ui": "workspace:*",
+    "@dscarabelli/server": "workspace:*",
+    "@dscarabelli/shared": "workspace:*",
+    "@dscarabelli/ui": "workspace:*",
     "commander": "^11.1.0",
     "dotenv": "^16.3.1",
     "gray-matter": "^4.0.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@system2/cli",
   "version": "0.1.0",
+  "license": "SEE LICENSE IN LICENSE",
+  "publishConfig": {
+    "access": "restricted"
+  },
   "type": "module",
   "bin": {
     "system2": "./dist/index.js"
@@ -19,6 +23,7 @@
     "@iarna/toml": "^2.2.5",
     "@system2/server": "workspace:*",
     "@system2/shared": "workspace:*",
+    "@system2/ui": "workspace:*",
     "commander": "^11.1.0",
     "dotenv": "^16.3.1",
     "gray-matter": "^4.0.3",

--- a/packages/cli/src/commands/onboard.ts
+++ b/packages/cli/src/commands/onboard.ts
@@ -10,7 +10,13 @@ import { existsSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import * as p from '@clack/prompts';
-import type { LlmConfig, LlmKey, LlmProvider, ServicesConfig, ToolsConfig } from '@system2/shared';
+import type {
+  LlmConfig,
+  LlmKey,
+  LlmProvider,
+  ServicesConfig,
+  ToolsConfig,
+} from '@dscarabelli/shared';
 import pc from 'picocolors';
 import { buildConfigToml, CONFIG_FILE, SYSTEM2_DIR, writeConfigFile } from '../utils/config.js';
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -7,7 +7,8 @@
 
 import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import open from 'open';
 import { backupIfNeeded } from '../utils/backup.js';
 import { loadConfig, SYSTEM2_DIR } from '../utils/config.js';
@@ -86,7 +87,10 @@ export async function start(options: {
     const server = new Server({
       port,
       dbPath: join(SYSTEM2_DIR, 'app.db'),
-      uiDistPath: join(import.meta.dirname, '..', '..', 'ui', 'dist'),
+      uiDistPath: join(
+        dirname(createRequire(import.meta.url).resolve('@system2/ui/package.json')),
+        'dist'
+      ),
       llmConfig: config.llm,
       servicesConfig: config.services,
       toolsConfig: config.tools,

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -83,12 +83,12 @@ export async function start(options: {
     console.log('Press Ctrl+C to stop');
     console.log('');
 
-    const { Server } = await import('@system2/server');
+    const { Server } = await import('@dscarabelli/server');
     const server = new Server({
       port,
       dbPath: join(SYSTEM2_DIR, 'app.db'),
       uiDistPath: join(
-        dirname(createRequire(import.meta.url).resolve('@system2/ui/package.json')),
+        dirname(createRequire(import.meta.url).resolve('@dscarabelli/ui/package.json')),
         'dist'
       ),
       llmConfig: config.llm,

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -11,14 +11,14 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import TOML from '@iarna/toml';
 import type {
   LlmConfig,
   LlmProvider,
   LlmProviderConfig,
   ServicesConfig,
   ToolsConfig,
-} from '@system2/shared';
+} from '@dscarabelli/shared';
+import TOML from '@iarna/toml';
 
 export const SYSTEM2_DIR = join(homedir(), '.system2');
 export const CONFIG_FILE = join(SYSTEM2_DIR, 'config.toml');

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     'url',
     'better-sqlite3',
     // Server dependencies with CJS code
-    '@system2/server',
+    '@dscarabelli/server',
     '@mariozechner/pi-coding-agent',
     '@mariozechner/pi-agent-core',
     '@mariozechner/pi-ai',

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@system2/server",
+  "name": "@dscarabelli/server",
   "version": "0.1.0",
   "license": "SEE LICENSE IN LICENSE",
   "publishConfig": {
@@ -24,7 +24,7 @@
     "@mariozechner/pi-coding-agent": "^0.55.3",
     "@mozilla/readability": "^0.6.0",
     "@sinclair/typebox": "^0.32.0",
-    "@system2/shared": "workspace:*",
+    "@dscarabelli/shared": "workspace:*",
     "better-sqlite3": "^11.10.0",
     "croner": "^10.0.1",
     "dotenv": "^16.3.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@system2/server",
   "version": "0.1.0",
+  "license": "SEE LICENSE IN LICENSE",
+  "publishConfig": {
+    "access": "restricted"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/server/src/agents/auth-resolver.test.ts
+++ b/packages/server/src/agents/auth-resolver.test.ts
@@ -1,4 +1,4 @@
-import type { LlmConfig } from '@system2/shared';
+import type { LlmConfig } from '@dscarabelli/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AuthResolver } from './auth-resolver.js';
 

--- a/packages/server/src/agents/auth-resolver.ts
+++ b/packages/server/src/agents/auth-resolver.ts
@@ -11,8 +11,8 @@
  * 4. Keys in cooldown recover after the cooldown period expires
  */
 
+import type { LlmConfig, LlmKey, LlmProvider } from '@dscarabelli/shared';
 import { AuthStorage } from '@mariozechner/pi-coding-agent';
-import type { LlmConfig, LlmKey, LlmProvider } from '@system2/shared';
 
 /** Default cooldown period: 5 minutes */
 const DEFAULT_COOLDOWN_MS = 5 * 60 * 1000;

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -9,7 +9,7 @@
 import { mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { LlmConfig } from '@system2/shared';
+import type { LlmConfig } from '@dscarabelli/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AgentHost } from './host.js';
 import type { AgentRegistry } from './registry.js';

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -17,6 +17,7 @@ import {
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { LlmConfig, LlmProvider, ServicesConfig, ToolsConfig } from '@dscarabelli/shared';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import {
   type AgentSession,
@@ -27,7 +28,6 @@ import {
   SessionManager,
   SettingsManager,
 } from '@mariozechner/pi-coding-agent';
-import type { LlmConfig, LlmProvider, ServicesConfig, ToolsConfig } from '@system2/shared';
 import matter from 'gray-matter';
 import { MessageHistory } from '../chat/history.js';
 import type { DatabaseClient } from '../db/client.js';

--- a/packages/server/src/agents/tools/message-agent.test.ts
+++ b/packages/server/src/agents/tools/message-agent.test.ts
@@ -1,4 +1,4 @@
-import type { Agent } from '@system2/shared';
+import type { Agent } from '@dscarabelli/shared';
 import { describe, expect, it, vi } from 'vitest';
 import type { DatabaseClient } from '../../db/client.js';
 import type { AgentRegistry } from '../registry.js';

--- a/packages/server/src/agents/tools/resurrect-agent.test.ts
+++ b/packages/server/src/agents/tools/resurrect-agent.test.ts
@@ -1,4 +1,4 @@
-import type { Agent } from '@system2/shared';
+import type { Agent } from '@dscarabelli/shared';
 import { describe, expect, it, vi } from 'vitest';
 import type { DatabaseClient } from '../../db/client.js';
 import { createResurrectAgentTool } from './resurrect-agent.js';

--- a/packages/server/src/agents/tools/spawn-agent.test.ts
+++ b/packages/server/src/agents/tools/spawn-agent.test.ts
@@ -1,4 +1,4 @@
-import type { Agent, Project } from '@system2/shared';
+import type { Agent, Project } from '@dscarabelli/shared';
 import { describe, expect, it, vi } from 'vitest';
 import type { DatabaseClient } from '../../db/client.js';
 import { createSpawnAgentTool } from './spawn-agent.js';

--- a/packages/server/src/agents/tools/spawn-agent.ts
+++ b/packages/server/src/agents/tools/spawn-agent.ts
@@ -8,9 +8,9 @@
  * registration, and initial message delivery.
  */
 
+import type { Agent } from '@dscarabelli/shared';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { Type } from '@sinclair/typebox';
-import type { Agent } from '@system2/shared';
 import type { DatabaseClient } from '../../db/client.js';
 
 export type AgentSpawner = (

--- a/packages/server/src/agents/tools/terminate-agent.test.ts
+++ b/packages/server/src/agents/tools/terminate-agent.test.ts
@@ -1,4 +1,4 @@
-import type { Agent } from '@system2/shared';
+import type { Agent } from '@dscarabelli/shared';
 import { describe, expect, it, vi } from 'vitest';
 import type { DatabaseClient } from '../../db/client.js';
 import type { AgentRegistry } from '../registry.js';

--- a/packages/server/src/agents/tools/trigger-project-story.test.ts
+++ b/packages/server/src/agents/tools/trigger-project-story.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'node:fs';
-import type { Agent, Project, Task } from '@system2/shared';
+import type { Agent, Project, Task } from '@dscarabelli/shared';
 import { describe, expect, it, type Mock, vi } from 'vitest';
 import type { DatabaseClient } from '../../db/client.js';
 import type { AgentRegistry } from '../registry.js';

--- a/packages/server/src/agents/tools/write-system2-db.test.ts
+++ b/packages/server/src/agents/tools/write-system2-db.test.ts
@@ -1,4 +1,4 @@
-import type { Agent, Artifact, Project, Task, TaskComment, TaskLink } from '@system2/shared';
+import type { Agent, Artifact, Project, Task, TaskComment, TaskLink } from '@dscarabelli/shared';
 import { describe, expect, it } from 'vitest';
 import type { DatabaseClient } from '../../db/client.js';
 import { createWriteSystem2DbTool } from './write-system2-db.js';

--- a/packages/server/src/chat/history.test.ts
+++ b/packages/server/src/chat/history.test.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { ChatMessage } from '@system2/shared';
+import type { ChatMessage } from '@dscarabelli/shared';
 import { afterEach, describe, expect, it } from 'vitest';
 import { MessageHistory } from './history.js';
 

--- a/packages/server/src/chat/history.ts
+++ b/packages/server/src/chat/history.ts
@@ -8,7 +8,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
-import type { ChatMessage } from '@system2/shared';
+import type { ChatMessage } from '@dscarabelli/shared';
 
 export class MessageHistory {
   private messages: ChatMessage[] = [];

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -7,7 +7,7 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { Agent, Artifact, Project, Task, TaskComment, TaskLink } from '@system2/shared';
+import type { Agent, Artifact, Project, Task, TaskComment, TaskLink } from '@dscarabelli/shared';
 import Database from 'better-sqlite3';
 
 const __filename = fileURLToPath(import.meta.url);

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -9,8 +9,6 @@ import { createServer } from 'node:http';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join, normalize } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { Api, Model } from '@mariozechner/pi-ai';
-import { type AgentSessionEvent, ModelRegistry } from '@mariozechner/pi-coding-agent';
 import type {
   ChatConfig,
   ChatMessage,
@@ -19,7 +17,9 @@ import type {
   SchedulerConfig,
   ServicesConfig,
   ToolsConfig,
-} from '@system2/shared';
+} from '@dscarabelli/shared';
+import type { Api, Model } from '@mariozechner/pi-ai';
+import { type AgentSessionEvent, ModelRegistry } from '@mariozechner/pi-coding-agent';
 import express from 'express';
 import matter from 'gray-matter';
 import { WebSocketServer } from 'ws';
@@ -182,7 +182,7 @@ export class Server {
       try {
         const agents = this.db.query(
           "SELECT a.id, a.role, a.project, a.status, a.created_at, p.name AS project_name FROM agent a LEFT JOIN project p ON a.project = p.id WHERE a.status != 'archived' ORDER BY a.id"
-        ) as (import('@system2/shared').Agent & { project_name: string | null })[];
+        ) as (import('@dscarabelli/shared').Agent & { project_name: string | null })[];
 
         const result = agents.map((agent) => {
           const host = this.agentRegistry.get(agent.id);
@@ -624,7 +624,7 @@ export class Server {
   private async restoreActiveAgents(): Promise<void> {
     const agents = this.db.query(
       "SELECT * FROM agent WHERE status != 'archived' AND role NOT IN ('guide', 'narrator') ORDER BY id"
-    ) as import('@system2/shared').Agent[];
+    ) as import('@dscarabelli/shared').Agent[];
     if (agents.length === 0) return;
 
     console.log(`[Server] Restoring ${agents.length} agent(s)...`);

--- a/packages/server/src/websocket/handler.ts
+++ b/packages/server/src/websocket/handler.ts
@@ -8,8 +8,8 @@
  */
 
 import { type FSWatcher, watch } from 'node:fs';
+import type { ClientMessage, ServerMessage } from '@dscarabelli/shared';
 import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
-import type { ClientMessage, ServerMessage } from '@system2/shared';
 import type { WebSocket, WebSocketServer } from 'ws';
 import type { AgentHost } from '../agents/host.js';
 import type { AgentRegistry } from '../agents/registry.js';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@system2/shared",
   "version": "0.1.0",
+  "license": "SEE LICENSE IN LICENSE",
+  "publishConfig": {
+    "access": "restricted"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@system2/shared",
+  "name": "@dscarabelli/shared",
   "version": "0.1.0",
   "license": "SEE LICENSE IN LICENSE",
   "publishConfig": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@system2/ui",
   "version": "0.1.0",
+  "license": "SEE LICENSE IN LICENSE",
+  "publishConfig": {
+    "access": "restricted"
+  },
   "type": "module",
   "files": [
     "dist"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@system2/ui",
+  "name": "@dscarabelli/ui",
   "version": "0.1.0",
   "license": "SEE LICENSE IN LICENSE",
   "publishConfig": {
@@ -19,7 +19,7 @@
   "dependencies": {
     "@primer/octicons-react": "^19.22.0",
     "@primer/react": "^36.8.0",
-    "@system2/shared": "workspace:*",
+    "@dscarabelli/shared": "workspace:*",
     "@tsparticles/engine": "^3.0.2",
     "@tsparticles/react": "^3.0.0",
     "@tsparticles/slim": "^3.9.1",

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -7,7 +7,7 @@
  * Routes messages to/from per-agent state via agentId.
  */
 
-import type { ClientMessage, ServerMessage } from '@system2/shared';
+import type { ClientMessage, ServerMessage } from '@dscarabelli/shared';
 import { useCallback, useEffect, useRef } from 'react';
 import { useArtifactStore } from '../stores/artifact';
 import { useChatStore } from '../stores/chat';

--- a/packages/ui/src/stores/chat.ts
+++ b/packages/ui/src/stores/chat.ts
@@ -11,7 +11,12 @@
  * Active agent selection is persisted to localStorage so it survives refreshes.
  */
 
-import type { ChatMessage, ChatThinkingBlock, ChatToolCall, ChatTurnEvent } from '@system2/shared';
+import type {
+  ChatMessage,
+  ChatThinkingBlock,
+  ChatToolCall,
+  ChatTurnEvent,
+} from '@dscarabelli/shared';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@system2/shared':
         specifier: workspace:*
         version: link:../shared
+      '@system2/ui':
+        specifier: workspace:*
+        version: link:../ui
       commander:
         specifier: ^11.1.0
         version: 11.1.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,18 +32,18 @@ importers:
       '@clack/prompts':
         specifier: ^1.0.1
         version: 1.1.0
+      '@dscarabelli/server':
+        specifier: workspace:*
+        version: link:../server
+      '@dscarabelli/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@dscarabelli/ui':
+        specifier: workspace:*
+        version: link:../ui
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
-      '@system2/server':
-        specifier: workspace:*
-        version: link:../server
-      '@system2/shared':
-        specifier: workspace:*
-        version: link:../shared
-      '@system2/ui':
-        specifier: workspace:*
-        version: link:../ui
       commander:
         specifier: ^11.1.0
         version: 11.1.0
@@ -72,6 +72,9 @@ importers:
 
   packages/server:
     dependencies:
+      '@dscarabelli/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@mariozechner/pi-agent-core':
         specifier: ^0.55.3
         version: 0.55.4(ws@8.19.0)(zod@4.3.6)
@@ -87,9 +90,6 @@ importers:
       '@sinclair/typebox':
         specifier: ^0.32.0
         version: 0.32.35
-      '@system2/shared':
-        specifier: workspace:*
-        version: link:../shared
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -139,15 +139,15 @@ importers:
 
   packages/ui:
     dependencies:
+      '@dscarabelli/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@primer/octicons-react':
         specifier: ^19.22.0
         version: 19.22.0(react@18.3.1)
       '@primer/react':
         specifier: ^36.8.0
         version: 36.27.0(@types/react-dom@18.3.7)(@types/react@18.3.28)(react-dom@18.3.1)(react@18.3.1)(styled-components@5.3.11)
-      '@system2/shared':
-        specifier: workspace:*
-        version: link:../shared
       '@tsparticles/engine':
         specifier: ^3.0.2
         version: 3.9.1


### PR DESCRIPTION
## Summary

- Add `publishConfig` (restricted access) and proprietary `LICENSE` to all 4 packages
- Rename npm scope from `@system2` to `@dscarabelli` across the entire codebase (source, configs, docs, lockfile)
- Fix CLI's UI dist path resolution to use `createRequire` instead of a hardcoded relative path (works both in monorepo and when installed from npm)
- Add GitHub Actions release workflow that publishes to npm on `v*` tag push

## Setup required before first publish

1. Create the `@dscarabelli` npm org (npmjs.com/org/create, Teams plan)
2. Generate an npm automation token from npm account settings
3. Add it as `NPM_TOKEN` in GitHub repo secrets (Settings > Secrets > Actions)
4. To publish: bump versions, then `git tag v0.1.0 && git push --tags`

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm check` passes
- [x] `pnpm test` passes (363 tests)
- [x] Zero `@system2/` references remain outside node_modules/dist
- [ ] After merge: create npm org, add secret, tag and publish
