### PR TITLE
fix: prevent stale session creation on restart and unsafe runtime rotation

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -18,7 +18,7 @@ System2's agents are built on the [pi-coding-agent](https://github.com/badlogic/
 | **Conductor** | Orchestrates and executes work within a project: breaks it into tasks, spawns specialist agents or executes directly, and coordinates with the Reviewer before reporting completion. | Per-project, ephemeral | claude-sonnet-4-6, gpt-4o, gemini-2.5-flash |
 | **Reviewer** | Critically assesses work before it is considered complete. | Per-project, ephemeral | claude-sonnet-4-6, gpt-4o, gemini-2.5-flash |
 
-**Guide and Narrator** are singletons created at server startup. Their sessions persist indefinitely across restarts (via `SessionManager.continueRecent()`).
+**Guide and Narrator** are singletons created at server startup. Their sessions persist indefinitely across restarts.
 
 **Conductor and Reviewer** are project-scoped, spawned by Guide for every project and archived when done. The Guide uses the `spawn_agent` tool to create both simultaneously at project creation time. Spawned agents receive the same spawner callback, so Conductors can spawn additional specialist data agents within their own project. On server restart, all non-archived project-scoped agents are restored automatically. If an agent fails to restore, its status remains `active` in the database, the error is logged, and the Guide is notified so it can investigate.
 
@@ -213,9 +213,10 @@ Agent sessions are persisted as JSONL files in `~/.system2/sessions/{role}_{id}/
 - **Session format:** tree structure with `id` and `parentId` for in-place branching
 - **Auto-compaction:** when context approaches model limits, older messages are summarized
 - **Compaction pruning:** long-running agents can set `compaction_depth: N` in their frontmatter. After N auto-compactions, a manual "pruning" compaction runs at 30% context usage. It uses the Nth oldest compaction summary as a baseline to shed stale information, creating a sliding window instead of an ever-growing chain. The compaction counter is persisted to `.compaction-count` in the session directory so it survives restarts.
-- **Session continuation:** `SessionManager.continueRecent()` picks up the latest session on restart
 
-**Session rotation** (`session-rotation.ts`): when a JSONL file exceeds 10MB, a new file is created carrying over the compacted history. The old file is archived. Rotation is checked both at initialization and before each `deliverMessage()` call, so long-running singleton agents (Guide, Narrator) don't grow unbounded between server restarts.
+**Session continuation** (`initialize()`): at startup, system2 finds the newest `.jsonl` file by mtime (`findMostRecentSession()`) and opens it directly via `SessionManager.open()`. This tolerates files that lack a valid session header, which `SessionManager.continueRecent()` would reject and silently replace with a fresh empty session. `continueRecent()` is used only when no `.jsonl` file exists yet (first-time setup).
+
+**Session rotation** (`session-rotation.ts`): when a JSONL file exceeds 10MB at initialization, a new file is created carrying over the compacted history. The old file is renamed to `.jsonl.archived` so it is no longer picked up as a continuation candidate. Rotation only runs at initialization, before a `SessionManager` is created; running it while a session is active is unsafe because the SDK holds an open reference to the file and would recreate it without a header on the next append.
 
 See the [pi-coding-agent session format docs](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/session.md) for details.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -216,7 +216,7 @@ Agent sessions are persisted as JSONL files in `~/.system2/sessions/{role}_{id}/
 
 **Session continuation** (`initialize()`): at startup, system2 finds the newest `.jsonl` file by mtime (`findMostRecentSession()`) and opens it directly via `SessionManager.open()`. This tolerates files that lack a valid session header, which `SessionManager.continueRecent()` would reject and silently replace with a fresh empty session. `continueRecent()` is used only when no `.jsonl` file exists yet (first-time setup).
 
