### PR TITLE
fix: cooldown-based failover recovery

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -132,13 +132,19 @@ A simple `Map<number, AgentHost>` that maps agent database IDs to active AgentHo
 
 ## AuthResolver (`auth-resolver.ts`)
 
-Manages API key rotation and multi-provider failover. Providers and API keys are defined in [Configuration](configuration.md):
+Manages API key rotation and multi-provider failover. Providers and API keys are defined in [Configuration](configuration.md).
+
+**Shared state, per-agent provider choice:** one `AuthResolver` instance lives in `server.ts` and is shared by all `AgentHost`s. Key cooldown state is global: if Agent A puts a key in cooldown, Agent B sees it too. But each agent tracks its own `currentProvider` independently and only consults the resolver at failover time or reinitialization. There is no push mechanism: agents discover key failures when they hit errors themselves.
 
 ### Key Rotation
 
-Each provider can have multiple labeled API keys. Keys are tried in order. When a key fails:
-- **Auth errors (401/403):** Key is permanently marked failed
-- **Rate limits / transient errors:** Key enters 5-minute cooldown, then becomes available again
+Each provider can have multiple labeled API keys. Keys are tried in order. When a key fails, it enters cooldown:
+- **Rate limits (429):** 90-second cooldown (covers per-minute quota reset windows)
+- **All other errors (400, 401, 403, 5xx, timeout):** 5-minute cooldown (user needs time to take corrective action)
+
+All failures use cooldown (no permanent failures). The system auto-recovers after the cooldown expires, so if the user fixes the issue (adds credits, rotates a key, adjusts permissions), the key becomes available again without a restart.
+
+Cooldowns are set once: if a key is already in cooldown, subsequent failures skip the set to avoid extending the lockout when multiple agents hit the same key at staggered times.
 
 ### Failover Order
 
