### PR TITLE
feat: add set_reminder tool for non-blocking delayed agent actions

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -182,7 +182,7 @@ Schedule a delayed reminder for the calling agent. After the specified delay, a 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `delay_minutes` | number | Minutes from now until the reminder fires. Must be > 0. |
+| `delay_minutes` | number | Minutes from now. Must be 1 to 35,791 (~24.8 days max). |
 | `message` | string | Reminder text delivered back as a follow-up message when the timer fires. |
 
 - **Non-blocking:** uses `setTimeout` internally; the agent continues working after setting the reminder

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -8,6 +8,7 @@ Tools are built in `AgentHost.buildTools()` (`packages/server/src/agents/host.ts
 
 - Eight tools are always included: `bash`, `read`, `edit`, `write`, `read_system2_db`, `write_system2_db`, `message_agent`, `web_fetch`
 - `show_artifact` is Guide-only: the Guide is the only agent that interacts with the user via the UI
+- `set_reminder`, `cancel_reminder`, and `list_reminders` are included for all agents when a `ReminderManager` is provided
 - `spawn_agent`, `terminate_agent`, and `trigger_project_story` are conditional: only agents that receive a spawner callback (Guide and Conductors) get these tools
 - `resurrect_agent` is Guide-only: only the Guide receives a resurrector callback
 - `web_search` is conditional on a Brave Search API key being configured
@@ -174,6 +175,36 @@ Search the web via the Brave Search API.
 Returns structured results (title, URL, description). Requires a [Brave Search API](https://brave.com/search/api/) key in config.toml.
 
 **Conditional:** only registered when `[services.brave_search]` key exists AND `[tools.web_search].enabled` is not `false`. Max results configurable via `[tools.web_search].max_results`.
+
+### `set_reminder`
+
+Schedule a delayed reminder for the calling agent. After the specified delay, a follow-up message containing the reminder text is delivered back to the agent via `deliverMessage()`.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `delay_minutes` | number | Minutes from now until the reminder fires. Must be > 0. |
+| `message` | string | Reminder text delivered back as a follow-up message when the timer fires. |
+
+- **Non-blocking:** uses `setTimeout` internally; the agent continues working after setting the reminder
+- **Delivery:** fires as a `followUp` custom message with `sender: 0` (system sentinel)
+- **In-memory only:** reminders do not survive server restarts
+- **Timer handle:** `unref()`'d so it does not prevent graceful shutdown
+
+### `cancel_reminder`
+
+Cancel a pending reminder by its ID.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `reminder_id` | number | ID returned by `set_reminder`. |
+
+Only the agent that created the reminder can cancel it. Returns whether the cancellation succeeded.
+
+### `list_reminders`
+
+List the calling agent's active (pending) reminders. Takes no parameters.
+
+Returns reminder IDs, messages, and scheduled fire times.
 
 ### `spawn_agent`
 

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -62,6 +62,9 @@ The **Guide** is the primary user-facing agent. However, the user may choose to 
 | `terminate_agent` | Archive an agent — abort its session, unregister, mark archived | Guide, Conductors |
 | `resurrect_agent` | Bring back an archived agent — resume its session from persisted JSONL, re-register | Guide, Conductors |
 | `trigger_project_story` | Signal project completion: server creates story task, collects data, delivers to Narrator | Guide, Conductors |
+| `set_reminder` | Schedule a delayed follow-up message to yourself (1 to ~24.8 days). Non-blocking. | All agents |
+| `cancel_reminder` | Cancel a pending reminder by ID | All agents |
+| `list_reminders` | List your active pending reminders | All agents |
 | `web_search` | Search the web via Brave Search API | All agents (when configured) |
 
 **Notes:**
@@ -72,6 +75,7 @@ The **Guide** is the primary user-facing agent. However, the user may choose to 
 - `bash` streams output as the command runs. Set `run_in_background` to true for long-running commands — you will receive the result as a follow-up message when the command finishes.
 - `spawn_agent`, `terminate_agent`, and `trigger_project_story` are available to Guide and Conductors only. Narrator and Reviewer cannot spawn, terminate, or trigger project stories.
 - `resurrect_agent` is available to Guide and Conductors. Guide may resurrect any archived non-singleton. Conductors may only resurrect agents within their own project. Narrator and Reviewer cannot resurrect agents.
+- `set_reminder`, `cancel_reminder`, and `list_reminders` are available to all agents. Reminders are in-memory only and do not survive server restarts. See [Reminders](#reminders) under Communication for usage guidance.
 - `web_search` is only available when a Brave Search API key is configured.
 - `show_artifact` is available to all agents. Any agent can display a file in the user's UI. Accepts an absolute path (or `~/`-prefixed). If the artifact is registered in the database, its title is used for the tab label; otherwise the filename is used. Only one artifact is watched per client connection at a time (for live reload).
 
@@ -261,6 +265,28 @@ SELECT id, role, status, project FROM agent WHERE status = 'active';
 - **Be direct and terse.** No pleasantries, no filler, no hedging. State facts, IDs, and next actions. Agent-to-agent messages are operational, not conversational.
 - **Reference IDs.** Every message should include the relevant project, task, and/or comment IDs so the recipient can look up context with a single query.
 - **Use the right channel.** Direct messages (`message_agent`) are for real-time coordination and urgent updates. Task comments (`createTaskComment`) are for the permanent record — decisions, results, blockers, progress.
+
+### Reminders
+
+Use `set_reminder` to schedule a follow-up message to yourself. After the delay, you receive the reminder as a new message and can act on it. This is your primary tool for deferred work: instead of blocking or polling, set a reminder and continue.
+
+**When to use reminders:**
+
+- **Following up on delegated work.** After assigning a task or sending a question to another agent, set a reminder to check whether they responded or completed it. If they haven't, follow up or escalate.
+  - _"Check if Reviewer (id=4) provided feedback on task #12. If not, message them again."_
+  - _"Verify Conductor (id=3) has started project #2. If project status is still 'todo', ask for a status update."_
+- **Monitoring long-running operations.** After launching a background command, pipeline, or data load, set a reminder to check the results.
+  - _"Check if the LinkedIn data export (task #8) completed. Read ~/.system2/projects/1_linkedin/artifacts/export.csv and verify row count."_
+- **Periodic progress checks.** When coordinating multi-step work across agents, set reminders at intervals to review overall progress and unblock stalled work.
+  - _"Review task board for project #3. Identify any tasks stuck in 'in progress' for too long and message the assignee."_
+- **Deferred actions with timing requirements.** When something needs to happen after a specific delay (rate-limited API retries, waiting for external systems, scheduled follow-ups).
+  - _"Retry the API call for task #15. Last attempt hit rate limit."_
+
+**Guidelines:**
+
+- Write reminder messages as instructions to your future self. Include agent IDs, task IDs, and what action to take so you have full context when the reminder fires.
+- Reminders are in-memory only: they do not survive server restarts. For delays longer than a few hours, consider whether the action is better handled by a task comment and a check-on-startup pattern.
+- Use `list_reminders` to review your active reminders before setting duplicates. Use `cancel_reminder` if the situation changed and the follow-up is no longer needed.
 
 ## Knowledge and Memory
 

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -32,6 +32,7 @@ import matter from 'gray-matter';
 import { MessageHistory } from '../chat/history.js';
 import type { DatabaseClient } from '../db/client.js';
 import { resolveProjectDir } from '../projects/dir.js';
+import type { ReminderManager } from '../reminders/manager.js';
 import { AuthResolver } from './auth-resolver.js';
 import type { AgentRegistry } from './registry.js';
 import {
@@ -44,11 +45,14 @@ import {
 } from './retry.js';
 import { parseSessionEntries, rotateSessionIfNeeded } from './session-rotation.js';
 import { createBashTool } from './tools/bash.js';
+import { createCancelReminderTool } from './tools/cancel-reminder.js';
 import { createEditTool } from './tools/edit.js';
+import { createListRemindersTool } from './tools/list-reminders.js';
 import { createMessageAgentTool } from './tools/message-agent.js';
 import { createReadTool } from './tools/read.js';
 import { createReadSystem2DbTool } from './tools/read-system2-db.js';
 import { type AgentResurrector, createResurrectAgentTool } from './tools/resurrect-agent.js';
+import { createSetReminderTool } from './tools/set-reminder.js';
 import { createShowArtifactTool } from './tools/show-artifact.js';
 import { type AgentSpawner, createSpawnAgentTool } from './tools/spawn-agent.js';
 import { createTerminateAgentTool } from './tools/terminate-agent.js';
@@ -100,6 +104,7 @@ export interface AgentHostConfig {
   chatMaxMessages?: number;
   /** Shared AuthResolver for cross-agent rate limit awareness. Falls back to creating a local instance. */
   authResolver?: AuthResolver;
+  reminderManager?: ReminderManager;
 }
 
 export class AgentHost {
@@ -132,6 +137,7 @@ export class AgentHost {
   private isPruning = false;
   private contextWindow = 0;
   private contextOverflowHandled = false;
+  private reminderManager?: ReminderManager;
   private unsubscribeSession: (() => void) | null = null;
 
   constructor(config: AgentHostConfig) {
@@ -143,6 +149,7 @@ export class AgentHost {
     this.spawner = config.spawner;
     this.resurrector = config.resurrector;
     this.chatMaxMessages = config.chatMaxMessages ?? 1000;
+    this.reminderManager = config.reminderManager;
 
     // Store LLM config for openai-compatible provider registration
     this.llmConfig = config.llmConfig;
@@ -702,6 +709,13 @@ export class AgentHost {
 
     // All agents can show artifacts — any agent can now interact with the user directly
     tools.push(createShowArtifactTool(this.db));
+
+    // All agents can set, cancel, and list reminders
+    if (this.reminderManager) {
+      tools.push(createSetReminderTool(this.agentId, this.reminderManager));
+      tools.push(createCancelReminderTool(this.agentId, this.reminderManager));
+      tools.push(createListRemindersTool(this.agentId, this.reminderManager));
+    }
 
     // Guide and Conductor only: spawn, manage, and resurrect agents
     const canOrchestrate = this.agentRole !== null && ORCHESTRATOR_ROLES.has(this.agentRole);

--- a/packages/server/src/agents/library/conductor.md
+++ b/packages/server/src/agents/library/conductor.md
@@ -40,6 +40,9 @@ You are spawned by the Guide to execute a specific project. Your job is to:
 - `spawn_agent`: Spawn specialist data agents within your project
 - `terminate_agent`: Archive specialist agents when their work is done
 - `trigger_project_story`: Signal project completion. The server creates a story task, collects all project data, and delivers it to the Narrator. Returns the story task ID. Call this during the close-project routine.
+- `set_reminder`: Schedule a delayed follow-up message to yourself. Use to check on delegated work, follow up with agents, or monitor long-running operations.
+- `cancel_reminder`: Cancel a pending reminder by ID
+- `list_reminders`: List your active pending reminders
 
 ## Workflow
 

--- a/packages/server/src/agents/library/guide.md
+++ b/packages/server/src/agents/library/guide.md
@@ -247,6 +247,9 @@ After every update, ask yourself whether the document structure is still optimal
 - `spawn_agent`: Spawn a new Conductor or Reviewer for a project
 - `terminate_agent`: Archive an agent (Conductor or Reviewer) when their project work is done
 - `resurrect_agent`: Bring back an archived agent, resuming its session from persisted history. Use for project restarts.
+- `set_reminder`: Schedule a delayed follow-up message to yourself. Use to track delegated work, check on spawned agents, or defer actions.
+- `cancel_reminder`: Cancel a pending reminder by ID
+- `list_reminders`: List your active pending reminders
 - `show_artifact`: Display HTML artifacts in the UI panel
 - `web_fetch`: Fetch a URL and extract readable text content
 - `web_search`: Search the web via Brave Search (only if a Brave Search API key is configured)

--- a/packages/server/src/agents/library/narrator.md
+++ b/packages/server/src/agents/library/narrator.md
@@ -31,6 +31,9 @@ You are a **singleton**, created at server startup alongside the Guide, and your
 - **write**: Create new files or complete rewrites (memory.md restructuring, project stories)
 - **read_system2_db**: Query System2 app database (`~/.system2/app.db`): projects, tasks, agents, task_comments. Not for data pipeline databases.
 - **message_agent**: Send messages to other agents (e.g., interrogate Conductor for project context)
+- **set_reminder**: Schedule a delayed follow-up message to yourself. Use to check on pending responses or defer work.
+- **cancel_reminder**: Cancel a pending reminder by ID
+- **list_reminders**: List your active pending reminders
 
 ## Scheduled Tasks
 

--- a/packages/server/src/agents/library/reviewer.md
+++ b/packages/server/src/agents/library/reviewer.md
@@ -37,6 +37,9 @@ When the Conductor asks you to review work (via `message_agent` with task IDs), 
 - `write_system2_db`: Update task status or add comments in System2 app database when review is complete.
 - `write`: Create validation reports in the project workspace
 - `message_agent`: Reply to the Conductor with review outcome; escalate to Guide if needed
+- `set_reminder`: Schedule a delayed follow-up message to yourself. Use to follow up on review feedback or check if fixes were applied.
+- `cancel_reminder`: Cancel a pending reminder by ID
+- `list_reminders`: List your active pending reminders
 
 ## What to Check
 

--- a/packages/server/src/agents/tools/cancel-reminder.test.ts
+++ b/packages/server/src/agents/tools/cancel-reminder.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ReminderManager } from '../../reminders/manager.js';
+import { createCancelReminderTool } from './cancel-reminder.js';
+
+function setup(cancelResult = true) {
+  const reminderManager = {
+    cancel: vi.fn().mockReturnValue(cancelResult),
+  } as unknown as ReminderManager;
+  const tool = createCancelReminderTool(1, reminderManager);
+  return { tool, reminderManager };
+}
+
+const { tool: _refTool } = setup();
+type Params = Parameters<typeof _refTool.execute>[1];
+type Result = Awaited<ReturnType<typeof _refTool.execute>>;
+
+describe('cancel_reminder tool', () => {
+  const exec = (tool: typeof _refTool, params: Record<string, unknown>): Promise<Result> =>
+    tool.execute('test', params as Params);
+
+  it('cancels a reminder successfully', async () => {
+    const { tool, reminderManager } = setup(true);
+
+    const result = await exec(tool, { reminder_id: 42 });
+
+    expect(reminderManager.cancel).toHaveBeenCalledWith(42, 1);
+    expect((result.content[0] as { text: string }).text).toContain('#42 cancelled');
+    expect(result.details).toEqual({ cancelled: true, reminder_id: 42 });
+  });
+
+  it('reports failure when reminder not found or not owned', async () => {
+    const { tool } = setup(false);
+
+    const result = await exec(tool, { reminder_id: 99 });
+
+    expect((result.content[0] as { text: string }).text).toContain('#99 not found');
+    expect(result.details).toEqual({ cancelled: false });
+  });
+
+  it('handles manager errors gracefully', async () => {
+    const reminderManager = {
+      cancel: vi.fn().mockImplementation(() => {
+        throw new Error('cancel failed');
+      }),
+    } as unknown as ReminderManager;
+    const tool = createCancelReminderTool(1, reminderManager);
+
+    const result = await exec(tool, { reminder_id: 1 });
+
+    expect((result.content[0] as { text: string }).text).toContain('cancel failed');
+  });
+});

--- a/packages/server/src/agents/tools/cancel-reminder.ts
+++ b/packages/server/src/agents/tools/cancel-reminder.ts
@@ -1,0 +1,45 @@
+import type { AgentTool } from '@mariozechner/pi-agent-core';
+import { Type } from '@sinclair/typebox';
+import type { ReminderManager } from '../../reminders/manager.js';
+
+export function createCancelReminderTool(agentId: number, reminderManager: ReminderManager) {
+  const params = Type.Object({
+    reminder_id: Type.Number({
+      description: 'The ID of the reminder to cancel (returned by set_reminder).',
+    }),
+  });
+
+  const tool: AgentTool<typeof params> = {
+    name: 'cancel_reminder',
+    label: 'Cancel Reminder',
+    description: 'Cancel a pending reminder by its ID. Only your own reminders can be cancelled.',
+    parameters: params,
+    execute: async (_toolCallId, args) => {
+      try {
+        const cancelled = reminderManager.cancel(args.reminder_id, agentId);
+        if (!cancelled) {
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: `Reminder #${args.reminder_id} not found, not yours, or already fired/cancelled.`,
+              },
+            ],
+            details: { cancelled: false },
+          };
+        }
+        return {
+          content: [{ type: 'text' as const, text: `Reminder #${args.reminder_id} cancelled.` }],
+          details: { cancelled: true, reminder_id: args.reminder_id },
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(error as Error).message}` }],
+          details: { error: (error as Error).message },
+        };
+      }
+    },
+  };
+
+  return tool;
+}

--- a/packages/server/src/agents/tools/list-reminders.test.ts
+++ b/packages/server/src/agents/tools/list-reminders.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ReminderManager } from '../../reminders/manager.js';
+import { createListRemindersTool } from './list-reminders.js';
+
+function setup(
+  reminders: Array<{ id: number; agentId: number; message: string; fireAt: Date }> = []
+) {
+  const reminderManager = {
+    listForAgent: vi.fn().mockReturnValue(reminders),
+  } as unknown as ReminderManager;
+  const tool = createListRemindersTool(1, reminderManager);
+  return { tool, reminderManager };
+}
+
+const { tool: _refTool } = setup();
+type Result = Awaited<ReturnType<typeof _refTool.execute>>;
+
+describe('list_reminders tool', () => {
+  const exec = (tool: typeof _refTool): Promise<Result> =>
+    tool.execute('test', {} as Parameters<typeof _refTool.execute>[1]);
+
+  it('returns empty message when no reminders', async () => {
+    const { tool, reminderManager } = setup([]);
+
+    const result = await exec(tool);
+
+    expect(reminderManager.listForAgent).toHaveBeenCalledWith(1);
+    expect((result.content[0] as { text: string }).text).toBe('No pending reminders.');
+    expect(result.details).toEqual({ count: 0, reminders: [] });
+  });
+
+  it('lists pending reminders', async () => {
+    const { tool } = setup([
+      { id: 1, agentId: 1, message: 'Check PR', fireAt: new Date('2026-01-01T12:05:00Z') },
+      { id: 3, agentId: 1, message: 'Follow up', fireAt: new Date('2026-01-01T13:00:00Z') },
+    ]);
+
+    const result = await exec(tool);
+
+    const text = (result.content[0] as { text: string }).text;
+    expect(text).toContain('#1:');
+    expect(text).toContain('Check PR');
+    expect(text).toContain('#3:');
+    expect(text).toContain('Follow up');
+    expect(result.details).toEqual({
+      count: 2,
+      reminders: expect.arrayContaining([expect.objectContaining({ id: 1 })]),
+    });
+  });
+
+  it('handles manager errors gracefully', async () => {
+    const reminderManager = {
+      listForAgent: vi.fn().mockImplementation(() => {
+        throw new Error('list failed');
+      }),
+    } as unknown as ReminderManager;
+    const tool = createListRemindersTool(1, reminderManager);
+
+    const result = await exec(tool);
+
+    expect((result.content[0] as { text: string }).text).toContain('list failed');
+  });
+});

--- a/packages/server/src/agents/tools/list-reminders.ts
+++ b/packages/server/src/agents/tools/list-reminders.ts
@@ -1,0 +1,40 @@
+import type { AgentTool } from '@mariozechner/pi-agent-core';
+import { Type } from '@sinclair/typebox';
+import type { ReminderManager } from '../../reminders/manager.js';
+
+export function createListRemindersTool(agentId: number, reminderManager: ReminderManager) {
+  const params = Type.Object({});
+
+  const tool: AgentTool<typeof params> = {
+    name: 'list_reminders',
+    label: 'List Reminders',
+    description:
+      'List your active (pending) reminders. Shows reminder ID, message, and scheduled fire time.',
+    parameters: params,
+    execute: async () => {
+      try {
+        const reminders = reminderManager.listForAgent(agentId);
+        if (reminders.length === 0) {
+          return {
+            content: [{ type: 'text' as const, text: 'No pending reminders.' }],
+            details: { count: 0, reminders: [] },
+          };
+        }
+        const lines = reminders.map(
+          (r) => `#${r.id}: fires at ${r.fireAt.toISOString()} — "${r.message}"`
+        );
+        return {
+          content: [{ type: 'text' as const, text: `Pending reminders:\n${lines.join('\n')}` }],
+          details: { count: reminders.length, reminders },
+        };
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: `Error: ${(error as Error).message}` }],
+          details: { error: (error as Error).message },
+        };
+      }
+    },
+  };
+
+  return tool;
+}

