### PR TITLE
fix: tighten narrator and agent communication instructions

### DIFF
--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -257,7 +257,7 @@ SELECT id, role, status, project FROM agent WHERE status = 'active';
 
 ### Communication Discipline
 
-- **Always reply.** If another agent sends you a question or a request, you must respond via `message_agent`. Do not leave messages unanswered.
+- **Always reply via `message_agent`.** When another agent sends you a question or a request, you must call `message_agent` to respond after completing the work. An assistant text output (chat message) is NOT a reply: the sender cannot see your chat output. Only `message_agent` delivers your response to them. Do not leave messages unanswered.
 - **Be direct and terse.** No pleasantries, no filler, no hedging. State facts, IDs, and next actions. Agent-to-agent messages are operational, not conversational.
 - **Reference IDs.** Every message should include the relevant project, task, and/or comment IDs so the recipient can look up context with a single query.
 - **Use the right channel.** Direct messages (`message_agent`) are for real-time coordination and urgent updates. Task comments (`createTaskComment`) are for the permanent record — decisions, results, blockers, progress.

--- a/packages/server/src/agents/library/narrator.md
+++ b/packages/server/src/agents/library/narrator.md
@@ -234,3 +234,4 @@ Do not output file content as assistant text. Use tools directly to read and wri
 - Don't execute pipelines or run queries against user databases
 - Don't analyze data: document what was already done
 - Don't interact with the user directly: you work in the background
+- Don't message the Guide after completing scheduled knowledge file updates (project-log, daily-summary, memory-update): these are routine background tasks that don't need notification

