### PR TITLE
fix: resolve project directories by ID prefix to survive title renames

### DIFF
--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -41,7 +41,7 @@ The check lives in each job handler, not in the Scheduler class, so future jobs 
 
 For each active project (those with a non-archived Conductor):
 
-1. Ensure `~/.system2/projects/{id}_{name}/` directory exists
+1. Resolve `~/.system2/projects/{id}_{slug}/` directory via `resolveProjectDir()` (finds existing folder by ID prefix, renames if the project title changed, creates if missing, and patches stale `project_name` in `log.md` frontmatter)
 2. Create `log.md` with YAML frontmatter if it doesn't exist
 3. Read most recent `log.md` content (last 10,000 characters via `readTailChars`)
 4. Collect activity from all agents involved in the project (project-scoped agents + Guide; Narrator is excluded via `projectLogSystemAgents` to prevent recursive embedding). JSONL entries are stripped before injection: thinking blocks (type `thinking`) are dropped entirely; metadata fields `thoughtSignature`, `usage`, `api`, `provider`, `model`, and `details` are removed; tool call argument values and tool result content are truncated to 100 chars.

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -15,7 +15,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { LlmConfig, LlmProvider, ServicesConfig, ToolsConfig } from '@dscarabelli/shared';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
@@ -31,6 +31,7 @@ import {
 import matter from 'gray-matter';
 import { MessageHistory } from '../chat/history.js';
 import type { DatabaseClient } from '../db/client.js';
+import { resolveProjectDir } from '../projects/dir.js';
 import { AuthResolver } from './auth-resolver.js';
 import type { AgentRegistry } from './registry.js';
 import { calculateDelay, categorizeError, shouldFailover, shouldRetry, sleep } from './retry.js';
@@ -160,10 +161,9 @@ export class AgentHost {
     if (this.agentProject !== null) {
       const projectRecord = this.db.getProject(this.agentProject);
       if (projectRecord) {
-        this.agentProjectDirName = `${projectRecord.id}_${projectRecord.name
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, '-')
-          .replace(/^-|-$/g, '')}`;
+        const projectsDir = join(SYSTEM2_DIR, 'projects');
+        const projectDir = resolveProjectDir(projectsDir, projectRecord.id, projectRecord.name);
+        this.agentProjectDirName = basename(projectDir);
       }
     }
     this.agentRole = agentRecord.role;

--- a/packages/server/src/agents/tools/trigger-project-story.ts
+++ b/packages/server/src/agents/tools/trigger-project-story.ts
@@ -18,6 +18,7 @@ import { join } from 'node:path';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { Type } from '@sinclair/typebox';
 import type { DatabaseClient } from '../../db/client.js';
+import { resolveProjectDir } from '../../projects/dir.js';
 import {
   collectAgentActivity,
   collectProjectDbChanges,
@@ -107,12 +108,12 @@ export function createTriggerProjectStoryTool(
           };
         }
 
-        // Compute project slug and paths
-        const projectSlug = `${project.id}_${project.name
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, '-')
-          .replace(/^-|-$/g, '')}`;
-        const projectDir = join(SYSTEM2_DIR, 'projects', projectSlug);
+        // Resolve project directory (handles renames)
+        const projectDir = resolveProjectDir(
+          join(SYSTEM2_DIR, 'projects'),
+          project.id,
+          project.name
+        );
         const logFile = join(projectDir, 'log.md');
 
         // Read timestamps

--- a/packages/server/src/projects/dir.test.ts
+++ b/packages/server/src/projects/dir.test.ts
@@ -1,0 +1,92 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resolveProjectDir } from './dir.js';
+
+describe('resolveProjectDir', () => {
+  let projectsDir: string;
+
+  beforeEach(() => {
+    projectsDir = mkdtempSync(join(tmpdir(), 'system2-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(projectsDir, { recursive: true, force: true });
+  });
+
+  it('creates a new folder when none exists', () => {
+    const result = resolveProjectDir(projectsDir, 1, 'My Project');
+    expect(result).toBe(join(projectsDir, '1_my-project'));
+    expect(existsSync(result)).toBe(true);
+  });
+
+  it('returns existing folder when slug matches', () => {
+    mkdirSync(join(projectsDir, '1_my-project'));
+    const result = resolveProjectDir(projectsDir, 1, 'My Project');
+    expect(result).toBe(join(projectsDir, '1_my-project'));
+  });
+
+  it('renames folder when project title changed', () => {
+    const oldDir = join(projectsDir, '1_old-name');
+    mkdirSync(oldDir);
+    writeFileSync(join(oldDir, 'log.md'), 'some content');
+
+    const result = resolveProjectDir(projectsDir, 1, 'New Name');
+    expect(result).toBe(join(projectsDir, '1_new-name'));
+    expect(existsSync(join(projectsDir, '1_new-name', 'log.md'))).toBe(true);
+    expect(existsSync(oldDir)).toBe(false);
+  });
+
+  it('renames the most recent folder when multiple exist', () => {
+    // Create two folders for the same project ID (the bug scenario)
+    const older = join(projectsDir, '1_first-name');
+    const newer = join(projectsDir, '1_second-name');
+    mkdirSync(older);
+    writeFileSync(join(older, 'old-file.txt'), 'old');
+    // Ensure different mtimes
+    mkdirSync(newer);
+    writeFileSync(join(newer, 'new-file.txt'), 'new');
+
+    const result = resolveProjectDir(projectsDir, 1, 'Final Name');
+    expect(result).toBe(join(projectsDir, '1_final-name'));
+    // Most recent folder (1_second-name) was renamed, older one left as-is
+    expect(existsSync(join(projectsDir, '1_final-name', 'new-file.txt'))).toBe(true);
+    expect(existsSync(older)).toBe(true);
+  });
+
+  it('does not touch folders belonging to other project IDs', () => {
+    mkdirSync(join(projectsDir, '2_other-project'));
+    const result = resolveProjectDir(projectsDir, 1, 'My Project');
+    expect(result).toBe(join(projectsDir, '1_my-project'));
+    expect(existsSync(join(projectsDir, '2_other-project'))).toBe(true);
+  });
+
+  it('creates projectsDir when it does not exist', () => {
+    const nested = join(projectsDir, 'sub', 'projects');
+    const result = resolveProjectDir(nested, 1, 'Deep Project');
+    expect(result).toBe(join(nested, '1_deep-project'));
+    expect(existsSync(result)).toBe(true);
+  });
+
+  it('patches stale project_name in log.md frontmatter after rename', () => {
+    const oldDir = join(projectsDir, '1_old-name');
+    mkdirSync(oldDir);
+    writeFileSync(
+      join(oldDir, 'log.md'),
+      '---\nlast_narrator_update_ts: 2026-03-20T00:00:00Z\nproject_id: 1\nproject_name: Old Name\n---\n## Entry\nSome log content\n'
+    );
+
+    resolveProjectDir(projectsDir, 1, 'New Name');
+
+    const content = readFileSync(join(projectsDir, '1_new-name', 'log.md'), 'utf-8');
+    expect(content).toContain('project_name: New Name');
+    expect(content).toContain('project_id: 1');
+    expect(content).toContain('Some log content');
+  });
+
+  it('slugifies special characters correctly', () => {
+    const result = resolveProjectDir(projectsDir, 3, 'Medicaid Fraud Anomaly Detection (CA)');
+    expect(result).toBe(join(projectsDir, '3_medicaid-fraud-anomaly-detection-ca'));
+  });
+});

--- a/packages/server/src/projects/dir.test.ts
+++ b/packages/server/src/projects/dir.test.ts
@@ -1,4 +1,12 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -44,7 +52,9 @@ describe('resolveProjectDir', () => {
     const newer = join(projectsDir, '1_second-name');
     mkdirSync(older);
     writeFileSync(join(older, 'old-file.txt'), 'old');
-    // Ensure different mtimes
+    // Force older mtime so ordering is deterministic
+    const past = new Date(Date.now() - 10_000);
+    utimesSync(older, past, past);
     mkdirSync(newer);
     writeFileSync(join(newer, 'new-file.txt'), 'new');
 

--- a/packages/server/src/projects/dir.ts
+++ b/packages/server/src/projects/dir.ts
@@ -48,13 +48,18 @@ export function resolveProjectDir(
     return canonicalPath;
   }
 
-  // Scan for any existing {id}_* folders
+  // Scan for any existing {id}_* folders, collecting stats in one pass
   const prefix = `${projectId}_`;
-  let candidates: string[] = [];
+  type DirEntry = { name: string; mtimeMs: number };
+  const candidates: DirEntry[] = [];
   if (existsSync(projectsDir)) {
-    candidates = readdirSync(projectsDir).filter(
-      (entry) => entry.startsWith(prefix) && statSync(join(projectsDir, entry)).isDirectory()
-    );
+    for (const entry of readdirSync(projectsDir)) {
+      if (!entry.startsWith(prefix)) continue;
+      const stats = statSync(join(projectsDir, entry));
+      if (stats.isDirectory()) {
+        candidates.push({ name: entry, mtimeMs: stats.mtimeMs });
+      }
+    }
   }
 
   if (candidates.length === 0) {
@@ -64,9 +69,7 @@ export function resolveProjectDir(
   }
 
   // Pick the most recently modified folder
-  const target = candidates
-    .map((name) => ({ name, mtime: statSync(join(projectsDir, name)).mtimeMs }))
-    .sort((a, b) => b.mtime - a.mtime)[0].name;
+  const target = candidates.sort((a, b) => b.mtimeMs - a.mtimeMs)[0].name;
 
   const targetPath = join(projectsDir, target);
 

--- a/packages/server/src/projects/dir.ts
+++ b/packages/server/src/projects/dir.ts
@@ -1,0 +1,87 @@
+/**
+ * Project Directory Resolution
+ *
+ * Resolves the filesystem directory for a project under ~/.system2/projects/.
+ * Directories use the format {id}_{slug} where the ID is stable and the slug
+ * is derived from the current project name. If the project was renamed, the
+ * existing directory is renamed to match.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+
+function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * Resolve (and ensure) the project directory for a given project ID and name.
+ *
+ * - If a matching `{id}_{slug}` folder exists, returns it.
+ * - If a folder with the right ID but stale slug exists, renames it and returns the new path.
+ * - If multiple `{id}_*` folders exist (leftover from a prior bug), uses the most recent
+ *   one and leaves the older ones untouched.
+ * - If no folder exists, creates one.
+ */
+export function resolveProjectDir(
+  projectsDir: string,
+  projectId: number,
+  projectName: string
+): string {
+  const slug = slugify(projectName);
+  const canonicalName = `${projectId}_${slug}`;
+  const canonicalPath = join(projectsDir, canonicalName);
+
+  // Fast path: canonical folder already exists
+  if (existsSync(canonicalPath)) {
+    return canonicalPath;
+  }
+
+  // Scan for any existing {id}_* folders
+  const prefix = `${projectId}_`;
+  let candidates: string[] = [];
+  if (existsSync(projectsDir)) {
+    candidates = readdirSync(projectsDir).filter(
+      (entry) => entry.startsWith(prefix) && statSync(join(projectsDir, entry)).isDirectory()
+    );
+  }
+
+  if (candidates.length === 0) {
+    // No existing folder: create fresh
+    mkdirSync(canonicalPath, { recursive: true });
+    return canonicalPath;
+  }
+
+  // Pick the most recently modified folder
+  const target = candidates
+    .map((name) => ({ name, mtime: statSync(join(projectsDir, name)).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime)[0].name;
+
+  const targetPath = join(projectsDir, target);
+
+  // Rename to match current project name
+  renameSync(targetPath, canonicalPath);
+
+  // Patch stale project_name in log.md frontmatter
+  const logFile = join(canonicalPath, 'log.md');
+  if (existsSync(logFile)) {
+    const content = readFileSync(logFile, 'utf-8');
+    const updated = content.replace(/^project_name: .+$/m, () => `project_name: ${projectName}`);
+    if (updated !== content) {
+      writeFileSync(logFile, updated, 'utf-8');
+    }
+  }
+
+  return canonicalPath;
+}

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -12,6 +12,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 
 import { basename, join } from 'node:path';
 import type { AgentHost } from '../agents/host.js';
 import type { DatabaseClient } from '../db/client.js';
+import { resolveProjectDir } from '../projects/dir.js';
 import { isNetworkAvailable } from './network.js';
 import type { Scheduler } from './scheduler.js';
 
@@ -493,17 +494,8 @@ export function buildAndDeliverDailySummary(
   const projectDataList: ProjectActivityData[] = [];
 
   for (const project of activeProjects) {
-    const projectSlug = `${project.id}_${project.name
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-|-$/g, '')}`;
-    const projectDir = join(system2Dir, 'projects', projectSlug);
+    const projectDir = resolveProjectDir(join(system2Dir, 'projects'), project.id, project.name);
     const logFile = join(projectDir, 'log.md');
-
-    // Ensure project directory exists
-    if (!existsSync(projectDir)) {
-      mkdirSync(projectDir, { recursive: true });
-    }
 
     // Create log file if needed
     if (!existsSync(logFile)) {

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -501,7 +501,7 @@ export function buildAndDeliverDailySummary(
     if (!existsSync(logFile)) {
       writeFileSync(
         logFile,
-        `---\nlast_narrator_update_ts:\nproject_id: ${project.id}\nproject_name: ${project.name}\n---\n# Project Log — ${project.name}\n`,
+        `---\nlast_narrator_update_ts:\nproject_id: ${project.id}\nproject_name: ${project.name}\n---\n`,
         'utf-8'
       );
     }


### PR DESCRIPTION
## Summary

- Extract `resolveProjectDir()` helper that finds existing project folders by stable ID prefix (`{id}_*`) instead of recomputing the slug from the current DB title every time
- When a project is renamed, the existing folder is renamed to match (instead of creating a duplicate) and stale `project_name` in `log.md` frontmatter is patched
- If multiple `{id}_*` folders exist (leftover from prior bug), the most recent one is used and older ones are left untouched
- Replaces inline slug logic in `host.ts`, `jobs.ts`, and `trigger-project-story.ts`
- Adds 8 unit tests covering all resolution paths
- Updates `scheduler.md` to document the new behavior

## Context

When project #2 was renamed from "Medicaid Fraud Anomaly Detection (CA)" to "Medicaid Provider Spending Analysis", the scheduler created a new folder instead of reusing the existing one, orphaning all scripts, artifacts, and log entries.

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (384 tests, including 8 new ones for `resolveProjectDir`)
- [x] Pre-push hooks pass (lint, typecheck, tests)