### PR TITLE
fix: track key index per agent to prevent cross-agent cooldown corruption

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -134,7 +134,7 @@ A simple `Map<number, AgentHost>` that maps agent database IDs to active AgentHo
 
 Manages API key rotation and multi-provider failover. Providers and API keys are defined in [Configuration](configuration.md).
 
-**Shared state, per-agent provider choice:** one `AuthResolver` instance lives in `server.ts` and is shared by all `AgentHost`s. Key cooldown state is global: if Agent A puts a key in cooldown, Agent B sees it too. But each agent tracks its own `currentProvider` independently and only consults the resolver at failover time or reinitialization. There is no push mechanism: agents discover key failures when they hit errors themselves.
+**Shared state, per-agent provider choice:** one `AuthResolver` instance lives in `server.ts` and is shared by all `AgentHost`s. Key cooldown state is global: if Agent A puts a key in cooldown, Agent B sees it too. But each agent tracks its own `currentProvider` and `currentKeyIndex` independently, and only consults the resolver at failover time or reinitialization. There is no push mechanism: agents discover key failures when they hit errors themselves. The `currentKeyIndex` ensures each agent marks the correct key in cooldown, even when another agent has already rotated the shared key index.
 
 ### Key Rotation
 
@@ -162,7 +162,7 @@ When `AgentHost` detects an API error in a `message_end` event:
 4. Reinitialize the session with the new provider (`reinitializeWithProvider()`)
 5. Retry the pending prompt
 
-Error details (status code and category) are shown in agent chat messages so the user can diagnose issues. Key rotation within a provider: "429 rate_limit on google, rotating to next key". Provider switch: "429 rate_limit on google, switching to anthropic".
+Error details (status code and human-readable category) are shown in agent chat messages so the user can diagnose issues. Key rotation within a provider: "429 rate limited on google, rotating to next key". Provider switch: "429 rate limited on google, switching to anthropic".
 
 ### Retry Logic (`retry.ts`)
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -48,12 +48,14 @@ type ServerMessage =
   | { type: 'tool_call_end'; name: string; result: string; agentId?: number }
   | { type: 'artifact'; url: string; title?: string; filePath?: string }
   | { type: 'context_usage'; percent: number | null; tokens: number | null; contextWindow: number; agentId?: number }
-  | { type: 'provider_info'; provider: string }
-  | { type: 'provider_change'; provider: string }
+  | { type: 'provider_info'; provider: string; agentId: number }
+  | { type: 'provider_change'; provider: string; reason?: string; agentId: number }
   | { type: 'error'; message: string; agentId?: number }
   | { type: 'ready_for_input'; agentId?: number }
   | { type: 'chat_history'; messages: ChatMessage[]; agentId: number }
