### PR TITLE
fix: strengthen narrator scheduled-task rules and clarify frontmatter old_string construction

### DIFF
--- a/packages/server/src/agents/library/narrator.md
+++ b/packages/server/src/agents/library/narrator.md
@@ -38,6 +38,8 @@ Messages arrive with a `[Scheduled task: <name>]` prefix. Handle them as follows
 
 **IMPORTANT: Only perform the work described by the scheduled task you received. Do not update files belonging to other scheduled tasks. For example, do not update memory.md during a daily-summary or project-log task: memory.md is exclusively managed by the memory-update task.**
 
+**IMPORTANT: Never message the Guide when a scheduled task finishes — not on success, not on error, not when you use a fallback. Scheduled tasks are fire-and-forget background operations. The system does not wait for a response from you.**
+
 ### Project Log (`[Scheduled task: project-log]`)
 
 **Goal:** Append a narrative summary of recent project-scoped activity to the project's continuous log file.
@@ -60,7 +62,11 @@ The message contains pre-computed data: project ID and name, file path, timestam
 
    Derive the heading timestamp from `new_run_ts` (already UTC). Never rewrite, restructure, or remove existing content in log files.
 
-4. **Update frontmatter and commit:** Use `edit` (replace mode) to update `last_narrator_update_ts` to `new_run_ts` (UTC ISO 8601 format, e.g. `2026-03-13T16:00:00.002Z`) in the frontmatter. Include `commit_message: "project log: <project_name> YYYY-MM-DD HH:MM"` on this edit so both the appended narrative and the timestamp update are committed together.
+4. **Update frontmatter and commit:** Use `edit` (replace mode) to update `last_narrator_update_ts` in the frontmatter. Include `commit_message: "project log: <project_name> YYYY-MM-DD HH:MM"` on this edit so both the appended narrative and the timestamp update are committed together.
+
+   Construct the strings exactly:
+   - `old_string`: `last_narrator_update_ts: <last_run_ts>` (use the value from the message header verbatim)
+   - `new_string`: `last_narrator_update_ts: <new_run_ts>`
 
    **Ordering matters:** Always append first (step 3), then update the timestamp (step 4). If the timestamp is updated first and the append fails, the cursor advances with no narrative written, losing that window's data.
 
@@ -92,6 +98,10 @@ Your job is to synthesize each section into a concise but comprehensive narrativ
    Or run additional database queries for broader context.
 
 4. **Write the narrative section.** Use `edit` with `append: true` to add the new section (no `commit_message` yet). Then use `edit` (replace mode) to update `last_narrator_update_ts` in the frontmatter with `commit_message: "daily summary: YYYY-MM-DD HH:MM"` so both changes are committed together. **Append first, then update the timestamp** (if the timestamp is updated first and the append fails, the cursor advances with no narrative).
+
+   Construct the strings exactly:
+   - `old_string`: `last_narrator_update_ts: <last_run_ts>` (use the value from the message header verbatim)
+   - `new_string`: `last_narrator_update_ts: <new_run_ts>`
 
    Section format:
 
@@ -173,7 +183,7 @@ Use the `write` or `edit` tools for all file operations in `~/.system2/`. To ver
 **For append-only files (daily summaries, project logs):**
 
 1. `edit` with `append: true` to add your new section at the end of the file (no `commit_message` yet)
-2. `edit` (replace mode) to update `last_narrator_update_ts` in the frontmatter, with `commit_message` so both changes are committed together
+2. `edit` (replace mode) to update `last_narrator_update_ts` in the frontmatter, with `commit_message` so both changes are committed together. Use `old_string: last_narrator_update_ts: <last_run_ts>` and `new_string: last_narrator_update_ts: <new_run_ts>` (exact values from the message header).
 
 This is preferred over read + write because append cannot accidentally lose existing content.
 
@@ -231,4 +241,4 @@ Do not output file content as assistant text. Use tools directly to read and wri
 - Don't execute pipelines or run queries against user databases
 - Don't analyze data: document what was already done
 - Don't interact with the user directly: you work in the background
-- Don't message the Guide after completing scheduled knowledge file updates (project-log, daily-summary, memory-update): these are routine background tasks that don't need notification
+- Don't message the Guide for scheduled tasks (project-log, daily-summary, memory-update), ever: not on completion, not on error, not when using fallbacks. These are fire-and-forget background operations.

--- a/packages/server/src/agents/library/narrator.md
+++ b/packages/server/src/agents/library/narrator.md
@@ -62,11 +62,13 @@ The message contains pre-computed data: project ID and name, file path, timestam
 
    Derive the heading timestamp from `new_run_ts` (already UTC). Never rewrite, restructure, or remove existing content in log files.
 
