### PR TITLE
fix: increase rate limit retry delays to outlast per-minute token quotas

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -160,18 +160,20 @@ When `AgentHost` detects an API error in a `message_end` event:
 
 Exponential backoff with jitter: `min(baseDelay * 2^attempt + jitter, maxDelay)`
 
+Rate limit retries are tuned so that cumulative wait exceeds 60s before failover. This ensures per-minute token quotas (e.g., Google's 1M input tokens/min) have time to reset without unnecessarily switching providers.
+
 | Parameter | Default |
 |-----------|---------|
 | Base delay | 1000ms |
-| Max delay | 30,000ms |
+| Max delay | 90,000ms |
 | Jitter | 0-25% of delay |
-| Max rate limit retries | 3 |
+| Max rate limit retries | 7 |
 | Max transient retries | 2 |
 
 | Error Category | Retry | Failover |
 |---------------|-------|----------|
 | `auth` (401/403) | Never | Immediate |
-| `rate_limit` (429) | Up to 3x | After retries exhausted |
+| `rate_limit` (429) | Up to 7x (~127s cumulative) | After retries exhausted |
 | `transient` (500/503/timeout) | Up to 2x | After retries exhausted |
 | `context_overflow` (400 with token limit message) | Never | Never (compact and recover) |
 | `client` (400) | Never | Never (surface error) |

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -709,8 +709,8 @@ describe('AgentHost', () => {
       internal.authResolver.getNextProvider = vi.fn().mockReturnValue('anthropic');
       internal.reinitializeWithProvider = vi.fn().mockResolvedValue(undefined);
 
-      // 429 rate limit error: shouldRetry is false at attempt 3, triggers failover
-      internal.retryAttempts.set('google:rate_limit', 3);
+      // 429 rate limit error: shouldRetry is false at attempt 7, triggers failover
+      internal.retryAttempts.set('google:rate_limit', 7);
       await internal.handlePotentialError({
         type: 'message_end',
         message: { stopReason: 'error', errorMessage: 'Error 429: rate limit exceeded' },

--- a/packages/server/src/agents/retry.test.ts
+++ b/packages/server/src/agents/retry.test.ts
@@ -176,8 +176,8 @@ describe('shouldRetry', () => {
 
   it('retries rate_limit up to maxRateLimitRetries', () => {
     expect(shouldRetry('rate_limit', 0)).toBe(true);
-    expect(shouldRetry('rate_limit', 2)).toBe(true);
-    expect(shouldRetry('rate_limit', 3)).toBe(false);
+    expect(shouldRetry('rate_limit', 6)).toBe(true);
+    expect(shouldRetry('rate_limit', 7)).toBe(false);
   });
 
   it('retries transient up to maxTransientRetries', () => {

--- a/packages/server/src/agents/retry.ts
+++ b/packages/server/src/agents/retry.ts
@@ -8,9 +8,9 @@
 export interface RetryConfig {
   /** Base delay in milliseconds (default: 1000) */
   baseDelay: number;
-  /** Maximum delay cap in milliseconds (default: 30000) */
+  /** Maximum delay cap in milliseconds (default: 90000) */
   maxDelay: number;
-  /** Maximum retries for rate limit errors (default: 3) */
+  /** Maximum retries for rate limit errors (default: 7) */
   maxRateLimitRetries: number;
   /** Maximum retries for transient errors like 503 (default: 2) */
   maxTransientRetries: number;
@@ -18,8 +18,8 @@ export interface RetryConfig {
 
 export const DEFAULT_RETRY_CONFIG: RetryConfig = {
   baseDelay: 1000,
-  maxDelay: 30000,
-  maxRateLimitRetries: 3,
+  maxDelay: 90000,
+  maxRateLimitRetries: 7,
   maxTransientRetries: 2,
 };
 


### PR DESCRIPTION
## Summary

- Raise `maxRateLimitRetries` from 3 to 7 and `maxDelay` from 30s to 90s so cumulative backoff exceeds 60s (~127s minimum) before failover
- This gives per-minute token quotas (e.g., Google's 1M input tokens/min) time to reset instead of prematurely switching providers
- Update docs and tests to reflect new defaults

## Context

A conductor hit Google's `GenerateContentPaidTierInputTokensPerModelPerMinute` quota (1M tokens). With the old config (3 retries, 30s max), cumulative backoff was only ~8s before failover to Anthropic, which then also failed due to low Tier 1 rate limits. The new config waits ~127-159s (well over the 60s quota window) before giving up on a provider.

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (384 tests, including updated retry and failover assertions)