-  | { type: 'user_message_broadcast'; id: string; content: string; timestamp: number; agentId?: number };
+  | { type: 'user_message_broadcast'; id: string; content: string; timestamp: number; agentId?: number }
+  | { type: 'compaction_start'; agentId?: number }
+  | { type: 'compaction_end'; agentId?: number };
 ```
 
 | Message | Description |
@@ -63,8 +65,8 @@ type ServerMessage =
 | `tool_call_start` / `tool_call_end` | Tool execution lifecycle |
 | `artifact` | Display artifact in a UI tab. Includes `title` (from DB or filename) and `filePath` (absolute path for tab dedup and reload targeting). Also sent on live reload (file watch). |
 | `context_usage` | Context window usage after each agent turn |
-| `provider_info` | Sent on connect: current LLM provider name |
-| `provider_change` | Sent on failover: provider switched due to API issues |
+| `provider_info` | Sent on connect/switch: current LLM provider for an agent |
+| `provider_change` | Sent on failover: provider switched. Includes `reason` (status code + category) and `agentId` so the UI routes the system message to the correct agent chat |
 | `error` | Error message |
 | `ready_for_input` | Agent finished, ready for next message |
 | `chat_history` | Sent on connect (Guide) and on `switch_agent`: recent messages for the specified agent |

--- a/packages/server/src/agents/auth-resolver.test.ts
+++ b/packages/server/src/agents/auth-resolver.test.ts
@@ -151,6 +151,33 @@ describe('AuthResolver', () => {
     });
   });
 
+  describe('isKeyInCooldown', () => {
+    it('returns true for a key in cooldown', () => {
+      const resolver = new AuthResolver(makeConfig());
+      resolver.markKeyFailed('anthropic', 'rate_limit', undefined, 0);
+      expect(resolver.isKeyInCooldown('anthropic', 0)).toBe(true);
+      expect(resolver.isKeyInCooldown('anthropic', 1)).toBe(false);
+    });
+  });
+
+  describe('markKeyFailed with explicit keyIndex', () => {
+    it('marks the specified key, not the global active index', () => {
+      const resolver = new AuthResolver(makeConfig());
+
+      // Simulate Agent A rotating from key 0 to key 1
+      resolver.markKeyFailed('anthropic', 'rate_limit', undefined, 0);
+      expect(resolver.getActiveKey('anthropic')?.keyIndex).toBe(1);
+
+      // Simulate Agent B (still using key 0) reporting the same failure.
+      // Without explicit keyIndex, this would mark key 1 (the current active).
+      // With explicit keyIndex=0, it should be a no-op (already in cooldown).
+      resolver.markKeyFailed('anthropic', 'rate_limit', undefined, 0);
+      // Key 1 should NOT be in cooldown
+      expect(resolver.isKeyInCooldown('anthropic', 1)).toBe(false);
+      expect(resolver.getActiveKey('anthropic')?.keyIndex).toBe(1);
+    });
+  });
+
   describe('cooldown expiry', () => {
     it('restores keys after cooldown expires', () => {
       vi.useFakeTimers();

--- a/packages/server/src/agents/auth-resolver.ts
+++ b/packages/server/src/agents/auth-resolver.ts
@@ -158,20 +158,30 @@ export class AuthResolver {
   }
 
   /**
-   * Mark the current key for a provider as failed.
+   * Check if a specific key is currently in cooldown.
+   * Used by AgentHost to detect when another agent has already put its key in cooldown.
+   */
+  isKeyInCooldown(provider: LlmProvider, keyIndex: number): boolean {
+    return this.isKeyUnavailable(`${provider}:${keyIndex}`);
+  }
+
+  /**
+   * Mark a specific key for a provider as failed.
    * All failures use cooldown so the system recovers if the user fixes the issue.
    *
    * @param provider - The provider whose key failed
    * @param reason - Why it failed (determines cooldown duration for rate_limit)
    * @param errorMessage - Original API error message for logging
+   * @param keyIndex - The specific key index that failed (avoids stale global state when multiple agents share the resolver)
    * @returns true if there's a fallback available (next key or next provider)
    */
   markKeyFailed(
     provider: LlmProvider,
     reason: 'auth' | 'rate_limit' | 'transient' = 'transient',
-    errorMessage?: string
+    errorMessage?: string,
+    keyIndex?: number
   ): boolean {
-    const currentIndex = this.activeKeys.get(provider) ?? 0;
+    const currentIndex = keyIndex ?? this.activeKeys.get(provider) ?? 0;
     const keyId = `${provider}:${currentIndex}`;
 
     if (!this.cooldowns.has(keyId)) {

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -736,7 +736,7 @@ describe('AgentHost', () => {
   });
 
   describe('pushSystemMessage on failover', () => {
-    it('pushes a system message to chatCache before switching provider', async () => {
+    it('passes reason to reinitializeWithProvider when switching provider', async () => {
       const host = new AgentHost({
         db: makeDbStub(),
         agentId: 1,
@@ -747,8 +747,9 @@ describe('AgentHost', () => {
       const internal = host as unknown as {
         handlePotentialError: (event: unknown) => Promise<void>;
         currentProvider: string;
-        _chatCache: { push: ReturnType<typeof vi.fn>; getMessages: ReturnType<typeof vi.fn> };
+        currentKeyIndex: number;
         authResolver: {
+          isKeyInCooldown: ReturnType<typeof vi.fn>;
           markKeyFailed: ReturnType<typeof vi.fn>;
           getNextProvider: ReturnType<typeof vi.fn>;
         };
@@ -758,8 +759,9 @@ describe('AgentHost', () => {
       };
 
       internal.session = { prompt: vi.fn() };
-      internal._chatCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
       internal.currentProvider = 'google';
+      internal.currentKeyIndex = 0;
+      internal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
       internal.authResolver.markKeyFailed = vi.fn().mockReturnValue(true);
       internal.authResolver.getNextProvider = vi.fn().mockReturnValue('anthropic');
       internal.reinitializeWithProvider = vi.fn().mockResolvedValue(undefined);
@@ -771,13 +773,14 @@ describe('AgentHost', () => {
         message: { stopReason: 'error', errorMessage: 'Error 429: rate limit exceeded' },
       });
 
-      expect(internal._chatCache.push).toHaveBeenCalledOnce();
-      const pushed = internal._chatCache.push.mock.calls[0][0];
-      expect(pushed.role).toBe('system');
-      expect(pushed.content).toBe('429 rate_limit on google, switching to anthropic');
+      expect(internal.reinitializeWithProvider).toHaveBeenCalledWith(
+        'anthropic',
+        null,
+        '429 rate limited on google, switching to anthropic'
+      );
     });
 
-    it('pushes key rotation message when staying on same provider', async () => {
+    it('passes key rotation reason when staying on same provider', async () => {
       const host = new AgentHost({
         db: makeDbStub(),
         agentId: 1,
@@ -788,8 +791,9 @@ describe('AgentHost', () => {
       const internal = host as unknown as {
         handlePotentialError: (event: unknown) => Promise<void>;
         currentProvider: string;
-        _chatCache: { push: ReturnType<typeof vi.fn>; getMessages: ReturnType<typeof vi.fn> };
+        currentKeyIndex: number;
         authResolver: {
+          isKeyInCooldown: ReturnType<typeof vi.fn>;
           markKeyFailed: ReturnType<typeof vi.fn>;
           getNextProvider: ReturnType<typeof vi.fn>;
         };
@@ -799,8 +803,9 @@ describe('AgentHost', () => {
       };
 
       internal.session = { prompt: vi.fn() };
-      internal._chatCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
       internal.currentProvider = 'google';
+      internal.currentKeyIndex = 0;
+      internal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
       internal.authResolver.markKeyFailed = vi.fn().mockReturnValue(true);
       // Same provider returned — key rotation, not provider switch
       internal.authResolver.getNextProvider = vi.fn().mockReturnValue('google');
@@ -812,10 +817,11 @@ describe('AgentHost', () => {
         message: { stopReason: 'error', errorMessage: 'Error 429: rate limit exceeded' },
       });
 
-      expect(internal._chatCache.push).toHaveBeenCalledOnce();
-      const pushed = internal._chatCache.push.mock.calls[0][0];
-      expect(pushed.role).toBe('system');
-      expect(pushed.content).toBe('429 rate_limit on google, rotating to next key');
+      expect(internal.reinitializeWithProvider).toHaveBeenCalledWith(
+        'google',
+        null,
+        '429 rate limited on google, rotating to next key'
+      );
     });
 
     it('pushes unavailable message when no providers remain', async () => {
@@ -829,8 +835,10 @@ describe('AgentHost', () => {
       const internal = host as unknown as {
         handlePotentialError: (event: unknown) => Promise<void>;
         currentProvider: string;
+        currentKeyIndex: number;
         _chatCache: { push: ReturnType<typeof vi.fn>; getMessages: ReturnType<typeof vi.fn> };
         authResolver: {
+          isKeyInCooldown: ReturnType<typeof vi.fn>;
           markKeyFailed: ReturnType<typeof vi.fn>;
           getNextProvider: ReturnType<typeof vi.fn>;
         };
@@ -842,6 +850,8 @@ describe('AgentHost', () => {
       internal.session = { prompt: vi.fn() };
       internal._chatCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
       internal.currentProvider = 'cerebras';
+      internal.currentKeyIndex = 0;
+      internal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
       internal.authResolver.markKeyFailed = vi.fn().mockReturnValue(true);
       internal.authResolver.getNextProvider = vi.fn().mockReturnValue(null);
 
@@ -853,12 +863,12 @@ describe('AgentHost', () => {
       expect(internal._chatCache.push).toHaveBeenCalledOnce();
       const pushed = internal._chatCache.push.mock.calls[0][0];
       expect(pushed.role).toBe('system');
-      expect(pushed.content).toBe('401 auth on cerebras, all providers unavailable');
+      expect(pushed.content).toBe('401 auth error on cerebras, all providers unavailable');
     });
   });
 
   describe('shared AuthResolver early-out', () => {
-    it('skips retries and fails over immediately when provider key is already in cooldown', async () => {
+    it('skips retries and fails over immediately when our key is already in cooldown', async () => {
       const host = new AgentHost({
         db: makeDbStub(),
         agentId: 1,
@@ -869,7 +879,7 @@ describe('AgentHost', () => {
       const internal = host as unknown as {
         handlePotentialError: (event: unknown) => Promise<void>;
         currentProvider: string;
-        _chatCache: { push: ReturnType<typeof vi.fn>; getMessages: ReturnType<typeof vi.fn> };
+        currentKeyIndex: number;
         authResolver: import('./auth-resolver.js').AuthResolver;
         reinitializeWithProvider: ReturnType<typeof vi.fn>;
         retryAttempts: Map<string, number>;
@@ -877,12 +887,12 @@ describe('AgentHost', () => {
       };
 
       internal.session = { prompt: vi.fn() };
-      internal._chatCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
       internal.currentProvider = 'cerebras';
+      internal.currentKeyIndex = 0;
       internal.reinitializeWithProvider = vi.fn().mockResolvedValue(undefined);
 
-      // Simulate another agent having already put cerebras in cooldown
-      internal.authResolver.markKeyFailed('cerebras', 'rate_limit');
+      // Simulate another agent having already put cerebras key 0 in cooldown
+      internal.authResolver.markKeyFailed('cerebras', 'rate_limit', undefined, 0);
 
       // Fire a rate limit error (attempt 0, normally would retry)
       expect(internal.retryAttempts.get('cerebras:rate_limit')).toBeUndefined();
@@ -892,14 +902,14 @@ describe('AgentHost', () => {
       });
 
       // Should have skipped retries and failed over directly to google
-      expect(internal.reinitializeWithProvider).toHaveBeenCalledWith('google', null);
-      // System message should mention the cooldown
-      const pushed = internal._chatCache.push.mock.calls[0][0];
-      expect(pushed.role).toBe('system');
-      expect(pushed.content).toContain('cooldown');
+      expect(internal.reinitializeWithProvider).toHaveBeenCalledWith(
+        'google',
+        null,
+        expect.stringContaining('cooldown')
+      );
     });
 
-    it('proceeds with normal retries when provider key is not in cooldown', async () => {
+    it('proceeds with normal retries when our key is not in cooldown', async () => {
       const host = new AgentHost({
         db: makeDbStub(),
         agentId: 1,
@@ -910,6 +920,7 @@ describe('AgentHost', () => {
       const internal = host as unknown as {
         handlePotentialError: (event: unknown) => Promise<void>;
         currentProvider: string;
+        currentKeyIndex: number;
         authResolver: import('./auth-resolver.js').AuthResolver;
         reinitializeWithProvider: ReturnType<typeof vi.fn>;
         retryAttempts: Map<string, number>;
@@ -919,6 +930,7 @@ describe('AgentHost', () => {
 
       internal.session = { prompt: vi.fn().mockResolvedValue(undefined) };
       internal.currentProvider = 'cerebras';
+      internal.currentKeyIndex = 0;
       internal.pendingPrompt = 'test';
       internal.reinitializeWithProvider = vi.fn();
 
@@ -946,9 +958,9 @@ describe('AgentHost', () => {
       const internal = host as unknown as {
         handlePotentialError: (event: unknown) => Promise<void>;
         currentProvider: string;
-        _chatCache: { push: ReturnType<typeof vi.fn>; getMessages: ReturnType<typeof vi.fn> };
+        currentKeyIndex: number;
         authResolver: {
-          getActiveKey: ReturnType<typeof vi.fn>;
+          isKeyInCooldown: ReturnType<typeof vi.fn>;
           markKeyFailed: ReturnType<typeof vi.fn>;
           getNextProvider: ReturnType<typeof vi.fn>;
         };
@@ -959,13 +971,11 @@ describe('AgentHost', () => {
       };
 
       internal.session = { prompt: vi.fn() };
-      internal._chatCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
       internal.currentProvider = 'anthropic';
+      internal.currentKeyIndex = 0;
       internal.reinitializeWithProvider = vi.fn().mockResolvedValue(undefined);
 
-      internal.authResolver.getActiveKey = vi
-        .fn()
-        .mockReturnValue({ provider: 'anthropic', keyIndex: 0, label: 'main' });
+      internal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
       internal.authResolver.markKeyFailed = vi.fn().mockReturnValue(true);
       internal.authResolver.getNextProvider = vi.fn().mockReturnValue('google');
 
@@ -974,10 +984,11 @@ describe('AgentHost', () => {
         message: { stopReason: 'error', errorMessage: 'Error 400: credit balance too low' },
       });
 
-      expect(internal.reinitializeWithProvider).toHaveBeenCalledWith('google', null);
-      const pushed = internal._chatCache.push.mock.calls[0][0];
-      expect(pushed.role).toBe('system');
-      expect(pushed.content).toBe('400 client on anthropic, switching to google');
+      expect(internal.reinitializeWithProvider).toHaveBeenCalledWith(
+        'google',
+        null,
+        '400 client error on anthropic, switching to google'
+      );
     });
 
     it('gives up when all providers exhausted', async () => {
@@ -991,9 +1002,10 @@ describe('AgentHost', () => {
       const internal = host as unknown as {
         handlePotentialError: (event: unknown) => Promise<void>;
         currentProvider: string;
+        currentKeyIndex: number;
         _chatCache: { push: ReturnType<typeof vi.fn>; getMessages: ReturnType<typeof vi.fn> };
         authResolver: {
-          getActiveKey: ReturnType<typeof vi.fn>;
+          isKeyInCooldown: ReturnType<typeof vi.fn>;
           markKeyFailed: ReturnType<typeof vi.fn>;
           getNextProvider: ReturnType<typeof vi.fn>;
         };
@@ -1006,13 +1018,12 @@ describe('AgentHost', () => {
       internal.session = { prompt: vi.fn() };
       internal._chatCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
       internal.currentProvider = 'anthropic';
+      internal.currentKeyIndex = 0;
       internal.busy = true;
       internal.reinitializeWithProvider = vi.fn();
 
       // All providers exhausted
-      internal.authResolver.getActiveKey = vi
-        .fn()
-        .mockReturnValue({ provider: 'anthropic', keyIndex: 0, label: 'main' });
+      internal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
       internal.authResolver.markKeyFailed = vi.fn().mockReturnValue(false);
       internal.authResolver.getNextProvider = vi.fn().mockReturnValue('anthropic');
 
@@ -1027,7 +1038,7 @@ describe('AgentHost', () => {
       expect(internal.busy).toBe(false);
       // Should show error details in the exhausted message
       const pushed = internal._chatCache.push.mock.calls[0][0];
-      expect(pushed.content).toBe('400 client on anthropic, all providers unavailable');
+      expect(pushed.content).toBe('400 client error on anthropic, all providers unavailable');
     });
   });
 

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -599,6 +599,12 @@ export class AgentHost {
       this.currentProvider = provider;
       this.currentKeyIndex = this.authResolver.getActiveKey(provider)?.keyIndex ?? 0;
 
+      // Push chat message before init so the user sees the reason even if
+      // initialization fails. Only for actual failovers, not compaction recovery.
+      if (reason) {
+        this.pushSystemMessage(reason);
+      }
+
       // Recreate model registry with updated auth
       const authStorage = this.authResolver.createAuthStorage();
       this.modelRegistry = new ModelRegistry(authStorage);
@@ -609,9 +615,9 @@ export class AgentHost {
       // Clear retry attempts on successful reinit
       this.retryAttempts.clear();
 
-      // Notify UI of provider/key change (only for actual failovers, not compaction recovery)
+      // Notify UI of provider change (after init succeeds, so the provider
+      // indicator only updates when the switch actually worked)
       if (reason) {
-        this.pushSystemMessage(reason);
         const failoverEvent: AgentSessionEvent = {
           type: 'status' as AgentSessionEvent['type'],
           provider,
@@ -631,6 +637,10 @@ export class AgentHost {
       }
     } catch (error) {
       console.error('[AgentHost] Failed to reinitialize:', error);
+      if (reason) {
+        const msg = error instanceof Error ? error.message : String(error);
+        this.pushSystemMessage(`Failed to switch: ${msg}`);
+      }
     } finally {
       this.isReinitializing = false;
     }

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -310,6 +310,7 @@ export class AgentHost {
 
       llmProvider = resolvedProvider;
       this.currentProvider = resolvedProvider;
+      this.currentKeyIndex = this.authResolver.getActiveKey(resolvedProvider)?.keyIndex ?? 0;
     }
 
     console.log('[AgentHost] Selected model:', modelId, 'for provider:', llmProvider);

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -37,11 +37,31 @@ import type { AgentRegistry } from './registry.js';
 import {
   calculateDelay,
   categorizeError,
+  type ErrorCategory,
   extractStatusCode,
   shouldFailover,
   shouldRetry,
   sleep,
 } from './retry.js';
+
+/** Human-readable label for error categories shown in chat messages. */
+function categoryLabel(category: ErrorCategory): string {
+  switch (category) {
+    case 'auth':
+      return 'auth error';
+    case 'rate_limit':
+      return 'rate limited';
+    case 'transient':
+      return 'server error';
+    case 'client':
+      return 'client error';
+    case 'context_overflow':
+      return 'context overflow';
+    case 'unknown':
+      return 'error';
+  }
+}
+
 import { parseSessionEntries, rotateSessionIfNeeded } from './session-rotation.js';
 import { createBashTool } from './tools/bash.js';
 import { createEditTool } from './tools/edit.js';
@@ -116,6 +136,7 @@ export class AgentHost {
   private modelRegistry: ModelRegistry;
   private listeners: Set<(event: AgentSessionEvent) => void> = new Set();
   private currentProvider: LlmProvider;
+  private currentKeyIndex = 0;
   private retryAttempts: Map<string, number> = new Map(); // Track retries per error type
   private isReinitializing = false;
   private pendingPrompt: string | null = null;
@@ -152,6 +173,7 @@ export class AgentHost {
     const authStorage = this.authResolver.createAuthStorage();
     this.modelRegistry = new ModelRegistry(authStorage);
     this.currentProvider = this.authResolver.primaryProvider;
+    this.currentKeyIndex = this.authResolver.getActiveKey(this.currentProvider)?.keyIndex ?? 0;
 
     console.log('[AgentHost] Auth status:', this.authResolver.getStatus());
   }
@@ -416,10 +438,11 @@ export class AgentHost {
     const errorMessage = message.errorMessage;
     console.log('[AgentHost] API error detected:', errorMessage);
 
-    // Categorize the error and extract status code for user-facing messages
+    // Categorize the error and build human-readable prefix for chat messages
     const category = categorizeError({ message: errorMessage });
     const statusCode = extractStatusCode({ message: errorMessage });
-    const errorPrefix = statusCode ? `${statusCode} ${category}` : category;
+    const label = categoryLabel(category);
+    const errorPrefix = statusCode ? `${statusCode} ${label}` : label;
     console.log('[AgentHost] Error category:', category);
 
     // Get retry key for this error type
@@ -429,17 +452,20 @@ export class AgentHost {
     // Capture before any await — agent_end may clear it before this async handler resumes
     const promptToRetry = this.pendingPrompt;
 
-    // If another agent already put this provider's key in cooldown, skip retries and fail over
-    if (!this.authResolver.getActiveKey(this.currentProvider)) {
+    // If another agent already put our key in cooldown, skip retries and reinitialize.
+    // Uses the tracked key index so we check our actual key, not whatever index
+    // another agent may have rotated to.
+    if (this.authResolver.isKeyInCooldown(this.currentProvider, this.currentKeyIndex)) {
       const nextProvider = this.authResolver.getNextProvider();
-      if (nextProvider && nextProvider !== this.currentProvider) {
+      if (nextProvider) {
+        const reason =
+          nextProvider === this.currentProvider
+            ? `${errorPrefix} on ${this.currentProvider}, rotating to next key`
+            : `${errorPrefix} on ${this.currentProvider} (key already in cooldown), switching to ${nextProvider}`;
         console.log(
-          `[AgentHost] Provider ${this.currentProvider} already in cooldown, failing over to ${nextProvider}`
+          `[AgentHost] Key ${this.currentProvider}:${this.currentKeyIndex} already in cooldown`
         );
-        this.pushSystemMessage(
-          `${errorPrefix} on ${this.currentProvider} (key already in cooldown), switching to ${nextProvider}`
-        );
-        await this.reinitializeWithProvider(nextProvider, promptToRetry);
+        await this.reinitializeWithProvider(nextProvider, promptToRetry, reason);
         return;
       }
     }
@@ -475,11 +501,13 @@ export class AgentHost {
       const failureReason =
         category === 'auth' ? 'auth' : category === 'rate_limit' ? 'rate_limit' : 'transient';
 
-      // Mark current key as failed
+      // Mark our specific key as failed (pass currentKeyIndex to avoid marking the wrong key
+      // when another agent has already rotated the shared activeKeys index)
       const hasMore = this.authResolver.markKeyFailed(
         this.currentProvider,
         failureReason,
-        errorMessage
+        errorMessage,
+        this.currentKeyIndex
       );
 
       if (hasMore) {
@@ -487,17 +515,14 @@ export class AgentHost {
         const nextProvider = this.authResolver.getNextProvider();
         if (nextProvider) {
           if (nextProvider === this.currentProvider) {
+            const reason = `${errorPrefix} on ${this.currentProvider}, rotating to next key`;
             console.log(`[AgentHost] Rotating to next key for ${this.currentProvider}`);
-            this.pushSystemMessage(
-              `${errorPrefix} on ${this.currentProvider}, rotating to next key`
-            );
+            await this.reinitializeWithProvider(nextProvider, promptToRetry, reason);
           } else {
+            const reason = `${errorPrefix} on ${this.currentProvider}, switching to ${nextProvider}`;
             console.log(`[AgentHost] Failing over from ${this.currentProvider} to ${nextProvider}`);
-            this.pushSystemMessage(
-              `${errorPrefix} on ${this.currentProvider}, switching to ${nextProvider}`
-            );
+            await this.reinitializeWithProvider(nextProvider, promptToRetry, reason);
           }
-          await this.reinitializeWithProvider(nextProvider, promptToRetry);
           return;
         }
       }
@@ -529,13 +554,11 @@ export class AgentHost {
     // switch to it. This covers cases like being stuck on a dead fallback provider.
     const nextProvider = this.authResolver.getNextProvider();
     if (nextProvider && nextProvider !== this.currentProvider) {
+      const reason = `${errorPrefix} on ${this.currentProvider}, switching to ${nextProvider}`;
       console.log(
         `[AgentHost] Recovery: switching from ${this.currentProvider} to ${nextProvider}`
       );
-      this.pushSystemMessage(
-        `${errorPrefix} on ${this.currentProvider}, switching to ${nextProvider}`
-      );
-      await this.reinitializeWithProvider(nextProvider, promptToRetry);
+      await this.reinitializeWithProvider(nextProvider, promptToRetry, reason);
       return;
     }
 
@@ -550,10 +573,12 @@ export class AgentHost {
 
   /**
    * Reinitialize the agent session with a different provider.
+   * @param reason - Human-readable reason for the switch (shown in chat and UI status)
    */
   private async reinitializeWithProvider(
     provider: LlmProvider,
-    promptToRetry?: string | null
+    promptToRetry?: string | null,
+    reason?: string
   ): Promise<void> {
     if (this.isReinitializing) {
       console.log('[AgentHost] Already reinitializing, skipping');
@@ -569,8 +594,9 @@ export class AgentHost {
     }
 
     try {
-      // Update current provider
+      // Update current provider and key index
       this.currentProvider = provider;
+      this.currentKeyIndex = this.authResolver.getActiveKey(provider)?.keyIndex ?? 0;
 
       // Recreate model registry with updated auth
       const authStorage = this.authResolver.createAuthStorage();
@@ -582,15 +608,18 @@ export class AgentHost {
       // Clear retry attempts on successful reinit
       this.retryAttempts.clear();
 
-      // Emit a custom event to notify UI of provider change
-      const failoverEvent: AgentSessionEvent = {
-        type: 'status' as AgentSessionEvent['type'],
-        provider,
-        message: `Switched to ${provider} due to API issues`,
-      } as AgentSessionEvent;
-      this.listeners.forEach((listener) => {
-        listener(failoverEvent);
-      });
+      // Notify UI of provider/key change (only for actual failovers, not compaction recovery)
+      if (reason) {
+        this.pushSystemMessage(reason);
+        const failoverEvent: AgentSessionEvent = {
+          type: 'status' as AgentSessionEvent['type'],
+          provider,
+          reason,
+        } as AgentSessionEvent;
+        this.listeners.forEach((listener) => {
+          listener(failoverEvent);
+        });
+      }
 
       // Retry the pending prompt with the new provider
       if (promptToRetry && this.session) {

--- a/packages/server/src/websocket/handler.ts
+++ b/packages/server/src/websocket/handler.ts
@@ -201,9 +201,14 @@ export class WebSocketHandler {
     // Handle synthetic events (not part of AgentSessionEvent type)
     const eventType = event.type as string;
     if (eventType === 'status') {
-      const statusEvent = event as unknown as { provider?: string };
+      const statusEvent = event as unknown as { provider?: string; reason?: string };
       if (statusEvent.provider) {
-        this.send({ type: 'provider_change', provider: statusEvent.provider, agentId });
+        this.send({
+          type: 'provider_change',
+          provider: statusEvent.provider,
+          reason: statusEvent.reason,
+          agentId,
+        });
       }
       return;
     }

--- a/packages/shared/src/types/messages.ts
+++ b/packages/shared/src/types/messages.ts
@@ -42,6 +42,6 @@ export type ServerMessage =
       agentId?: number;
     }
   | { type: 'provider_info'; provider: string; agentId: number } // Sent on connect/switch — current LLM provider for an agent
-  | { type: 'provider_change'; provider: string; agentId: number } // Sent on failover — provider switched
+  | { type: 'provider_change'; provider: string; reason?: string; agentId: number } // Sent on failover — provider switched
   | { type: 'compaction_start'; agentId?: number } // Sent when auto-compaction begins
   | { type: 'compaction_end'; agentId?: number }; // Sent when auto-compaction completes

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -175,7 +175,7 @@ export function useWebSocket() {
 
         case 'provider_change':
           state.setProvider(message.provider, message.agentId);
-          state.addSystemMessage(`Switched to ${message.provider}`);
+          state.addSystemMessage(message.reason ?? `Switched to ${message.provider}`);
           break;
 
         case 'compaction_start': {

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -175,7 +175,10 @@ export function useWebSocket() {
 
         case 'provider_change':
           state.setProvider(message.provider, message.agentId);
-          state.addSystemMessage(message.reason ?? `Switched to ${message.provider}`);
+          state.addSystemMessage(
+            message.reason ?? `Switched to ${message.provider}`,
+            message.agentId
+          );
           break;
 
         case 'compaction_start': {

--- a/packages/ui/src/stores/chat.test.ts
+++ b/packages/ui/src/stores/chat.test.ts
@@ -191,6 +191,40 @@ describe('useChatStore', () => {
     });
   });
 
+  describe('addSystemMessage', () => {
+    it('routes to specified agentId instead of activeAgentId', () => {
+      useChatStore.getState().loadHistory([], 1);
+      useChatStore.getState().loadHistory([], 2);
+      useChatStore.setState({ activeAgentId: 1 });
+
+      // System message targets agent 2 (background agent failover)
+      useChatStore
+        .getState()
+        .addSystemMessage('429 rate_limit on google, switching to anthropic', 2);
+
+      // Agent 2 should have the message
+      const state2 = useChatStore.getState().agentStates.get(2);
+      expect(state2?.messages).toHaveLength(1);
+      expect(state2?.messages[0].role).toBe('system');
+      expect(state2?.messages[0].content).toContain('rate_limit');
+
+      // Agent 1 (active) should not
+      const state1 = useChatStore.getState().agentStates.get(1);
+      expect(state1?.messages).toHaveLength(0);
+    });
+
+    it('defaults to activeAgentId when agentId is omitted', () => {
+      useChatStore.getState().loadHistory([], 1);
+      useChatStore.setState({ activeAgentId: 1 });
+
+      useChatStore.getState().addSystemMessage('something happened');
+
+      const state = useChatStore.getState().agentStates.get(1);
+      expect(state?.messages).toHaveLength(1);
+      expect(state?.messages[0].role).toBe('system');
+    });
+  });
+
   describe('provider (per-agent state)', () => {
     it('setProvider updates only the specified agent', () => {
       useChatStore.getState().loadHistory([], 1);

--- a/packages/ui/src/stores/chat.ts
+++ b/packages/ui/src/stores/chat.ts
@@ -76,7 +76,7 @@ interface ChatState {
 
   // Actions (agentId optional, defaults to active agent)
   addUserMessage: (content: string, id?: string, timestamp?: number, agentId?: number) => void;
-  addSystemMessage: (content: string) => void;
+  addSystemMessage: (content: string, agentId?: number) => void;
   loadHistory: (messages: Message[], agentId: number) => void;
   startAssistantMessage: (agentId?: number) => void;
   appendAssistantChunk: (chunk: string, agentId?: number) => void;
@@ -185,8 +185,8 @@ export const useChatStore = create<ChatState>()(
         }));
       },
 
-      addSystemMessage: (content: string) => {
-        const targetId = get().activeAgentId;
+      addSystemMessage: (content: string, agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
         if (targetId === null) return;
 
         const message: Message = {


### PR DESCRIPTION
## Summary

- **Key index tracking**: Each `AgentHost` now tracks its own `currentKeyIndex` and passes it explicitly to `markKeyFailed`, preventing agents from putting the wrong key in cooldown when another agent has already rotated the shared index.
- **Error details in UI**: Failover reason is propagated through the status event to WebSocket to the UI, replacing the hardcoded "Switched to {provider}" message with the actual error details.
- **Human-readable labels**: Chat messages now show "429 rate limited" instead of "429 rate_limit", "400 client error" instead of "400 client", etc.
- **Compaction event suppression**: `reinitializeWithProvider` only emits a status event when a reason is provided, preventing misleading "Switched to" messages during context overflow recovery.

Fixes the bug where Guide agent gets stuck on a dead fallback provider because Narrator had already rotated the shared `activeKeys` index, causing Guide to mark the wrong key in cooldown.

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (399 tests, +2 new: `isKeyInCooldown`, `markKeyFailed with explicit keyIndex`)
- [ ] Manual: add a bad API key as first key for a provider, verify both agents show detailed error messages and recover correctly