--- a/packages/server/src/agents/tools/set-reminder.test.ts
+++ b/packages/server/src/agents/tools/set-reminder.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ReminderManager } from '../../reminders/manager.js';
+import { createSetReminderTool } from './set-reminder.js';
+
+function setup() {
+  const reminderManager = {
+    schedule: vi.fn().mockReturnValue({ id: 1, fireAt: new Date('2026-01-01T12:05:00Z') }),
+  } as unknown as ReminderManager;
+  const tool = createSetReminderTool(1, reminderManager);
+  return { tool, reminderManager };
+}
+
+const { tool: _refTool } = setup();
+type Params = Parameters<typeof _refTool.execute>[1];
+type Result = Awaited<ReturnType<typeof _refTool.execute>>;
+
+describe('set_reminder tool', () => {
+  const exec = (tool: typeof _refTool, params: Record<string, unknown>): Promise<Result> =>
+    tool.execute('test', params as Params);
+
+  it('sets a reminder and returns confirmation', async () => {
+    const { tool, reminderManager } = setup();
+
+    const result = await exec(tool, { delay_minutes: 5, message: 'Check PR review' });
+
+    expect(reminderManager.schedule).toHaveBeenCalledWith(1, 'Check PR review', 5);
+    expect((result.content[0] as { text: string }).text).toContain('Reminder #1 set');
+    expect((result.content[0] as { text: string }).text).toContain('5 minute(s)');
+  });
+
+  it('rejects delay_minutes <= 0', async () => {
+    const { tool, reminderManager } = setup();
+
+    const result = await exec(tool, { delay_minutes: 0, message: 'bad' });
+
+    expect(reminderManager.schedule).not.toHaveBeenCalled();
+    expect((result.content[0] as { text: string }).text).toContain('must be greater than 0');
+  });
+
+  it('handles manager errors gracefully', async () => {
+    const reminderManager = {
+      schedule: vi.fn().mockImplementation(() => {
+        throw new Error('timer failed');
+      }),
+    } as unknown as ReminderManager;
+    const tool = createSetReminderTool(1, reminderManager);
+
+    const result = await exec(tool, { delay_minutes: 5, message: 'boom' });
+
+    expect((result.content[0] as { text: string }).text).toContain('timer failed');
+  });
+});