-**Session rotation** (`session-rotation.ts`): when a JSONL file exceeds 10MB at initialization, a new file is created carrying over the compacted history. The old file is renamed to `.jsonl.archived` so it is no longer picked up as a continuation candidate. Rotation only runs at initialization, before a `SessionManager` is created; running it while a session is active is unsafe because the SDK holds an open reference to the file and would recreate it without a header on the next append.
+**Session rotation** (`session-rotation.ts`): when a JSONL file exceeds 10MB at initialization, a new file is created carrying over the compacted history. The old file is renamed to `.jsonl.archived` so it is no longer picked up as a continuation candidate. Rotation only runs on cold start (when no prior session exists in memory), before a `SessionManager` is created. It is skipped during failover re-initialization because the outgoing SDK session still holds an open reference to the file and would recreate it without a header on the next append.
 
 See the [pi-coding-agent session format docs](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/session.md) for details.
 

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -43,6 +43,11 @@ import {
   shouldRetry,
   sleep,
 } from './retry.js';
+import {
+  findMostRecentSession,
+  parseSessionEntries,
+  rotateSessionIfNeeded,
+} from './session-rotation.js';
 
 /** Human-readable label for error categories shown in chat messages. */
 function categoryLabel(category: ErrorCategory): string {
@@ -61,8 +66,6 @@ function categoryLabel(category: ErrorCategory): string {
       return 'error';
   }
 }
-
-import { parseSessionEntries, rotateSessionIfNeeded } from './session-rotation.js';
 import { createBashTool } from './tools/bash.js';
 import { createEditTool } from './tools/edit.js';
 import { createMessageAgentTool } from './tools/message-agent.js';
@@ -349,11 +352,19 @@ export class AgentHost {
     });
     await this.resourceLoader.reload();
 
-    // Create session with JSONL persistence - use continueRecent to persist across restarts
+    // Create session with JSONL persistence.
+    // Use open() on the most recent .jsonl (by mtime) if one exists — this tolerates
+    // files that lack a valid session header, which continueRecent() would reject and
+    // silently replace with a new empty session. Fall back to continueRecent() only
+    // when no .jsonl file exists at all (first-time setup).
+    const latestSession = findMostRecentSession(agentSessionDir);
+    const sessionManager = latestSession
+      ? SessionManager.open(latestSession, agentSessionDir)
+      : SessionManager.continueRecent(SYSTEM2_DIR, agentSessionDir);
     const { session } = await createAgentSession({
       cwd: SYSTEM2_DIR,
       agentDir: SYSTEM2_DIR,
-      sessionManager: SessionManager.continueRecent(SYSTEM2_DIR, agentSessionDir),
+      sessionManager,
       authStorage: this.authResolver.createAuthStorage(),
       modelRegistry: this.modelRegistry,
       resourceLoader: this.resourceLoader,
@@ -854,11 +865,6 @@ export class AgentHost {
         content: cacheContent,
         timestamp: details.timestamp,
       });
-    }
-
-    // Rotate session file if needed (catches growth between server restarts)
-    if (this._sessionDir) {
-      rotateSessionIfNeeded(this._sessionDir, SYSTEM2_DIR);
     }
 
     // Reload resource loader to pick up knowledge file changes, then deliver.

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -231,10 +231,15 @@ export class AgentHost {
       );
     }
 