--- a/packages/server/src/agents/library/narrator.md
+++ b/packages/server/src/agents/library/narrator.md
@@ -50,7 +50,7 @@ The message contains pre-computed data: project ID and name, file path, timestam
 
 2. **Review provided data:** Read through Agent Activity (all agents involved, including Guide whose activity may span multiple projects; focus on what's relevant to this project) and Database Changes (project-scoped records).
 
-3. **Append narrative section:** Use `edit` with `append: true` to add a new timestamped section at the end of the file. Include a `commit_message: "project log: <project_name> YYYY-MM-DD HH:MM"`.
+3. **Append narrative section:** Use `edit` with `append: true` to add a new timestamped section at the end of the file. Do not include a `commit_message` yet.
 
    ```text
    ## YYYY-MM-DDTHH:MMZ
@@ -60,7 +60,7 @@ The message contains pre-computed data: project ID and name, file path, timestam
 
    Derive the heading timestamp from `new_run_ts` (already UTC). Never rewrite, restructure, or remove existing content in log files.
 
-4. **Update frontmatter:** Use `edit` (replace mode) to update `last_narrator_update_ts` to `new_run_ts` (UTC ISO 8601 format, e.g. `2026-03-13T16:00:00.002Z`) in the frontmatter.
+4. **Update frontmatter and commit:** Use `edit` (replace mode) to update `last_narrator_update_ts` to `new_run_ts` (UTC ISO 8601 format, e.g. `2026-03-13T16:00:00.002Z`) in the frontmatter. Include `commit_message: "project log: <project_name> YYYY-MM-DD HH:MM"` on this edit so both the appended narrative and the timestamp update are committed together.
 
    **Ordering matters:** Always append first (step 3), then update the timestamp (step 4). If the timestamp is updated first and the append fails, the cursor advances with no narrative written, losing that window's data.
 
@@ -94,7 +94,7 @@ Your job is to synthesize each section into a concise but comprehensive narrativ
 4. **Write the narrative section.** Check the "Current daily summary file content" in the message to determine whether the file already exists:
 
    - **New file** (content is empty): Use `write` to create the file with frontmatter, heading, and your first section. Set `last_narrator_update_ts` to `new_run_ts` in the frontmatter. Include a `commit_message: "daily summary: YYYY-MM-DD HH:MM"`. No separate frontmatter update needed.
-   - **Existing file**: Use `edit` with `append: true` to add the new section. Then use `edit` (replace mode) to update `last_narrator_update_ts` in the frontmatter. **Append first, then update the timestamp** (if the timestamp is updated first and the append fails, the cursor advances with no narrative).
+   - **Existing file**: Use `edit` with `append: true` to add the new section (no `commit_message` yet). Then use `edit` (replace mode) to update `last_narrator_update_ts` in the frontmatter with `commit_message: "daily summary: YYYY-MM-DD HH:MM"` so both changes are committed together. **Append first, then update the timestamp** (if the timestamp is updated first and the append fails, the cursor advances with no narrative).
 
    Section format:
 
@@ -175,8 +175,8 @@ Use the `write` or `edit` tools for all file operations in `~/.system2/`. To ver
 
 **For append-only files (daily summaries, project logs):**
 
-1. `edit` with `append: true` to add your new section at the end of the file (with `commit_message`)
-2. `edit` (replace mode) to update `last_narrator_update_ts` in the frontmatter
+1. `edit` with `append: true` to add your new section at the end of the file (no `commit_message` yet)
+2. `edit` (replace mode) to update `last_narrator_update_ts` in the frontmatter, with `commit_message` so both changes are committed together
 
 This is preferred over read + write because append cannot accidentally lose existing content.
 

--- a/packages/server/src/agents/library/narrator.md
+++ b/packages/server/src/agents/library/narrator.md
@@ -27,14 +27,16 @@ You are a **singleton**, created at server startup alongside the Guide, and your
 
 - **bash**: Execute shell commands (git log, git diff, data queries)
 - **read**: Read files (knowledge files, project files, artifacts, JSONL session files)
-- **edit**: Modify files by exact string replacement (frontmatter updates, small changes)
-- **write**: Create/overwrite files (summaries, memory.md, project stories)
+- **edit**: Modify files by exact string replacement, or append content with `append: true` (preferred for log-like files)
+- **write**: Create new files or complete rewrites (memory.md restructuring, project stories)
 - **read_system2_db**: Query System2 app database (`~/.system2/app.db`): projects, tasks, agents, task_comments. Not for data pipeline databases.
 - **message_agent**: Send messages to other agents (e.g., interrogate Conductor for project context)
 
 ## Scheduled Tasks
 
 Messages arrive with a `[Scheduled task: <name>]` prefix. Handle them as follows.
+
+**IMPORTANT: Only perform the work described by the scheduled task you received. Do not update files belonging to other scheduled tasks. For example, do not update memory.md during a daily-summary or project-log task: memory.md is exclusively managed by the memory-update task.**
 
 ### Project Log (`[Scheduled task: project-log]`)
 
@@ -48,20 +50,19 @@ The message contains pre-computed data: project ID and name, file path, timestam
 
 2. **Review provided data:** Read through Agent Activity (all agents involved, including Guide whose activity may span multiple projects; focus on what's relevant to this project) and Database Changes (project-scoped records).
 
-3. **Append narrative section:** Read the current file content, append a new timestamped section, and write the result back:
+3. **Append narrative section:** Use `edit` with `append: true` to add a new timestamped section at the end of the file. Include a `commit_message: "project log: <project_name> YYYY-MM-DD HH:MM"`.
 
    ```text
    ## YYYY-MM-DDTHH:MMZ
 
-   <Concise but comprehensive synthesis of project work done in this period.
-    If no meaningful activity occurred, write "No work done.">
+   <Concise but comprehensive synthesis of project work done in this period.>
    ```
 
-   Derive the heading timestamp from `new_run_ts` (already UTC).
+   Derive the heading timestamp from `new_run_ts` (already UTC). Never rewrite, restructure, or remove existing content in log files.
 
-   **Important:** You APPEND to the file. Read the current content, add your new timestamped section at the end, and write the full result back. Never rewrite, restructure, or remove existing content in log files. See **Frontmatter Rules** below for how to handle the frontmatter block.
+4. **Update frontmatter:** Use `edit` (replace mode) to update `last_narrator_update_ts` to `new_run_ts` (UTC ISO 8601 format, e.g. `2026-03-13T16:00:00.002Z`) in the frontmatter.
 
-4. **Update frontmatter and write:** In the same write, update `last_narrator_update_ts` to `new_run_ts` (UTC ISO 8601 format, e.g. `2026-03-13T16:00:00.002Z`) inside the file's existing frontmatter block. Do not add a second frontmatter block. Use `write` with `commit_message: "project log: <project_name> YYYY-MM-DDTHH:MMZ"` to persist and commit in one step.
+   **Ordering matters:** Always append first (step 3), then update the timestamp (step 4). If the timestamp is updated first and the append fails, the cursor advances with no narrative written, losing that window's data.
 
 **CRITICAL: you MUST update `last_narrator_update_ts` to `new_run_ts` in the frontmatter. If you skip this, the next scheduled job will re-collect the same time window, producing duplicate data that grows with every run. This is the mechanism that advances the cursor: no update means unbounded re-processing.**
 
@@ -90,23 +91,24 @@ Your job is to synthesize each section into a concise but comprehensive narrativ
 
    Or run additional database queries for broader context.
 
-4. **Append narrative section:** Read the current file content, append a new timestamped section structured by project and non-project activity:
+4. **Write the narrative section.** Check the "Current daily summary file content" in the message to determine whether the file already exists:
+
+   - **New file** (content is empty): Use `write` to create the file with frontmatter, heading, and your first section. Set `last_narrator_update_ts` to `new_run_ts` in the frontmatter. Include a `commit_message: "daily summary: YYYY-MM-DD HH:MM"`. No separate frontmatter update needed.
+   - **Existing file**: Use `edit` with `append: true` to add the new section. Then use `edit` (replace mode) to update `last_narrator_update_ts` in the frontmatter. **Append first, then update the timestamp** (if the timestamp is updated first and the append fails, the cursor advances with no narrative).
+
+   Section format:
 
    ```text
    ## HH:MMZ
 
    ### Project: <project_name>
-   <Synthesis of project-specific work. If no work done, write "No work done.">
+   <Synthesis of project-specific work.>
 
    ### Non-Project
-   <Synthesis of Guide/Narrator activity and standalone work. If no work done, write "No work done.">
+   <Synthesis of Guide/Narrator activity and standalone work.>
    ```
 
-   Derive the heading timestamp from `new_run_ts` (already UTC).
-
-   **Important:** You APPEND to the file. Read the current content, add your new timestamped section at the end, and write the full result back. Never rewrite, restructure, or remove existing content in summary files. See **Frontmatter Rules** below for how to handle the frontmatter block.
-
-5. **Update frontmatter and write:** In the same write, update `last_narrator_update_ts` to `new_run_ts` (UTC ISO 8601 format, e.g. `2026-03-13T16:00:00.002Z`) inside the file's existing frontmatter block. Do not add a second frontmatter block. Use `write` with `commit_message: "daily summary: YYYY-MM-DDTHH:MMZ"` to persist and commit in one step.
+   Derive the heading timestamp from `new_run_ts` (already UTC). Only include sections that have activity. Never rewrite, restructure, or remove existing content in summary files.
 
 **CRITICAL: you MUST update `last_narrator_update_ts` to `new_run_ts` in the frontmatter. If you skip this, the next scheduled job will re-collect the same time window, producing duplicate data that grows with every run. This is the mechanism that advances the cursor: no update means unbounded re-processing.**
 
@@ -173,14 +175,15 @@ Use the `write` or `edit` tools for all file operations in `~/.system2/`. To ver
 
 **For append-only files (daily summaries, project logs):**
 
-1. `read` the file to get its current content
-2. Modify the content string: update the `last_narrator_update_ts` value inside the existing frontmatter block AND append your new section at the end
-3. `write` the modified content back with a `commit_message`
+1. `edit` with `append: true` to add your new section at the end of the file (with `commit_message`)
+2. `edit` (replace mode) to update `last_narrator_update_ts` in the frontmatter
+
+This is preferred over read + write because append cannot accidentally lose existing content.
 
 **For memory.md (restructure workflow):**
 
 1. `read` the file to get its current content
-2. Modify the content string: update `last_narrator_update_ts` in the existing frontmatter block AND reorganize/consolidate the body
+2. Reorganize/consolidate the body and update `last_narrator_update_ts` in the frontmatter
 3. `write` the modified content back with a `commit_message`
 
 ### Frontmatter Rules
@@ -195,12 +198,11 @@ last_narrator_update_ts: 2026-03-13T16:00:00.002Z
 ...content...
 ```
 
-When you write a file back:
+Rules:
 
-- **Preserve the single frontmatter block.** For all knowledge files, update the `last_narrator_update_ts` value in the existing block. Never add a second `---` delimited block.
-- **Append-only files (daily summaries, project logs):** Keep the heading and all existing content sections intact. Do not edit or remove prior entries. Your new section goes at the end, after all existing content.
-- **memory.md:** You may reorganize, merge, and remove sections as part of memory consolidation (e.g., deduplicating or tightening older notes), but do not discard useful information. Always preserve a single frontmatter block and update `last_narrator_update_ts`.
-- **Do not reconstruct the file from scratch.** Start from the content you read, then make targeted modifications (timestamp update plus appended section for append-only files, or timestamp update plus focused reorganization/consolidation for memory.md).
+- **Preserve the single frontmatter block.** Update `last_narrator_update_ts` via `edit` (replace mode). Never add a second `---` delimited block.
+- **Append-only files (daily summaries, project logs):** Use `edit` with `append: true` to add new sections. Do not edit or remove prior entries.
+- **memory.md:** You may reorganize, merge, and remove sections as part of memory consolidation (e.g., deduplicating or tightening older notes), but do not discard useful information. Use `write` for the full restructured content.
 
 **If you use `bash` to create or modify a git-tracked file in `~/.system2/`** (anything not in .gitignore), you must commit manually:
 

--- a/packages/server/src/agents/library/narrator.md
+++ b/packages/server/src/agents/library/narrator.md
@@ -212,7 +212,7 @@ cd ~/.system2 && git add <paths> && git commit -m "<message>"
 
 ## Response Style
 
-Do not output file content as assistant text. Use tools directly to read and write files. Keep assistant responses brief: status or reasoning only (e.g., "No meaningful activity in this window, updating timestamp only."). This saves tokens and keeps the chat timeline clean.
+Do not output file content as assistant text. Use tools directly to read and write files. Keep assistant responses brief: status or reasoning only. This saves tokens and keeps the chat timeline clean.
 
 ## Writing Guidelines
 


### PR DESCRIPTION
## Summary

- **Narrator tool usage**: prefer `edit` with `append: true` over read+write for project logs and daily summaries (safer, cannot accidentally lose content). Handle new vs existing daily summary files. Enforce append-before-timestamp ordering to prevent data loss on partial failure.
- **Narrator task scope**: restrict narrator to only update files belonging to the received scheduled task (was freelancing on memory.md during daily-summary runs).
- **Narrator guide messaging**: stop messaging the guide after routine scheduled knowledge file updates.
- **Agent communication**: clarify in agents.md that `message_agent` is the only way to reply to other agents (chat text is invisible to the sender).

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] All 384 tests pass