### PR TITLE
fix: prevent stale session subscriptions from misattributing API errors

### DIFF
--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -125,6 +125,7 @@ export class AgentHost {
   private isPruning = false;
   private contextWindow = 0;
   private contextOverflowHandled = false;
+  private unsubscribeSession: (() => void) | null = null;
 
   constructor(config: AgentHostConfig) {
     this.db = config.db;
@@ -288,9 +289,11 @@ export class AgentHost {
     // Store context window size for overflow recovery
     this.contextWindow = model.contextWindow;
 
-    // Configure auto-compaction to fire at 90% of context window instead of default ~98%
+    // Configure auto-compaction to fire at 50% of context window instead of default ~98%.
+    // Earlier compaction reduces the chance of hitting per-model token quotas
+    // when multiple agents share the same API key.
     const settingsManager = SettingsManager.inMemory({
-      compaction: { reserveTokens: Math.floor(model.contextWindow * 0.1) },
+      compaction: { reserveTokens: Math.floor(model.contextWindow * 0.5) },
     });
 
     // Create resource loader with custom system prompt
@@ -334,8 +337,14 @@ export class AgentHost {
       );
     }
 
+    // Clean up old subscription before attaching to the new session
+    if (this.unsubscribeSession) {
+      this.unsubscribeSession();
+      this.unsubscribeSession = null;
+    }
+
     // Subscribe to session events and forward to listeners
-    session.subscribe((event) => {
+    this.unsubscribeSession = session.subscribe((event) => {
       this.handleSessionEvent(event);
     });
 

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -153,6 +153,13 @@ export class AgentHost {
    * Initialize the agent session (must be called before use)
    */
   async initialize(): Promise<void> {
+    // Detach from old session immediately, before any async work.
+    // Prevents stale events from being processed if createAgentSession() throws.
+    if (this.unsubscribeSession) {
+      this.unsubscribeSession();
+      this.unsubscribeSession = null;
+    }
+
     // Look up the agent record from the database
     const agentRecord = this.db.getAgent(this.agentId);
     if (!agentRecord) {
@@ -335,12 +342,6 @@ export class AgentHost {
       console.log(
         `[AgentHost] Compaction pruning enabled: depth=${this.compactionDepth}, count=${this.compactionCount}`
       );
-    }
-
-    // Clean up old subscription before attaching to the new session
-    if (this.unsubscribeSession) {
-      this.unsubscribeSession();
-      this.unsubscribeSession = null;
     }
 
     // Subscribe to session events and forward to listeners


### PR DESCRIPTION
## Summary

- Fix stale session subscription leak: `session.subscribe()` returned an unsubscribe function that was discarded, causing old session callbacks to persist after provider failover and misattribute errors to the wrong provider (Google errors marked as Anthropic failures, cascading to Cerebras)
- Lower auto-compaction threshold from 90% to 50% of context window to reduce per-model token quota pressure when multiple agents share the same API key

## Root cause

During `reinitializeWithProvider()`, the old session's event callback persisted because the unsubscribe function was never stored or called. When the old session emitted events, `handleSessionEvent` used the already-updated `this.currentProvider`, incorrectly attributing old provider errors to the new provider and triggering unnecessary failover.

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (384 tests)
- [ ] Manual: run system2 with Google as primary, verify failover only triggers on actual provider errors