--- a/packages/server/src/agents/tools/set-reminder.test.ts
+++ b/packages/server/src/agents/tools/set-reminder.test.ts
@@ -34,7 +34,16 @@ describe('set_reminder tool', () => {
     const result = await exec(tool, { delay_minutes: 0, message: 'bad' });
 
     expect(reminderManager.schedule).not.toHaveBeenCalled();
-    expect((result.content[0] as { text: string }).text).toContain('must be greater than 0');
+    expect((result.content[0] as { text: string }).text).toContain('must be between 1 and');
+  });
+
+  it('rejects delay_minutes exceeding setTimeout limit (~24.8 days)', async () => {
+    const { tool, reminderManager } = setup();
+
+    const result = await exec(tool, { delay_minutes: 40_000, message: 'too far' });
+
+    expect(reminderManager.schedule).not.toHaveBeenCalled();
+    expect((result.content[0] as { text: string }).text).toContain('must be between 1 and');
   });
 
   it('handles manager errors gracefully', async () => {

--- a/packages/server/src/agents/tools/set-reminder.test.ts
+++ b/packages/server/src/agents/tools/set-reminder.test.ts
@@ -28,13 +28,16 @@ describe('set_reminder tool', () => {
     expect((result.content[0] as { text: string }).text).toContain('5 minute(s)');
   });
 
-  it('rejects delay_minutes <= 0', async () => {
+  it('rejects delay_minutes < 1 (including fractional sub-minute values)', async () => {
     const { tool, reminderManager } = setup();
 
-    const result = await exec(tool, { delay_minutes: 0, message: 'bad' });
-
+    const result0 = await exec(tool, { delay_minutes: 0, message: 'bad' });
     expect(reminderManager.schedule).not.toHaveBeenCalled();
-    expect((result.content[0] as { text: string }).text).toContain('must be between 1 and');
+    expect((result0.content[0] as { text: string }).text).toContain('must be between 1 and');
+
+    const result05 = await exec(tool, { delay_minutes: 0.5, message: 'bad' });
+    expect(reminderManager.schedule).not.toHaveBeenCalled();
+    expect((result05.content[0] as { text: string }).text).toContain('must be between 1 and');
   });
 
   it('rejects delay_minutes exceeding setTimeout limit (~24.8 days)', async () => {

--- a/packages/server/src/agents/tools/set-reminder.ts
+++ b/packages/server/src/agents/tools/set-reminder.ts
@@ -1,0 +1,57 @@
+import type { AgentTool } from '@mariozechner/pi-agent-core';
+import { Type } from '@sinclair/typebox';
+import type { ReminderManager } from '../../reminders/manager.js';
+
+export function createSetReminderTool(agentId: number, reminderManager: ReminderManager) {
+  const params = Type.Object({
+    delay_minutes: Type.Number({
+      description: 'How many minutes from now the reminder should fire. Must be greater than 0.',
+    }),
+    message: Type.String({
+      description:
+        'The reminder message. Describe what you need to do when the timer fires. This text will be delivered back to you as a follow-up message.',
+    }),
+  });
+
+  const tool: AgentTool<typeof params> = {
+    name: 'set_reminder',
+    label: 'Set Reminder',
+    description:
+      'Schedule a delayed reminder for yourself. After the specified delay, you will receive a follow-up message with your reminder text. Use this to defer actions: set the timer, continue your current work, and handle the reminder when it arrives.',
+    parameters: params,
+    execute: async (_toolCallId, args) => {
+      const { delay_minutes, message } = args;
+
+      if (delay_minutes <= 0) {
+        return {
+          content: [
+            { type: 'text' as const, text: 'Error: delay_minutes must be greater than 0.' },
+          ],
+          details: { error: 'invalid_delay' },
+        };
+      }
+
+      try {
+        const { id, fireAt } = reminderManager.schedule(agentId, message, delay_minutes);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: `Reminder #${id} set. It will fire in ${delay_minutes} minute(s) (around ${fireAt.toISOString()}). You will receive a follow-up message with your reminder text. Continue your current work.`,
+            },
+          ],
+          details: { reminder_id: id, fire_at: fireAt.toISOString() },
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: 'text' as const, text: `Error setting reminder: ${(error as Error).message}` },
+          ],
+          details: { error: (error as Error).message },
+        };
+      }
+    },
+  };
+
+  return tool;
+}

--- a/packages/server/src/agents/tools/set-reminder.ts
+++ b/packages/server/src/agents/tools/set-reminder.ts
@@ -2,10 +2,13 @@ import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { Type } from '@sinclair/typebox';
 import type { ReminderManager } from '../../reminders/manager.js';
 
+// Node.js setTimeout clamps delays > 2^31-1 ms, causing them to fire immediately.
+const MAX_DELAY_MINUTES = 35_791; // ~24.8 days
+
 export function createSetReminderTool(agentId: number, reminderManager: ReminderManager) {
   const params = Type.Object({
     delay_minutes: Type.Number({
-      description: 'How many minutes from now the reminder should fire. Must be greater than 0.',
+      description: `How many minutes from now the reminder should fire. Must be between 1 and ${MAX_DELAY_MINUTES} (~24.8 days).`,
     }),
     message: Type.String({
       description:
@@ -22,10 +25,13 @@ export function createSetReminderTool(agentId: number, reminderManager: Reminder
     execute: async (_toolCallId, args) => {
       const { delay_minutes, message } = args;
 
-      if (delay_minutes <= 0) {
+      if (delay_minutes <= 0 || delay_minutes > MAX_DELAY_MINUTES) {
         return {
           content: [
-            { type: 'text' as const, text: 'Error: delay_minutes must be greater than 0.' },
+            {
+              type: 'text' as const,
+              text: `Error: delay_minutes must be between 1 and ${MAX_DELAY_MINUTES} (~24.8 days).`,
+            },
           ],
           details: { error: 'invalid_delay' },
         };

--- a/packages/server/src/agents/tools/set-reminder.ts
+++ b/packages/server/src/agents/tools/set-reminder.ts
@@ -25,7 +25,7 @@ export function createSetReminderTool(agentId: number, reminderManager: Reminder
     execute: async (_toolCallId, args) => {
       const { delay_minutes, message } = args;
 
-      if (delay_minutes <= 0 || delay_minutes > MAX_DELAY_MINUTES) {
+      if (delay_minutes < 1 || delay_minutes > MAX_DELAY_MINUTES) {
         return {
           content: [
             {

--- a/packages/server/src/reminders/manager.test.ts
+++ b/packages/server/src/reminders/manager.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentHost } from '../agents/host.js';
+import type { AgentRegistry } from '../agents/registry.js';
+import { ReminderManager } from './manager.js';
+
+function makeRegistry(
+  registeredAgents: Record<number, { deliverMessage: ReturnType<typeof vi.fn> }>
+) {
+  return {
+    get: (id: number) => registeredAgents[id] as unknown as AgentHost | undefined,
+  } as unknown as AgentRegistry;
+}
+
+describe('ReminderManager', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('schedules a reminder and fires it after delay', () => {
+    const deliverMessage = vi.fn();
+    const registry = makeRegistry({ 1: { deliverMessage } });
+    const manager = new ReminderManager(registry);
+
+    const { id, fireAt } = manager.schedule(1, 'Check PR review', 5);
+
+    expect(id).toBe(1);
+    expect(fireAt).toBeInstanceOf(Date);
+    expect(deliverMessage).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(5 * 60_000);
+
+    expect(deliverMessage).toHaveBeenCalledTimes(1);
+    const [content, details] = deliverMessage.mock.calls[0];
+    expect(content).toContain('[Reminder #1]');
+    expect(content).toContain('Check PR review');
+    expect(details.sender).toBe(0);
+    expect(details.receiver).toBe(1);
+  });
+
+  it('assigns incrementing IDs', () => {
+    const registry = makeRegistry({ 1: { deliverMessage: vi.fn() } });
+    const manager = new ReminderManager(registry);
+
+    const r1 = manager.schedule(1, 'first', 10);
+    const r2 = manager.schedule(1, 'second', 20);
+
+    expect(r1.id).toBe(1);
+    expect(r2.id).toBe(2);
+  });
+
+  it('cancels a pending reminder', () => {
+    const deliverMessage = vi.fn();
+    const registry = makeRegistry({ 1: { deliverMessage } });
+    const manager = new ReminderManager(registry);
+
+    const { id } = manager.schedule(1, 'will be cancelled', 5);
+    const cancelled = manager.cancel(id, 1);
+
+    expect(cancelled).toBe(true);
+
+    vi.advanceTimersByTime(5 * 60_000);
+    expect(deliverMessage).not.toHaveBeenCalled();
+  });
+
+  it('rejects cancel for wrong agent', () => {
+    const registry = makeRegistry({ 1: { deliverMessage: vi.fn() } });
+    const manager = new ReminderManager(registry);
+
+    const { id } = manager.schedule(1, 'agent 1 reminder', 5);
+    const cancelled = manager.cancel(id, 2);
+
+    expect(cancelled).toBe(false);
+  });
+
+  it('rejects cancel for non-existent reminder', () => {
+    const registry = makeRegistry({});
+    const manager = new ReminderManager(registry);
+
+    expect(manager.cancel(999, 1)).toBe(false);
+  });
+
+  it('lists reminders for a specific agent', () => {
+    const registry = makeRegistry({
+      1: { deliverMessage: vi.fn() },
+      2: { deliverMessage: vi.fn() },
+    });
+    const manager = new ReminderManager(registry);
+
+    manager.schedule(1, 'agent 1 reminder', 5);
+    manager.schedule(2, 'agent 2 reminder', 10);
+    manager.schedule(1, 'another agent 1', 15);
+
+    const agent1Reminders = manager.listForAgent(1);
+    expect(agent1Reminders).toHaveLength(2);
+    expect(agent1Reminders[0].message).toBe('agent 1 reminder');
+    expect(agent1Reminders[1].message).toBe('another agent 1');
+
+    const agent2Reminders = manager.listForAgent(2);
+    expect(agent2Reminders).toHaveLength(1);
+  });
+
+  it('removes reminder from list after firing', () => {
+    const registry = makeRegistry({ 1: { deliverMessage: vi.fn() } });
+    const manager = new ReminderManager(registry);
+
+    manager.schedule(1, 'will fire', 5);
+    expect(manager.listForAgent(1)).toHaveLength(1);
+
+    vi.advanceTimersByTime(5 * 60_000);
+    expect(manager.listForAgent(1)).toHaveLength(0);
+  });
+
+  it('logs warning and drops reminder when agent is not active', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const registry = makeRegistry({}); // no agents registered
+    const manager = new ReminderManager(registry);
+
+    manager.schedule(1, 'orphaned reminder', 5);
+    vi.advanceTimersByTime(5 * 60_000);
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Agent 1 not active'));
+    warnSpy.mockRestore();
+  });
+
+  it('stop() clears all timers', () => {
+    const deliverMessage = vi.fn();
+    const registry = makeRegistry({ 1: { deliverMessage } });
+    const manager = new ReminderManager(registry);
+
+    manager.schedule(1, 'reminder 1', 5);
+    manager.schedule(1, 'reminder 2', 10);
+    manager.stop();
+
+    vi.advanceTimersByTime(10 * 60_000);
+    expect(deliverMessage).not.toHaveBeenCalled();
+    expect(manager.listForAgent(1)).toHaveLength(0);
+  });
+});

--- a/packages/server/src/reminders/manager.ts
+++ b/packages/server/src/reminders/manager.ts
@@ -1,0 +1,90 @@
+/**
+ * Reminder Manager
+ *
+ * In-memory manager for agent reminders. Agents schedule reminders with a delay,
+ * and when the timer fires, a follow-up message is delivered back to the agent
+ * via deliverMessage(). Reminders do not survive server restarts.
+ */
+
+import type { AgentRegistry } from '../agents/registry.js';
+
+export interface PendingReminder {
+  id: number;
+  agentId: number;
+  message: string;
+  fireAt: Date;
+}
+
+/** Internal representation including the timer handle. */
+interface StoredReminder extends PendingReminder {
+  timer: NodeJS.Timeout;
+}
+
+export class ReminderManager {
+  private nextId = 1;
+  private reminders: Map<number, StoredReminder> = new Map();
+
+  constructor(private registry: AgentRegistry) {}
+
+  /** Schedule a reminder that fires after `delayMinutes`. Returns the ID and fire time. */
+  schedule(agentId: number, message: string, delayMinutes: number): { id: number; fireAt: Date } {
+    const id = this.nextId++;
+    const delayMs = delayMinutes * 60_000;
+    const fireAt = new Date(Date.now() + delayMs);
+
+    const timer = setTimeout(() => this.fire(id), delayMs);
+    // Prevent the timer from keeping the Node.js process alive during shutdown
+    timer.unref();
+
+    this.reminders.set(id, { id, agentId, message, fireAt, timer });
+    return { id, fireAt };
+  }
+
+  /** Cancel a pending reminder. Returns true if cancelled, false if not found or not owned. */
+  cancel(reminderId: number, agentId: number): boolean {
+    const reminder = this.reminders.get(reminderId);
+    if (!reminder || reminder.agentId !== agentId) return false;
+
+    clearTimeout(reminder.timer);
+    this.reminders.delete(reminderId);
+    return true;
+  }
+
+  /** List pending reminders for a given agent. */
+  listForAgent(agentId: number): PendingReminder[] {
+    const results: PendingReminder[] = [];
+    for (const r of this.reminders.values()) {
+      if (r.agentId === agentId) {
+        results.push({ id: r.id, agentId: r.agentId, message: r.message, fireAt: r.fireAt });
+      }
+    }
+    return results;
+  }
+
+  /** Clear all active timers. Called on graceful shutdown. */
+  stop(): void {
+    for (const r of this.reminders.values()) {
+      clearTimeout(r.timer);
+    }
+    this.reminders.clear();
+  }
+
+  /** Fire a reminder: deliver the message and remove it from the map. */
+  private fire(reminderId: number): void {
+    const reminder = this.reminders.get(reminderId);
+    if (!reminder) return;
+
+    this.reminders.delete(reminderId);
+
+    const host = this.registry.get(reminder.agentId);
+    if (!host) {
+      console.warn(
+        `[ReminderManager] Agent ${reminder.agentId} not active, dropping reminder #${reminderId}`
+      );
+      return;
+    }
+
+    const content = `[Reminder #${reminderId}]\n\n${reminder.message}`;
+    host.deliverMessage(content, { sender: 0, receiver: reminder.agentId, timestamp: Date.now() });
+  }
+}

--- a/packages/server/src/reminders/manager.ts
+++ b/packages/server/src/reminders/manager.ts
@@ -58,6 +58,7 @@ export class ReminderManager {
         results.push({ id: r.id, agentId: r.agentId, message: r.message, fireAt: r.fireAt });
       }
     }
+    results.sort((a, b) => a.fireAt.getTime() - b.fireAt.getTime());
     return results;
   }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -32,6 +32,7 @@ import { ConversationSummarizer } from './chat/summarizer.js';
 import { DatabaseClient } from './db/client.js';
 import { initializeGitRepo } from './knowledge/git.js';
 import { initializeKnowledge } from './knowledge/init.js';
+import { ReminderManager } from './reminders/manager.js';
 import {
   buildAndDeliverDailySummary,
   buildAndDeliverMemoryUpdate,
@@ -73,6 +74,7 @@ export class Server {
   private guideAgentId: number;
   private conversationSummarizer?: ConversationSummarizer;
   private authResolver: AuthResolver;
+  private reminderManager: ReminderManager;
 
   constructor(config: ServerConfig) {
     this.config = config;
@@ -90,6 +92,9 @@ export class Server {
     // Shared AuthResolver: all agents see the same cooldown/failover state
     this.authResolver = new AuthResolver(config.llmConfig);
 
+    // Shared ReminderManager: all agents schedule reminders through the same instance
+    this.reminderManager = new ReminderManager(this.agentRegistry);
+
     // Initialize Guide agent (singleton) — receives the spawner so it can create Conductors/Reviewers
     const chatMaxMessages = config.chatConfig?.max_history_messages ?? 1000;
 
@@ -106,6 +111,7 @@ export class Server {
       resurrector: this.makeResurrector(),
       chatMaxMessages,
       authResolver: this.authResolver,
+      reminderManager: this.reminderManager,
     });
     this.agentRegistry.register(guideAgent.id, this.agentHost);
 
@@ -121,6 +127,7 @@ export class Server {
       toolsConfig: config.toolsConfig,
       chatMaxMessages,
       authResolver: this.authResolver,
+      reminderManager: this.reminderManager,
     });
     this.agentRegistry.register(narratorAgent.id, this.narratorHost);
 
@@ -333,6 +340,7 @@ export class Server {
       resurrector: this.makeResurrector(),
       chatMaxMessages,
       authResolver: this.authResolver,
+      reminderManager: this.reminderManager,
     });
 
     // Subscribe for chat cache capture before initialize() so no events are missed
@@ -755,7 +763,8 @@ export class Server {
     // Clean up conversation summarizer
     this.conversationSummarizer?.cleanup();
 
-    // Stop scheduled jobs first
+    // Stop reminder timers and scheduled jobs
+    this.reminderManager.stop();
     this.scheduler.stop();
 
     // Initiate clean WebSocket close handshake with all clients


### PR DESCRIPTION
## Summary

- Adds `set_reminder`, `cancel_reminder`, and `list_reminders` tools available to all agents
- Agents schedule a delayed reminder via `setTimeout`, continue working, and receive a `followUp` message when the timer fires
- Purely in-memory (no DB persistence): reminders do not survive server restarts
- New `ReminderManager` class manages timer lifecycle, wired into server startup/shutdown

## New files

- `packages/server/src/reminders/manager.ts`: `ReminderManager` class
- `packages/server/src/agents/tools/set-reminder.ts`: schedule a delayed self-reminder
- `packages/server/src/agents/tools/cancel-reminder.ts`: cancel by ID (ownership-checked)
- `packages/server/src/agents/tools/list-reminders.ts`: list pending reminders

## Test plan

- [x] `pnpm check` passes (format + lint)
- [x] `pnpm build` passes (all packages)
- [x] `pnpm test` passes (415/415, 15 new tests)
- [x] Pre-push hooks pass (lint, typecheck, tests)
- [ ] Manual: start server, agent calls `set_reminder` with short delay, verify follow-up arrives

Closes #59