-4. **Update frontmatter and commit:** Use `edit` (replace mode) to update `last_narrator_update_ts` in the frontmatter. Include `commit_message: "project log: <project_name> YYYY-MM-DD HH:MM"` on this edit so both the appended narrative and the timestamp update are committed together.
+4. **Update frontmatter and commit:** Use `edit` with `regex: true` to update `last_narrator_update_ts` in the frontmatter. Include `commit_message: "project log: <project_name> YYYY-MM-DD HH:MM"` on this edit so both the appended narrative and the timestamp update are committed together.
 
-   Construct the strings exactly:
-   - `old_string`: `last_narrator_update_ts: <last_run_ts>` (use the value from the message header verbatim)
-   - `new_string`: `last_narrator_update_ts: <new_run_ts>`
+   ```yaml
+   old_string: "last_narrator_update_ts: .*"
+   new_string: "last_narrator_update_ts: <new_run_ts>"
+   regex: true
+   ```
 
    **Ordering matters:** Always append first (step 3), then update the timestamp (step 4). If the timestamp is updated first and the append fails, the cursor advances with no narrative written, losing that window's data.
 
@@ -99,9 +101,13 @@ Your job is to synthesize each section into a concise but comprehensive narrativ
 
 4. **Write the narrative section.** Use `edit` with `append: true` to add the new section (no `commit_message` yet). Then use `edit` (replace mode) to update `last_narrator_update_ts` in the frontmatter with `commit_message: "daily summary: YYYY-MM-DD HH:MM"` so both changes are committed together. **Append first, then update the timestamp** (if the timestamp is updated first and the append fails, the cursor advances with no narrative).
 
-   Construct the strings exactly:
-   - `old_string`: `last_narrator_update_ts: <last_run_ts>` (use the value from the message header verbatim)
-   - `new_string`: `last_narrator_update_ts: <new_run_ts>`
+   Use `regex: true` for the replace:
+
+   ```yaml
+   old_string: "last_narrator_update_ts: .*"
+   new_string: "last_narrator_update_ts: <new_run_ts>"
+   regex: true
+   ```
 
    Section format:
 
@@ -183,7 +189,7 @@ Use the `write` or `edit` tools for all file operations in `~/.system2/`. To ver
 **For append-only files (daily summaries, project logs):**
 
 1. `edit` with `append: true` to add your new section at the end of the file (no `commit_message` yet)
-2. `edit` (replace mode) to update `last_narrator_update_ts` in the frontmatter, with `commit_message` so both changes are committed together. Use `old_string: last_narrator_update_ts: <last_run_ts>` and `new_string: last_narrator_update_ts: <new_run_ts>` (exact values from the message header).
+2. `edit` with `regex: true` to update `last_narrator_update_ts` in the frontmatter (`old_string: "last_narrator_update_ts: .*"`, `new_string: "last_narrator_update_ts: <new_run_ts>"`), with `commit_message` so both changes are committed together.
 
 This is preferred over read + write because append cannot accidentally lose existing content.
 

--- a/packages/server/src/agents/tools/edit.test.ts
+++ b/packages/server/src/agents/tools/edit.test.ts
@@ -124,6 +124,89 @@ describe('edit tool', () => {
     expect(result.details).toHaveProperty('error', 'missing_old_string');
   });
 