-    // Rotate session file if it exceeds size threshold (10MB)
-    const rotated = rotateSessionIfNeeded(agentSessionDir, SYSTEM2_DIR);
-    if (rotated) {
-      console.log('[AgentHost] Session file rotated to new file');
+    // Rotate session file only on cold start. During re-initialization (failover),
+    // the outgoing SDK session still holds a reference to the active JSONL file;
+    // renaming it would cause the SDK to recreate the file without a header on
+    // the next append — exactly the hazard rotation is meant to prevent.
+    if (!this.session) {
+      const rotated = rotateSessionIfNeeded(agentSessionDir, SYSTEM2_DIR);
+      if (rotated) {
+        console.log('[AgentHost] Session file rotated to new file');
+      }
     }
 
     // Load shared agent reference (prepended to all agent system prompts)

--- a/packages/server/src/agents/session-rotation.test.ts
+++ b/packages/server/src/agents/session-rotation.test.ts
@@ -1,7 +1,7 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { findMostRecentSession, rotateSessionIfNeeded } from './session-rotation.js';
 
 function makeTmpDir(): string {
@@ -49,6 +49,10 @@ beforeEach(() => {
   tmpDir = makeTmpDir();
 });
 
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
 describe('findMostRecentSession', () => {
   it('returns null when directory does not exist', () => {
     expect(findMostRecentSession('/nonexistent/path/xyz')).toBeNull();
@@ -69,13 +73,14 @@ describe('findMostRecentSession', () => {
     expect(findMostRecentSession(tmpDir)).toBe(file);
   });
 
-  it('returns the most recently modified .jsonl file', async () => {
+  it('returns the most recently modified .jsonl file', () => {
     const older = join(tmpDir, 'older.jsonl');
-    writeFileSync(older, '');
-    // Small delay to ensure distinct mtime
-    await new Promise((r) => setTimeout(r, 10));
     const newer = join(tmpDir, 'newer.jsonl');
+    writeFileSync(older, '');
     writeFileSync(newer, '');
+    // Set mtimes deterministically to avoid relying on filesystem timestamp resolution
+    utimesSync(older, new Date(1000), new Date(1000));
+    utimesSync(newer, new Date(2000), new Date(2000));
     expect(findMostRecentSession(tmpDir)).toBe(newer);
   });
 

--- a/packages/server/src/agents/session-rotation.test.ts
+++ b/packages/server/src/agents/session-rotation.test.ts
@@ -1,0 +1,188 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { findMostRecentSession, rotateSessionIfNeeded } from './session-rotation.js';
+
+function makeTmpDir(): string {
+  const dir = join(
+    tmpdir(),
+    `session-rotation-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeJsonl(path: string, entries: object[]): void {
+  writeFileSync(path, `${entries.map((e) => JSON.stringify(e)).join('\n')}\n`);
+}
+
+function sessionHeader(id = 'abc12345'): object {
+  return { type: 'session', version: 3, id, timestamp: new Date().toISOString(), cwd: '/tmp' };
+}
+
+function messageEntry(id: string, parentId: string | null, role: string): object {
+  return {
+    type: 'message',
+    id,
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: { role, content: [{ type: 'text', text: `msg ${id}` }] },
+  };
+}
+
+function compactionEntry(id: string, parentId: string, firstKeptEntryId: string): object {
+  return {
+    type: 'compaction',
+    id,
+    parentId,
+    timestamp: new Date().toISOString(),
+    summary: 'Summary of earlier messages.',
+    firstKeptEntryId,
+    tokensBefore: 5000,
+  };
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = makeTmpDir();
+});
+
+describe('findMostRecentSession', () => {
+  it('returns null when directory does not exist', () => {
+    expect(findMostRecentSession('/nonexistent/path/xyz')).toBeNull();
+  });
+
+  it('returns null when directory is empty', () => {
+    expect(findMostRecentSession(tmpDir)).toBeNull();
+  });
+
+  it('returns null when directory has no .jsonl files', () => {
+    writeFileSync(join(tmpDir, 'session.txt'), 'hello');
+    expect(findMostRecentSession(tmpDir)).toBeNull();
+  });
+
+  it('returns the single .jsonl file when only one exists', () => {
+    const file = join(tmpDir, 'session.jsonl');
+    writeFileSync(file, '');
+    expect(findMostRecentSession(tmpDir)).toBe(file);
+  });
+
+  it('returns the most recently modified .jsonl file', async () => {
+    const older = join(tmpDir, 'older.jsonl');
+    writeFileSync(older, '');
+    // Small delay to ensure distinct mtime
+    await new Promise((r) => setTimeout(r, 10));
+    const newer = join(tmpDir, 'newer.jsonl');
+    writeFileSync(newer, '');
+    expect(findMostRecentSession(tmpDir)).toBe(newer);
+  });
+
+  it('ignores .jsonl.archived files', () => {
+    writeFileSync(join(tmpDir, 'session.jsonl.archived'), '');
+    expect(findMostRecentSession(tmpDir)).toBeNull();
+  });
+});
+
+describe('rotateSessionIfNeeded', () => {
+  it('returns false when no session file exists', () => {
+    expect(rotateSessionIfNeeded(tmpDir, '/tmp', 0)).toBe(false);
+  });
+
+  it('returns false when file is below the threshold', () => {
+    const file = join(tmpDir, 'session.jsonl');
+    writeJsonl(file, [sessionHeader()]);
+    expect(rotateSessionIfNeeded(tmpDir, '/tmp', 10 * 1024 * 1024)).toBe(false);
+  });
+
+  it('returns false when file has no compaction entry', () => {
+    const file = join(tmpDir, 'session.jsonl');
+    writeJsonl(file, [
+      sessionHeader(),
+      messageEntry('e1', null, 'user'),
+      messageEntry('e2', 'e1', 'assistant'),
+    ]);
+    expect(rotateSessionIfNeeded(tmpDir, '/tmp', 0)).toBe(false);
+  });
+
+  it('returns false when firstKeptEntryId is not found', () => {
+    const file = join(tmpDir, 'session.jsonl');
+    writeJsonl(file, [
+      sessionHeader(),
+      messageEntry('e1', null, 'user'),
+      compactionEntry('c1', 'e1', 'missing-id'),
+    ]);
+    expect(rotateSessionIfNeeded(tmpDir, '/tmp', 0)).toBe(false);
+  });
+
+  it('creates a new file and renames the old one to .archived on rotation', () => {
+    const file = join(tmpDir, 'session.jsonl');
+    writeJsonl(file, [
+      sessionHeader(),
+      messageEntry('e1', null, 'user'),
+      messageEntry('e2', 'e1', 'assistant'),
+      compactionEntry('c1', 'e2', 'e1'),
+      messageEntry('e3', 'c1', 'user'),
+    ]);
+
+    const rotated = rotateSessionIfNeeded(tmpDir, '/tmp', 0);
+
+    expect(rotated).toBe(true);
+    // Old file renamed to .archived
+    expect(existsSync(file)).toBe(false);
+    expect(existsSync(`${file}.archived`)).toBe(true);
+    // New file exists
+    const newFile = findMostRecentSession(tmpDir);
+    expect(newFile).not.toBeNull();
+    expect(newFile).not.toBe(file);
+  });
+
+  it('new file starts with a valid session header', () => {
+    const file = join(tmpDir, 'session.jsonl');
+    writeJsonl(file, [
+      sessionHeader(),
+      messageEntry('e1', null, 'user'),
+      messageEntry('e2', 'e1', 'assistant'),
+      compactionEntry('c1', 'e2', 'e1'),
+      messageEntry('e3', 'c1', 'user'),
+    ]);
+
+    rotateSessionIfNeeded(tmpDir, '/tmp', 0);
+
+    const newFile = findMostRecentSession(tmpDir);
+    expect(newFile).not.toBeNull();
+    const firstLine = readFileSync(newFile as string, 'utf-8').split('\n')[0];
+    const parsed = JSON.parse(firstLine);
+    expect(parsed.type).toBe('session');
+    expect(typeof parsed.id).toBe('string');
+  });
+
+  it('new file contains kept entries, compaction, and post-compaction entries', () => {
+    const file = join(tmpDir, 'session.jsonl');
+    // e1=kept, e2=kept, c1=compaction(firstKept=e1), e3=post-compaction
+    writeJsonl(file, [
+      sessionHeader(),
+      messageEntry('e1', null, 'user'),
+      messageEntry('e2', 'e1', 'assistant'),
+      compactionEntry('c1', 'e2', 'e1'),
+      messageEntry('e3', 'c1', 'user'),
+    ]);
+
+    rotateSessionIfNeeded(tmpDir, '/tmp', 0);
+
+    const newFile = findMostRecentSession(tmpDir);
+    expect(newFile).not.toBeNull();
+    const content = readFileSync(newFile as string, 'utf-8');
+    const entries = content
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l));
+
+    const ids = entries.map((e: { id?: string }) => e.id);
+    expect(ids).toContain('e1');
+    expect(ids).toContain('e2');
+    expect(ids).toContain('c1');
+    expect(ids).toContain('e3');
+  });
+});

--- a/packages/server/src/agents/session-rotation.ts
+++ b/packages/server/src/agents/session-rotation.ts
@@ -6,7 +6,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { readdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const SESSION_FILE_SIZE_LIMIT = 10 * 1024 * 1024; // 10MB
@@ -24,9 +24,9 @@ export interface SessionEntry {
 
 /**
  * Find the most recent JSONL session file by modification time.
- * Returns null if no valid session files exist.
+ * Returns null if no .jsonl files exist in the directory.
  */
-function findMostRecentSession(sessionDir: string): string | null {
+export function findMostRecentSession(sessionDir: string): string | null {
   let files: string[];
   try {
     files = readdirSync(sessionDir);
@@ -107,14 +107,19 @@ function createSessionHeader(cwd: string): SessionEntry {
 /**
  * Rotate session file if it exceeds the size threshold.
  *
+ * Only call this during initialization, before a SessionManager is created.
+ * Calling it while a session is running is unsafe: the SDK holds an open
+ * reference to the current file and will recreate it (without a header) on
+ * the next append if it disappears.
+ *
  * When rotation occurs:
  * 1. Creates new JSONL file with:
  *    - New session header
  *    - Entries from firstKeptEntryId up to compaction entry
  *    - The compaction entry
  *    - All entries after the compaction entry
- * 2. Old file remains on disk (archived)
- * 3. New file will be picked up by continueRecent() due to newer mtime
+ * 2. Old file is renamed to <filename>.jsonl.archived
+ * 3. New file is picked up by findMostRecentSession() on next initialize()
  *
  * @param sessionDir - Directory containing session JSONL files
  * @param cwd - Current working directory for session header
@@ -204,10 +209,14 @@ export function rotateSessionIfNeeded(
   const content = `${newEntries.map((e) => JSON.stringify(e)).join('\n')}\n`;
   writeFileSync(newFilePath, content);
 
+  // Rename old file so it is no longer picked up as a candidate session
+  const archivedPath = `${currentFile}.archived`;
+  renameSync(currentFile, archivedPath);
+
   console.log(
     `[SessionRotation] Created new session file: ${newFilename} with ${newEntries.length} entries`
   );
-  console.log(`[SessionRotation] Old file archived: ${currentFile.split('/').pop()}`);
+  console.log(`[SessionRotation] Old file archived: ${currentFile.split('/').pop()}.archived`);
 
   return true;
 }

--- a/packages/server/src/agents/session-rotation.ts
+++ b/packages/server/src/agents/session-rotation.ts
@@ -7,7 +7,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { readdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 
 const SESSION_FILE_SIZE_LIMIT = 10 * 1024 * 1024; // 10MB
 
@@ -216,7 +216,7 @@ export function rotateSessionIfNeeded(
   console.log(
     `[SessionRotation] Created new session file: ${newFilename} with ${newEntries.length} entries`
   );
-  console.log(`[SessionRotation] Old file archived: ${currentFile.split('/').pop()}.archived`);
+  console.log(`[SessionRotation] Old file archived: ${basename(currentFile)}.archived`);
 
   return true;
 }


### PR DESCRIPTION
## Summary

- `SessionManager.continueRecent()` validates the session header and silently creates a new empty session when the file lacks one (e.g. after a crash or rename while the server was running). Replace it in `initialize()` with `findMostRecentSession()` + `SessionManager.open()`, which opens any `.jsonl` regardless of header validity. `continueRecent()` is now only used as a fallback when no `.jsonl` exists at all (first-time setup).
- After rotation, rename the old file to `.jsonl.archived` so it is no longer a continuation candidate on next startup.
- Remove the `rotateSessionIfNeeded()` call from `deliverMessage()`. It was a no-op: the running SDK session still held a reference to the old file and kept appending to it, so the rotated file was ignored and the old file won on mtime at the next restart. The call was also unsafe — renaming a file the SDK is actively writing to causes it to recreate the file without a header on the next append.

## Test plan

- [ ] `pnpm test` passes (410 tests, including 13 new tests in `session-rotation.test.ts` covering `findMostRecentSession` and `rotateSessionIfNeeded` including rename-on-rotation behavior)
- [ ] Start server, verify narrator and guide sessions resume from existing `.jsonl` files
- [ ] Verify old `.jsonl` files in `~/.system2/sessions/narrator_2/` are now `.jsonl.archived` and not picked up as candidates