### PR TITLE
feat: include project ID and name in project-log chat label

### DIFF
--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -650,9 +650,7 @@ describe('AgentHost', () => {
       );
 
       const pushed = internal._chatCache.push.mock.calls[0][0];
-      expect(pushed.content).toBe(
-        'Scheduled task: project-log #3 (US Employment Rate Analysis)'
-      );
+      expect(pushed.content).toBe('Scheduled task: project-log #3 (US Employment Rate Analysis)');
     });
 
     it('falls back to plain project-log label when metadata is missing', () => {

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -626,6 +626,63 @@ describe('AgentHost', () => {
       expect(pushed.content).toBe('Task: project-story');
     });
 
+    it('includes project ID and name in project-log chat label', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as {
+        session: { sendCustomMessage: ReturnType<typeof vi.fn> };
+        _chatCache: { push: ReturnType<typeof vi.fn>; getMessages: ReturnType<typeof vi.fn> };
+        _sessionDir: string | null;
+      };
+
+      internal.session = { sendCustomMessage: vi.fn().mockResolvedValue(undefined) };
+      internal._chatCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
+      internal._sessionDir = null;
+
+      host.deliverMessage(
+        '[Scheduled task: project-log]\n\nproject_id: 3\nproject_name: US Employment Rate Analysis\n\n## Activity\nsome log content',
+        { sender: 0, receiver: 2, timestamp: 1_700_000_000_000 }
+      );
+
+      const pushed = internal._chatCache.push.mock.calls[0][0];
+      expect(pushed.content).toBe(
+        'Scheduled task: project-log #3 (US Employment Rate Analysis)'
+      );
+    });
+
+    it('falls back to plain project-log label when metadata is missing', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as {
+        session: { sendCustomMessage: ReturnType<typeof vi.fn> };
+        _chatCache: { push: ReturnType<typeof vi.fn>; getMessages: ReturnType<typeof vi.fn> };
+        _sessionDir: string | null;
+      };
+
+      internal.session = { sendCustomMessage: vi.fn().mockResolvedValue(undefined) };
+      internal._chatCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
+      internal._sessionDir = null;
+
+      host.deliverMessage('[Scheduled task: project-log]\n\n## Activity\nno metadata here', {
+        sender: 0,
+        receiver: 2,
+        timestamp: 1_700_000_000_000,
+      });
+
+      const pushed = internal._chatCache.push.mock.calls[0][0];
+      expect(pushed.content).toBe('Scheduled task: project-log');
+    });
+
     it('truncates untagged content to 100 characters', () => {
       const host = new AgentHost({
         db: makeDbStub(),

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -756,8 +756,11 @@ export class AgentHost {
 
         if (tag.startsWith('Scheduled task:') || tag.startsWith('Task:')) {
           if (tag === 'Scheduled task: project-log') {
-            const pidMatch = body.match(/^project_id:\s*(\d+)/m);
-            const pnameMatch = body.match(/^project_name:\s*(.+)/m);
+            const firstBlankLine = body.search(/\n\s*\n/);
+            const metadata =
+              firstBlankLine === -1 ? body.slice(0, 4096) : body.slice(0, firstBlankLine);
+            const pidMatch = metadata.match(/^project_id:\s*(\d+)/m);
+            const pnameMatch = metadata.match(/^project_name:\s*(.+)/m);
             const pid = pidMatch?.[1];
             const pname = pnameMatch?.[1]?.trim();
             cacheContent = pid && pname ? `${tag} #${pid} (${pname})` : tag;

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -755,7 +755,15 @@ export class AgentHost {
         const body = content.slice(tagMatch[0].length).replace(/^\n+/, '');
 
         if (tag.startsWith('Scheduled task:') || tag.startsWith('Task:')) {
-          cacheContent = tag;
+          if (tag === 'Scheduled task: project-log') {
+            const pidMatch = body.match(/^project_id:\s*(\d+)/m);
+            const pnameMatch = body.match(/^project_name:\s*(.+)/m);
+            const pid = pidMatch?.[1];
+            const pname = pnameMatch?.[1]?.trim();
+            cacheContent = pid && pname ? `${tag} #${pid} (${pname})` : tag;
+          } else {
+            cacheContent = tag;
+          }
         } else {
           cacheContent = body ? `${tag}\n\n${body}` : tag;
         }


### PR DESCRIPTION
## Summary

- Scheduled task: project-log messages in chat now display the project ID and name (e.g. `Scheduled task: project-log #3 (US Employment Rate Analysis)`) instead of a generic label
- Makes multiple active projects distinguishable at a glance in the chat sidebar

## Test plan

- [ ] Start server with multiple active projects
- [ ] Wait for or trigger a project-log scheduled task cycle
- [ ] Verify each project-log message in chat shows the project ID and name
- [ ] Verify fallback: if project_id/project_name can't be parsed from body, label stays as plain `Scheduled task: project-log`