@@ -152,9 +158,11 @@ When `AgentHost` detects an API error in a `message_end` event:
 
 1. Categorize the error (see [retry.ts](#retry-logic))
 2. If retriable: wait with exponential backoff, retry with same provider
-3. If retries exhausted: mark key failed, failover to next provider
+3. If retries exhausted or immediate failover: mark key in cooldown, failover to next provider
 4. Reinitialize the session with the new provider (`reinitializeWithProvider()`)
 5. Retry the pending prompt
+
+Error details (status code and category) are shown in agent chat messages so the user can diagnose issues. Key rotation within a provider: "429 rate_limit on google, rotating to next key". Provider switch: "429 rate_limit on google, switching to anthropic".
 
 ### Retry Logic (`retry.ts`)
 
@@ -176,7 +184,7 @@ Rate limit retries are tuned so that cumulative wait exceeds 60s before failover
 | `rate_limit` (429) | Up to 7x (~127s cumulative) | After retries exhausted |
 | `transient` (500/503/timeout) | Up to 2x | After retries exhausted |
 | `context_overflow` (400 with token limit message) | Never | Never (compact and recover) |
-| `client` (400) | Never | Never (surface error) |
+| `client` (400) | Never | Immediate |
 
 **Context overflow detection:** `categorizeError()` in `retry.ts` checks the error message _before_ status code classification, so a 400 error that matches a context overflow pattern is categorized as `context_overflow` rather than `client`. Detection uses provider-specific regex patterns:
 
@@ -196,6 +204,8 @@ These patterns are intentionally narrow to avoid false positives on rate-limit e
 The result is a session with a compact summary of the safe history plus the recent tail. The overflow-causing prompt is not retried; the agent resumes naturally on the next interaction. If no split point below 90% is found, or if the tail is empty, recovery skips the corresponding steps. If recovery fails mid-way after the file has been truncated, the tail is restored to the file as a best-effort safeguard.
 
 Auto-compaction is also configured to fire earlier (at 90% of the context window instead of the SDK default of ~98%) to reduce the chance of overflow in the first place.
+
+**Last-resort provider recovery:** after all normal recovery paths (retry, failover, context overflow) are exhausted, `handlePotentialError` checks if a different provider is available before giving up. This covers cases where an agent is stuck on a dead fallback provider (e.g., Anthropic with $0 credits returning 400 `client` errors) while the primary provider's cooldown has expired. `getNextProvider()` iterates in provider order (primary first), so agents naturally gravitate back to the primary when it becomes available.
 
 ## Session Persistence
 

--- a/packages/server/src/agents/auth-resolver.test.ts
+++ b/packages/server/src/agents/auth-resolver.test.ts
@@ -56,7 +56,7 @@ describe('AuthResolver', () => {
   });
 
   describe('markKeyFailed', () => {
-    it('marks auth failure as permanent and moves to next key', () => {
+    it('puts auth failure in cooldown and moves to next key', () => {
       const resolver = new AuthResolver(makeConfig());
       const hasMore = resolver.markKeyFailed('anthropic', 'auth');
       expect(hasMore).toBe(true);
@@ -83,18 +83,78 @@ describe('AuthResolver', () => {
     });
 
     it('puts rate_limit failures in cooldown (not permanent)', () => {
-      const resolver = new AuthResolver(makeConfig(), 1000);
+      const resolver = new AuthResolver(makeConfig(), { rateLimitMs: 1000 });
       resolver.markKeyFailed('anthropic', 'rate_limit');
       // Key 0 in cooldown, should switch to key 1
       const active = resolver.getActiveKey('anthropic');
       expect(active?.keyIndex).toBe(1);
+    });
+
+    it('uses shorter cooldown for rate_limit than transient', () => {
+      vi.useFakeTimers();
+      const resolver = new AuthResolver(makeConfig(), { rateLimitMs: 2000, defaultMs: 10000 });
+
+      resolver.markKeyFailed('anthropic', 'rate_limit');
+      // Key 0 in cooldown, key 1 active
+      expect(resolver.getActiveKey('anthropic')?.keyIndex).toBe(1);
+
+      // After 3s, rate_limit cooldown (2s) should have expired
+      vi.advanceTimersByTime(3000);
+      const status = resolver.getStatus();
+      expect(status.cooldowns).toHaveLength(0);
+
+      vi.useRealTimers();
+    });
+
+    it('uses longer cooldown for transient errors', () => {
+      vi.useFakeTimers();
+      const resolver = new AuthResolver(makeConfig(), { rateLimitMs: 2000, defaultMs: 10000 });
+
+      resolver.markKeyFailed('anthropic', 'transient');
+      expect(resolver.getActiveKey('anthropic')?.keyIndex).toBe(1);
+
+      // After 3s, transient cooldown (10s) should still be active
+      vi.advanceTimersByTime(3000);
+      const status = resolver.getStatus();
+      expect(status.cooldowns).toHaveLength(1);
+
+      vi.useRealTimers();
+    });
+
+    it('does not reset cooldown if key is already in cooldown', () => {
+      vi.useFakeTimers();
+      // Use a single-key provider so activeKeys stays at 0 after first failure
+      const resolver = new AuthResolver(
+        makeConfig({
+          primary: 'openai',
+          fallback: [],
+          providers: {
+            openai: { keys: [{ key: 'oai-key-1', label: 'main' }] },
+          },
+        }),
+        { rateLimitMs: 5000, defaultMs: 5000 }
+      );
+
+      resolver.markKeyFailed('openai', 'rate_limit');
+
+      // Advance 3s, then mark same key failed again (simulates a second agent)
+      vi.advanceTimersByTime(3000);
+      resolver.markKeyFailed('openai', 'rate_limit');
+
+      // Cooldown should still expire at original time (5s from start), not reset to 5s from now
+      // At 3s elapsed, 2s remaining from original cooldown
+      vi.advanceTimersByTime(2500);
+      const status = resolver.getStatus();
+      expect(status.cooldowns).toHaveLength(0);
+
+      vi.useRealTimers();
     });
   });
 
   describe('cooldown expiry', () => {
     it('restores keys after cooldown expires', () => {
       vi.useFakeTimers();
-      const resolver = new AuthResolver(makeConfig(), 5000);
+      const resolver = new AuthResolver(makeConfig(), { rateLimitMs: 5000 });
       resolver.markKeyFailed('anthropic', 'rate_limit');
       expect(resolver.getActiveKey('anthropic')?.keyIndex).toBe(1);
 
@@ -109,14 +169,13 @@ describe('AuthResolver', () => {
   });
 
   describe('resetFailures', () => {
-    it('clears all failures and cooldowns', () => {
+    it('clears all cooldowns', () => {
       const resolver = new AuthResolver(makeConfig());
       resolver.markKeyFailed('anthropic', 'auth');
       resolver.markKeyFailed('openai', 'rate_limit');
       resolver.resetFailures();
 
       const status = resolver.getStatus();
-      expect(status.failedKeys).toHaveLength(0);
       expect(status.cooldowns).toHaveLength(0);
       expect(status.activeProvider).toBe('anthropic');
     });
@@ -128,7 +187,6 @@ describe('AuthResolver', () => {
       const status = resolver.getStatus();
       expect(status.primary).toBe('anthropic');
       expect(status.activeProvider).toBe('anthropic');
-      expect(status.failedKeys).toHaveLength(0);
       expect(status.cooldowns).toHaveLength(0);
     });
   });

--- a/packages/server/src/agents/auth-resolver.ts
+++ b/packages/server/src/agents/auth-resolver.ts
@@ -14,8 +14,14 @@
 import type { LlmConfig, LlmKey, LlmProvider } from '@dscarabelli/shared';
 import { AuthStorage } from '@mariozechner/pi-coding-agent';
 
-/** Default cooldown period: 5 minutes */
+/** Default cooldown durations */
+const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 90 * 1000;
 const DEFAULT_COOLDOWN_MS = 5 * 60 * 1000;
+
+export interface CooldownConfig {
+  rateLimitMs: number;
+  defaultMs: number;
+}
 
 export interface ActiveKey {
   provider: LlmProvider;
@@ -38,13 +44,15 @@ interface KeyCooldown {
 export class AuthResolver {
   private config: LlmConfig;
   private activeKeys: Map<LlmProvider, number> = new Map();
-  private failedKeys: Set<string> = new Set();
   private cooldowns: Map<string, KeyCooldown> = new Map();
-  private cooldownMs: number;
+  private cooldownConfig: CooldownConfig;
 
-  constructor(llmConfig: LlmConfig, cooldownMs: number = DEFAULT_COOLDOWN_MS) {
+  constructor(llmConfig: LlmConfig, cooldownConfig?: Partial<CooldownConfig>) {
     this.config = this.validateConfig(llmConfig);
-    this.cooldownMs = cooldownMs;
+    this.cooldownConfig = {
+      rateLimitMs: cooldownConfig?.rateLimitMs ?? DEFAULT_RATE_LIMIT_COOLDOWN_MS,
+      defaultMs: cooldownConfig?.defaultMs ?? DEFAULT_COOLDOWN_MS,
+    };
 
     // Initialize active key index to 0 for each provider with keys
     for (const provider of Object.keys(this.config.providers) as LlmProvider[]) {
@@ -65,24 +73,18 @@ export class AuthResolver {
   }
 
   /**
-   * Check if a key is currently unavailable (failed or in cooldown).
+   * Check if a key is currently unavailable (in cooldown).
    */
   private isKeyUnavailable(keyId: string): boolean {
-    // Permanently failed (auth error)
-    if (this.failedKeys.has(keyId)) return true;
-
-    // Check cooldown
     const cooldown = this.cooldowns.get(keyId);
     if (cooldown) {
       if (Date.now() >= cooldown.expiresAt) {
-        // Cooldown expired, remove it
         this.cooldowns.delete(keyId);
         console.log(`[AuthResolver] Cooldown expired for ${keyId}, key available again`);
         return false;
       }
       return true;
     }
-
     return false;
   }
 
@@ -157,33 +159,36 @@ export class AuthResolver {
 
   /**
    * Mark the current key for a provider as failed.
+   * All failures use cooldown so the system recovers if the user fixes the issue.
    *
    * @param provider - The provider whose key failed
-   * @param reason - Why it failed: 'auth' = permanent, others = cooldown
+   * @param reason - Why it failed (determines cooldown duration for rate_limit)
+   * @param errorMessage - Original API error message for logging
    * @returns true if there's a fallback available (next key or next provider)
    */
   markKeyFailed(
     provider: LlmProvider,
-    reason: 'auth' | 'rate_limit' | 'transient' = 'transient'
+    reason: 'auth' | 'rate_limit' | 'transient' = 'transient',
+    errorMessage?: string
   ): boolean {
     const currentIndex = this.activeKeys.get(provider) ?? 0;
     const keyId = `${provider}:${currentIndex}`;
 
-    if (reason === 'auth') {
-      // Auth errors are permanent - key is invalid/revoked
-      this.failedKeys.add(keyId);
-      console.log(`[AuthResolver] Key permanently failed (auth error): ${keyId}`);
-    } else {
-      // Rate limits and transient errors go into cooldown
+    if (!this.cooldowns.has(keyId)) {
       const now = Date.now();
+      const duration =
+        reason === 'rate_limit' ? this.cooldownConfig.rateLimitMs : this.cooldownConfig.defaultMs;
       this.cooldowns.set(keyId, {
         startTime: now,
-        expiresAt: now + this.cooldownMs,
+        expiresAt: now + duration,
         reason,
       });
+      const detail = errorMessage ? `: ${errorMessage}` : '';
       console.log(
-        `[AuthResolver] Key in cooldown (${reason}): ${keyId}, expires in ${this.cooldownMs / 1000}s`
+        `[AuthResolver] Key in cooldown: ${keyId}, expires in ${duration / 1000}s${detail}`
       );
+    } else {
+      console.log(`[AuthResolver] Key ${keyId} already in cooldown, skipping`);
     }
 
     // Try to find next valid key for this provider
@@ -223,10 +228,9 @@ export class AuthResolver {
   }
 
   /**
-   * Reset all failed keys and cooldowns.
+   * Reset all cooldowns.
    */
   resetFailures(): void {
-    this.failedKeys.clear();
     this.cooldowns.clear();
     // Reset to first key for each provider
     for (const provider of Object.keys(this.config.providers) as LlmProvider[]) {
@@ -279,7 +283,6 @@ export class AuthResolver {
   getStatus(): {
     primary: LlmProvider;
     activeProvider: LlmProvider | undefined;
-    failedKeys: string[];
     cooldowns: { keyId: string; reason: string; expiresIn: number }[];
   } {
     // Clear expired cooldowns first
@@ -294,7 +297,6 @@ export class AuthResolver {
     return {
       primary: this.config.primary,
       activeProvider: this.getNextProvider(),
-      failedKeys: Array.from(this.failedKeys),
       cooldowns: cooldownInfo,
     };
   }

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -719,7 +719,48 @@ describe('AgentHost', () => {
       expect(internal._chatCache.push).toHaveBeenCalledOnce();
       const pushed = internal._chatCache.push.mock.calls[0][0];
       expect(pushed.role).toBe('system');
-      expect(pushed.content).toBe('Rate limit on google, switching to anthropic');
+      expect(pushed.content).toBe('429 rate_limit on google, switching to anthropic');
+    });
+
+    it('pushes key rotation message when staying on same provider', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as {
+        handlePotentialError: (event: unknown) => Promise<void>;
+        currentProvider: string;
+        _chatCache: { push: ReturnType<typeof vi.fn>; getMessages: ReturnType<typeof vi.fn> };
+        authResolver: {
+          markKeyFailed: ReturnType<typeof vi.fn>;
+          getNextProvider: ReturnType<typeof vi.fn>;
+        };
+        reinitializeWithProvider: ReturnType<typeof vi.fn>;
+        retryAttempts: Map<string, number>;
+        session: unknown;
+      };
+
+      internal.session = { prompt: vi.fn() };
+      internal._chatCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
+      internal.currentProvider = 'google';
+      internal.authResolver.markKeyFailed = vi.fn().mockReturnValue(true);
+      // Same provider returned — key rotation, not provider switch
+      internal.authResolver.getNextProvider = vi.fn().mockReturnValue('google');
+      internal.reinitializeWithProvider = vi.fn().mockResolvedValue(undefined);
+
+      internal.retryAttempts.set('google:rate_limit', 7);
+      await internal.handlePotentialError({
+        type: 'message_end',
+        message: { stopReason: 'error', errorMessage: 'Error 429: rate limit exceeded' },
+      });
+
+      expect(internal._chatCache.push).toHaveBeenCalledOnce();
+      const pushed = internal._chatCache.push.mock.calls[0][0];
+      expect(pushed.role).toBe('system');
+      expect(pushed.content).toBe('429 rate_limit on google, rotating to next key');
     });
 
     it('pushes unavailable message when no providers remain', async () => {
@@ -757,7 +798,7 @@ describe('AgentHost', () => {
       expect(internal._chatCache.push).toHaveBeenCalledOnce();
       const pushed = internal._chatCache.push.mock.calls[0][0];
       expect(pushed.role).toBe('system');
-      expect(pushed.content).toBe('All providers unavailable, error will surface in chat');
+      expect(pushed.content).toBe('401 auth on cerebras, all providers unavailable');
     });
   });
 
@@ -835,6 +876,103 @@ describe('AgentHost', () => {
       // Should have retried (attempt incremented), NOT failed over
       expect(internal.retryAttempts.get('cerebras:rate_limit')).toBe(1);
       expect(internal.reinitializeWithProvider).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('failover and recovery', () => {
+    it('fails over on client error to available provider', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as {
+        handlePotentialError: (event: unknown) => Promise<void>;
+        currentProvider: string;
+        _chatCache: { push: ReturnType<typeof vi.fn>; getMessages: ReturnType<typeof vi.fn> };
+        authResolver: {
+          getActiveKey: ReturnType<typeof vi.fn>;
+          markKeyFailed: ReturnType<typeof vi.fn>;
+          getNextProvider: ReturnType<typeof vi.fn>;
+        };
+        reinitializeWithProvider: ReturnType<typeof vi.fn>;
+        retryAttempts: Map<string, number>;
+        session: unknown;
+        busy: boolean;
+      };
+
+      internal.session = { prompt: vi.fn() };
+      internal._chatCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
+      internal.currentProvider = 'anthropic';
+      internal.reinitializeWithProvider = vi.fn().mockResolvedValue(undefined);
+
+      internal.authResolver.getActiveKey = vi
+        .fn()
+        .mockReturnValue({ provider: 'anthropic', keyIndex: 0, label: 'main' });
+      internal.authResolver.markKeyFailed = vi.fn().mockReturnValue(true);
+      internal.authResolver.getNextProvider = vi.fn().mockReturnValue('google');
+
+      await internal.handlePotentialError({
+        type: 'message_end',
+        message: { stopReason: 'error', errorMessage: 'Error 400: credit balance too low' },
+      });
+
+      expect(internal.reinitializeWithProvider).toHaveBeenCalledWith('google', null);
+      const pushed = internal._chatCache.push.mock.calls[0][0];
+      expect(pushed.role).toBe('system');
+      expect(pushed.content).toBe('400 client on anthropic, switching to google');
+    });
+
+    it('gives up when all providers exhausted', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as {
+        handlePotentialError: (event: unknown) => Promise<void>;
+        currentProvider: string;
+        _chatCache: { push: ReturnType<typeof vi.fn>; getMessages: ReturnType<typeof vi.fn> };
+        authResolver: {
+          getActiveKey: ReturnType<typeof vi.fn>;
+          markKeyFailed: ReturnType<typeof vi.fn>;
+          getNextProvider: ReturnType<typeof vi.fn>;
+        };
+        reinitializeWithProvider: ReturnType<typeof vi.fn>;
+        retryAttempts: Map<string, number>;
+        session: unknown;
+        busy: boolean;
+      };
+
+      internal.session = { prompt: vi.fn() };
+      internal._chatCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
+      internal.currentProvider = 'anthropic';
+      internal.busy = true;
+      internal.reinitializeWithProvider = vi.fn();
+
+      // All providers exhausted
+      internal.authResolver.getActiveKey = vi
+        .fn()
+        .mockReturnValue({ provider: 'anthropic', keyIndex: 0, label: 'main' });
+      internal.authResolver.markKeyFailed = vi.fn().mockReturnValue(false);
+      internal.authResolver.getNextProvider = vi.fn().mockReturnValue('anthropic');
+
+      await internal.handlePotentialError({
+        type: 'message_end',
+        message: { stopReason: 'error', errorMessage: 'Error 400: credit balance too low' },
+      });
+
+      // Should NOT have switched
+      expect(internal.reinitializeWithProvider).not.toHaveBeenCalled();
+      // Busy should be cleared
+      expect(internal.busy).toBe(false);
+      // Should show error details in the exhausted message
+      const pushed = internal._chatCache.push.mock.calls[0][0];
+      expect(pushed.content).toBe('400 client on anthropic, all providers unavailable');
     });
   });
 

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -34,7 +34,14 @@ import type { DatabaseClient } from '../db/client.js';
 import { resolveProjectDir } from '../projects/dir.js';
 import { AuthResolver } from './auth-resolver.js';
 import type { AgentRegistry } from './registry.js';
-import { calculateDelay, categorizeError, shouldFailover, shouldRetry, sleep } from './retry.js';
+import {
+  calculateDelay,
+  categorizeError,
+  extractStatusCode,
+  shouldFailover,
+  shouldRetry,
+  sleep,
+} from './retry.js';
 import { parseSessionEntries, rotateSessionIfNeeded } from './session-rotation.js';
 import { createBashTool } from './tools/bash.js';
 import { createEditTool } from './tools/edit.js';
@@ -409,8 +416,10 @@ export class AgentHost {
     const errorMessage = message.errorMessage;
     console.log('[AgentHost] API error detected:', errorMessage);
 
-    // Categorize the error
+    // Categorize the error and extract status code for user-facing messages
     const category = categorizeError({ message: errorMessage });
+    const statusCode = extractStatusCode({ message: errorMessage });
+    const errorPrefix = statusCode ? `${statusCode} ${category}` : category;
     console.log('[AgentHost] Error category:', category);
 
     // Get retry key for this error type
@@ -428,7 +437,7 @@ export class AgentHost {
           `[AgentHost] Provider ${this.currentProvider} already in cooldown, failing over to ${nextProvider}`
         );
         this.pushSystemMessage(
-          `${this.currentProvider} in cooldown (another agent hit rate limit), switching to ${nextProvider}`
+          `${errorPrefix} on ${this.currentProvider} (key already in cooldown), switching to ${nextProvider}`
         );
         await this.reinitializeWithProvider(nextProvider, promptToRetry);
         return;
@@ -467,22 +476,35 @@ export class AgentHost {
         category === 'auth' ? 'auth' : category === 'rate_limit' ? 'rate_limit' : 'transient';
 
       // Mark current key as failed
-      const hasMore = this.authResolver.markKeyFailed(this.currentProvider, failureReason);
+      const hasMore = this.authResolver.markKeyFailed(
+        this.currentProvider,
+        failureReason,
+        errorMessage
+      );
 
       if (hasMore) {
         // Get next available provider
         const nextProvider = this.authResolver.getNextProvider();
         if (nextProvider) {
-          console.log(`[AgentHost] Failing over from ${this.currentProvider} to ${nextProvider}`);
-          this.pushSystemMessage(
-            `${category === 'rate_limit' ? 'Rate limit' : 'API error'} on ${this.currentProvider}, switching to ${nextProvider}`
-          );
+          if (nextProvider === this.currentProvider) {
+            console.log(`[AgentHost] Rotating to next key for ${this.currentProvider}`);
+            this.pushSystemMessage(
+              `${errorPrefix} on ${this.currentProvider}, rotating to next key`
+            );
+          } else {
+            console.log(`[AgentHost] Failing over from ${this.currentProvider} to ${nextProvider}`);
+            this.pushSystemMessage(
+              `${errorPrefix} on ${this.currentProvider}, switching to ${nextProvider}`
+            );
+          }
           await this.reinitializeWithProvider(nextProvider, promptToRetry);
           return;
         }
       }
 
-      this.pushSystemMessage('All providers unavailable, error will surface in chat');
+      this.pushSystemMessage(
+        `${errorPrefix} on ${this.currentProvider}, all providers unavailable`
+      );
       console.log('[AgentHost] No fallback providers available, error will be surfaced to user');
     }
 
@@ -501,6 +523,20 @@ export class AgentHost {
       }
       // Recovery was a no-op — reset guard so a future overflow can try again
       this.contextOverflowHandled = false;
+    }
+
+    // Last resort: if a different provider is available (e.g., primary came out of cooldown),
+    // switch to it. This covers cases like being stuck on a dead fallback provider.
+    const nextProvider = this.authResolver.getNextProvider();
+    if (nextProvider && nextProvider !== this.currentProvider) {
+      console.log(
+        `[AgentHost] Recovery: switching from ${this.currentProvider} to ${nextProvider}`
+      );
+      this.pushSystemMessage(
+        `${errorPrefix} on ${this.currentProvider}, switching to ${nextProvider}`
+      );
+      await this.reinitializeWithProvider(nextProvider, promptToRetry);
+      return;
     }
 
     // All recovery paths exhausted; ensure busy is cleared

--- a/packages/server/src/agents/retry.test.ts
+++ b/packages/server/src/agents/retry.test.ts
@@ -204,9 +204,9 @@ describe('shouldFailover', () => {
     expect(shouldFailover('auth', true)).toBe(true);
   });
 
-  it('never fails over on client errors', () => {
-    expect(shouldFailover('client', false)).toBe(false);
-    expect(shouldFailover('client', true)).toBe(false);
+  it('immediately fails over on client errors', () => {
+    expect(shouldFailover('client', false)).toBe(true);
+    expect(shouldFailover('client', true)).toBe(true);
   });
 
   it('never fails over on context_overflow errors', () => {

--- a/packages/server/src/agents/retry.ts
+++ b/packages/server/src/agents/retry.ts
@@ -31,7 +31,7 @@ export type ErrorCategory =
   | 'rate_limit' // 429 - exponential retry, then failover
   | 'transient' // 500, 503, timeout - brief retry, then failover
   | 'context_overflow' // 400 with token limit exceeded - compact and retry
-  | 'client' // 400 - no retry, surface error
+  | 'client' // 400 - no retry, immediate failover
   | 'unknown'; // unexpected - treat as transient
 
 /**
@@ -102,7 +102,7 @@ function isContextOverflow(message: string): boolean {
 /**
  * Extract HTTP status code from various error formats.
  */
-function extractStatusCode(error: unknown): number | undefined {
+export function extractStatusCode(error: unknown): number | undefined {
   if (!error || typeof error !== 'object') return undefined;
 
   const err = error as Record<string, unknown>;
@@ -202,8 +202,11 @@ export function shouldFailover(category: ErrorCategory, retriesExhausted: boolea
       // Failover only after retries exhausted
       return retriesExhausted;
     case 'client':
+      // Immediate failover for client errors (e.g., credit balance too low).
+      // Key goes into cooldown so the system recovers if the user fixes the issue.
+      return true;
     case 'context_overflow':
-      // Never failover for client or context overflow errors (another provider has the same context)
+      // Never failover for context overflow (another provider has the same context)
       return false;
   }
 }


### PR DESCRIPTION
## Summary

- All error types (auth, client, rate limit, transient) now use cooldown instead of permanent failure, so the system auto-recovers if the user fixes the issue (rotates key, adds credits, adjusts permissions)
- Rate limit (429) uses 90s cooldown; everything else (400, 401, 403, 5xx) uses 5 min cooldown
- Client (400) errors trigger immediate failover (previously no failover, agents got stuck on dead providers)
- Chat messages show status code and category (e.g. "429 rate_limit on google, switching to anthropic") and distinguish key rotation from provider switch
- Full API error string logged in system2.log on cooldown
- Cooldown not reset if key already in cooldown (prevents lockout extension from multiple agents)
- Last-resort provider recovery when stuck on dead fallback

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (395 tests)
- [ ] Manual: trigger 429 on primary, verify 90s cooldown and failover message in chat
- [ ] Manual: trigger 400 on fallback, verify immediate failover back to primary after cooldown expires
- [ ] Manual: verify system2.log shows full API error on cooldown entry