+  describe('regex mode', () => {
+    it('replaces a line matched by pattern', async () => {
+      const dir = trackDir(makeTmpDir());
+      const file = join(dir, 'test.txt');
+      writeFileSync(file, '---\nlast_narrator_update_ts: 2026-03-24T00:00:00.000Z\n---\n');
+
+      const result = await exec({
+        path: file,
+        old_string: 'last_narrator_update_ts: .*',
+        new_string: 'last_narrator_update_ts: 2026-03-25T12:00:00.000Z',
+        regex: true,
+      });
+
+      expect((result.content[0] as { text: string }).text).toContain('Edited');
+      expect(readFileSync(file, 'utf-8')).toBe(
+        '---\nlast_narrator_update_ts: 2026-03-25T12:00:00.000Z\n---\n'
+      );
+    });
+
+    it('treats new_string as a literal (does not interpret $ as backreference)', async () => {
+      const dir = trackDir(makeTmpDir());
+      const file = join(dir, 'test.txt');
+      writeFileSync(file, 'key: old_value\n');
+
+      await exec({
+        path: file,
+        old_string: 'key: \\w+',
+        new_string: 'key: new$value',
+        regex: true,
+      });
+
+      expect(readFileSync(file, 'utf-8')).toBe('key: new$value\n');
+    });
+
+    it('errors when pattern matches zero times', async () => {
+      const dir = trackDir(makeTmpDir());
+      const file = join(dir, 'test.txt');
+      writeFileSync(file, 'some content');
+
+      const result = await exec({
+        path: file,
+        old_string: 'nonexistent_field: .*',
+        new_string: 'nonexistent_field: value',
+        regex: true,
+      });
+
+      expect((result.content[0] as { text: string }).text).toContain('not found');
+      expect(result.details).toHaveProperty('error', 'not_found');
+    });
+
+    it('errors when pattern matches more than once', async () => {
+      const dir = trackDir(makeTmpDir());
+      const file = join(dir, 'test.txt');
+      writeFileSync(file, 'key: aaa\nkey: bbb\n');
+
+      const result = await exec({
+        path: file,
+        old_string: 'key: .*',
+        new_string: 'key: ccc',
+        regex: true,
+      });
+
+      expect((result.content[0] as { text: string }).text).toContain('2 times');
+      expect(result.details).toHaveProperty('error', 'not_unique');
+    });
+
+    it('errors on invalid regex', async () => {
+      const dir = trackDir(makeTmpDir());
+      const file = join(dir, 'test.txt');
+      writeFileSync(file, 'content');
+
+      const result = await exec({
+        path: file,
+        old_string: '[invalid',
+        new_string: 'x',
+        regex: true,
+      });
+
+      expect((result.content[0] as { text: string }).text).toContain('invalid regex');
+      expect(result.details).toHaveProperty('error', 'invalid_regex');
+    });
+  });
+
   describe('append mode', () => {
     it('appends to an existing file with trailing newline', async () => {
       const dir = trackDir(makeTmpDir());

--- a/packages/server/src/agents/tools/edit.ts
+++ b/packages/server/src/agents/tools/edit.ts
@@ -160,8 +160,11 @@ export function createEditTool() {
             };
           }
 
-          const matches = content.match(pattern);
-          const count = matches ? matches.length : 0;
+          let count = 0;
+          for (const _match of content.matchAll(pattern)) {
+            count++;
+            if (count > 1) break;
+          }
 
           if (count === 0) {
             return {

--- a/packages/server/src/agents/tools/edit.ts
+++ b/packages/server/src/agents/tools/edit.ts
@@ -8,6 +8,11 @@
  * insertions, use surrounding context as `old_string` and embed the new content
  * in `new_string`.
  *
+ * Regex mode (`regex: true`): same as replace mode but `old_string` is treated
+ * as a JavaScript regex pattern. `new_string` is used as a literal replacement
+ * string ($ is not interpreted as a backreference). The pattern must match
+ * exactly once.
+ *
  * Append mode (`append: true`): appends `new_string` to the end of the file.
  * Creates the file (and parent directories) if it does not exist. Adds a
  * newline separator if the existing content does not end with one.
@@ -28,7 +33,7 @@ export function createEditTool() {
     old_string: Type.Optional(
       Type.String({
         description:
-          'The exact text to find in the file. Must appear exactly once. Include enough surrounding context to make it unique. Required unless append is true.',
+          'The exact text to find in the file (or a regex pattern when regex is true). Must match exactly once. Include enough surrounding context to make it unique. Required unless append is true.',
       })
     ),
     new_string: Type.String({
@@ -39,6 +44,12 @@ export function createEditTool() {
       Type.Boolean({
         description:
           'If true, append new_string to the end of the file instead of replacing old_string. Creates the file (and parent directories) if it does not exist.',
+      })
+    ),
+    regex: Type.Optional(
+      Type.Boolean({
+        description:
+          'If true, treat old_string as a JavaScript regular expression pattern. new_string is used as a literal replacement ($ is not interpreted as a backreference). The pattern must match exactly once. Useful for replacing a field value without knowing the current value, e.g. old_string: "last_narrator_update_ts: .*". Ignored when append is true.',
       })
     ),
     commit_message: Type.Optional(
@@ -53,7 +64,7 @@ export function createEditTool() {
     name: 'edit',
     label: 'Edit File',
     description:
-      'Edit a file by replacing an exact string match, or append content to a file. When append is true, appends new_string to the end of the file (creating it if needed) — use this for adding entries to logs, memory files, and similar. When append is not set, old_string must appear exactly once in the file (include more context if not unique). Prefer this over `write` for modifying existing files. Use `write` for creating new files or complete rewrites. For bulk operations (e.g., find-and-replace across many lines), use `bash` with `sed`, `awk`, or similar.',
+      'Edit a file by replacing an exact string match, or append content to a file. When append is true, appends new_string to the end of the file (creating it if needed) — use this for adding entries to logs, memory files, and similar. When append is not set, old_string must appear exactly once in the file (include more context if not unique). Set regex to true to treat old_string as a regex pattern — useful when you need to replace a field value without knowing the current value (e.g. old_string: "fieldName: .*"). Prefer this over `write` for modifying existing files. Use `write` for creating new files or complete rewrites.',
     parameters: params,
     execute: async (_toolCallId, params, signal, _onUpdate) => {
       try {
@@ -131,6 +142,84 @@ export function createEditTool() {
         }
 
         const content = await readFile(filePath, 'utf-8');
+
+        if (params.regex) {
+          // Regex replace mode
+          let pattern: RegExp;
+          try {
+            pattern = new RegExp(params.old_string, 'g');
+          } catch {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `Error: invalid regex pattern: ${params.old_string}`,
+                },
+              ],
+              details: { error: 'invalid_regex' },
+            };
+          }
+
+          const matches = content.match(pattern);
+          const count = matches ? matches.length : 0;
+
+          if (count === 0) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `Error: pattern not found in ${params.path}. Make sure the regex matches the file content.`,
+                },
+              ],
+              details: { error: 'not_found', path: filePath },
+            };
+          }
+
+          if (count > 1) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: `Error: pattern matches ${count} times in ${params.path}. Refine the regex to match exactly once.`,
+                },
+              ],
+              details: { error: 'not_unique', count, path: filePath },
+            };
+          }
+
+          if (signal?.aborted) {
+            return {
+              content: [{ type: 'text', text: 'Edit aborted.' }],
+              details: { error: 'aborted' },
+            };
+          }
+
+          // Use a replacer function so new_string is treated as a literal
+          // string — $ signs are not interpreted as backreferences.
+          const newContent = content.replace(
+            new RegExp(params.old_string),
+            () => params.new_string
+          );
+          await writeFile(filePath, newContent, 'utf-8');
+
+          if (params.commit_message) {
+            commitIfStateDir(filePath, params.commit_message);
+          }
+
+          const matchIndex = content.search(new RegExp(params.old_string));
+          const linesBefore = content.slice(0, matchIndex).split('\n').length;
+          const linesChanged = params.new_string.split('\n').length;
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Edited ${params.path} — replaced pattern match at line ${linesBefore} with ${linesChanged} line(s).`,
+              },
+            ],
+            details: { path: filePath, startLine: linesBefore, linesChanged },
+          };
+        }
 
         if (params.old_string === params.new_string) {
           return {

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -554,6 +554,7 @@ last_run_ts: ${lastRunTs}
 new_run_ts: ${newRunTs}
 
 IMPORTANT: After writing the log entry, you MUST set last_narrator_update_ts to exactly "${newRunTs}" (UTC ISO 8601) in the frontmatter of ${logFile}. This advances the cursor for the next run.
+IMPORTANT: Do not message the Guide when you are done. This is a background task — no response is expected.
 
 ## Most recent log.md content
 
@@ -603,6 +604,7 @@ last_run_ts: ${lastRunTs}
 new_run_ts: ${newRunTs}
 
 IMPORTANT: After writing the summary, you MUST set last_narrator_update_ts to exactly "${newRunTs}" (UTC ISO 8601) in the frontmatter of ${filePath}. This advances the cursor for the next run.
+IMPORTANT: Do not message the Guide when you are done. This is a background task — no response is expected.
 
 ## Current daily summary file content
 
@@ -713,6 +715,7 @@ last_narrator_update_ts: ${lastTs ?? '(none)'}
 new_run_ts: ${newRunTs}
 
 IMPORTANT: After writing memory.md, you MUST set last_narrator_update_ts to exactly "${newRunTs}" (UTC ISO 8601) in the frontmatter of ${memoryFile}. This advances the cursor for the next run.
+IMPORTANT: Do not message the Guide when you are done. This is a background task — no response is expected.
 
 ## Daily summaries to incorporate
 


### PR DESCRIPTION
## Summary

- Never message the Guide for scheduled tasks: adds the rule prominently at the top of the Scheduled Tasks section (not just in What NOT to Do), makes the wording unconditional — covers success, errors, and fallbacks
- Clarifies how to construct `old_string`/`new_string` for the two-step frontmatter timestamp update: use the verbatim `last_run_ts` value from the message header, eliminating guesswork and the resulting "old_string not found" failures

## Background

Two observed narrator misbehaviors in the same scheduled run:

1. The narrator messaged the Guide after completing a daily-summary task, despite existing instructions not to. The rule was buried in "What NOT to Do" and phrased as "after completing", leaving a loophole for error/fallback scenarios.

2. The narrator failed the frontmatter timestamp replace step, fell back to `read + write`, and misattributed the failure to "the edit tool in append mode". The actual cause: the instructions didn't specify what `old_string` to use, so the narrator guessed the current timestamp value and guessed wrong.

Fixes #49