### PR TITLE
feat: collapsible detail blocks for system messages

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -162,7 +162,7 @@ When `AgentHost` detects an API error in a `message_end` event:
 4. Reinitialize the session with the new provider (`reinitializeWithProvider()`)
 5. Retry the pending prompt
 
-Error details (status code and human-readable category) are shown in agent chat messages so the user can diagnose issues. Key rotation within a provider: "429 rate limited on google, rotating to next key". Provider switch: "429 rate limited on google, switching to anthropic".
+Error details are shown as collapsible system messages in the agent chat. The title shows the error type and action taken, and the collapsible body has provider-specific details. Key rotation: "429 rate limited, rotating to next key". Provider switch: "503 server error, switched to anthropic".
 
 ### Retry Logic (`retry.ts`)
 

--- a/docs/packages/ui.md
+++ b/docs/packages/ui.md
@@ -70,7 +70,7 @@ Displays messages as a vertical timeline with color-coded indicators:
 | Thinking blocks | `#8b949e` (gray) | Collapsible extended thinking |
 | System messages | `#8b949e` (gray) | Inter-agent messages, scheduled tasks, provider changes |
 
-System messages have two rendering modes based on content format. Messages containing `\n\n` are treated as full-content: the text before the separator is shown as the header label (e.g., "Message from conductor agent (id=5)") and the body is rendered as markdown. Messages without `\n\n` are abbreviated: displayed as plain muted text under a "System2" header. The server's `deliverMessage()` controls which format is stored in the chat cache (full content for inter-agent messages and summaries, tag-only for scheduled tasks).
+System messages have two rendering modes based on content format. Messages containing `\n\n` are treated as collapsible: the text before the separator is shown as the header label (e.g., "Conversation: user <-> conductor_7" for summaries, "503 server error, switched to anthropic" for failovers) and the body is rendered as collapsible markdown, collapsed by default. Messages without `\n\n` are displayed as plain muted text under a "System2" header. The server's `deliverMessage()` controls which format is stored in the chat cache (full content for inter-agent messages and summaries, tag-only for scheduled tasks).
 
 Each assistant message shows its turn events (thinking -> tool calls -> response text) in chronological order. An animated "brain loader" appears while waiting for a response and between completed blocks (e.g., after a tool finishes, before the next starts) to indicate the agent is still working.
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -66,7 +66,7 @@ type ServerMessage =
 | `artifact` | Display artifact in a UI tab. Includes `title` (from DB or filename) and `filePath` (absolute path for tab dedup and reload targeting). Also sent on live reload (file watch). |
 | `context_usage` | Context window usage after each agent turn |
 | `provider_info` | Sent on connect/switch: current LLM provider for an agent |
-| `provider_change` | Sent on failover: provider switched. Includes `reason` (status code + category) and `agentId` so the UI routes the system message to the correct agent chat |
+| `provider_change` | Sent on failover: provider switched. Includes `reason` (e.g., "503 server error, switched to anthropic") and `agentId` so the UI routes the system message to the correct agent chat |
 | `error` | Error message |
 | `ready_for_input` | Agent finished, ready for next message |
 | `chat_history` | Sent on connect (Guide) and on `switch_agent`: recent messages for the specified agent |

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -776,7 +776,8 @@ describe('AgentHost', () => {
       expect(internal.reinitializeWithProvider).toHaveBeenCalledWith(
         'anthropic',
         null,
-        '429 rate limited on google, switching to anthropic'
+        '429 rate limited, switched to anthropic',
+        'on google, switching to anthropic'
       );
     });
 
@@ -820,7 +821,8 @@ describe('AgentHost', () => {
       expect(internal.reinitializeWithProvider).toHaveBeenCalledWith(
         'google',
         null,
-        '429 rate limited on google, rotating to next key'
+        '429 rate limited, rotating to next key',
+        'on google, rotating to next key'
       );
     });
 
@@ -863,7 +865,9 @@ describe('AgentHost', () => {
       expect(internal._chatCache.push).toHaveBeenCalledOnce();
       const pushed = internal._chatCache.push.mock.calls[0][0];
       expect(pushed.role).toBe('system');
-      expect(pushed.content).toBe('401 auth error on cerebras, all providers unavailable');
+      expect(pushed.content).toBe(
+        '401 auth error, all providers unavailable\n\non cerebras, all providers unavailable'
+      );
     });
   });
 
@@ -905,6 +909,7 @@ describe('AgentHost', () => {
       expect(internal.reinitializeWithProvider).toHaveBeenCalledWith(
         'google',
         null,
+        expect.stringContaining('switched to google'),
         expect.stringContaining('cooldown')
       );
     });
@@ -987,7 +992,8 @@ describe('AgentHost', () => {
       expect(internal.reinitializeWithProvider).toHaveBeenCalledWith(
         'google',
         null,
-        '400 client error on anthropic, switching to google'
+        '400 client error, switched to google',
+        'on anthropic, switching to google'
       );
     });
 
@@ -1038,7 +1044,9 @@ describe('AgentHost', () => {
       expect(internal.busy).toBe(false);
       // Should show error details in the exhausted message
       const pushed = internal._chatCache.push.mock.calls[0][0];
-      expect(pushed.content).toBe('400 client error on anthropic, all providers unavailable');
+      expect(pushed.content).toBe(
+        '400 client error, all providers unavailable\n\non anthropic, all providers unavailable'
+      );
     });
   });
 

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -67,6 +67,7 @@ function categoryLabel(category: ErrorCategory): string {
       return 'error';
   }
 }
+
 import { createBashTool } from './tools/bash.js';
 import { createCancelReminderTool } from './tools/cancel-reminder.js';
 import { createEditTool } from './tools/edit.js';
@@ -484,12 +485,16 @@ export class AgentHost {
       if (nextProvider) {
         const reason =
           nextProvider === this.currentProvider
-            ? `${errorPrefix} on ${this.currentProvider}, rotating to next key`
-            : `${errorPrefix} on ${this.currentProvider} (key already in cooldown), switching to ${nextProvider}`;
+            ? `${errorPrefix}, rotating to next key`
+            : `${errorPrefix}, switched to ${nextProvider}`;
+        const detail =
+          nextProvider === this.currentProvider
+            ? `on ${this.currentProvider}, rotating to next key`
+            : `on ${this.currentProvider} (key already in cooldown), switching to ${nextProvider}`;
         console.log(
           `[AgentHost] Key ${this.currentProvider}:${this.currentKeyIndex} already in cooldown`
         );
-        await this.reinitializeWithProvider(nextProvider, promptToRetry, reason);
+        await this.reinitializeWithProvider(nextProvider, promptToRetry, reason, detail);
         return;
       }
     }
@@ -539,20 +544,22 @@ export class AgentHost {
         const nextProvider = this.authResolver.getNextProvider();
         if (nextProvider) {
           if (nextProvider === this.currentProvider) {
-            const reason = `${errorPrefix} on ${this.currentProvider}, rotating to next key`;
+            const reason = `${errorPrefix}, rotating to next key`;
+            const detail = `on ${this.currentProvider}, rotating to next key`;
             console.log(`[AgentHost] Rotating to next key for ${this.currentProvider}`);
-            await this.reinitializeWithProvider(nextProvider, promptToRetry, reason);
+            await this.reinitializeWithProvider(nextProvider, promptToRetry, reason, detail);
           } else {
-            const reason = `${errorPrefix} on ${this.currentProvider}, switching to ${nextProvider}`;
+            const reason = `${errorPrefix}, switched to ${nextProvider}`;
+            const detail = `on ${this.currentProvider}, switching to ${nextProvider}`;
             console.log(`[AgentHost] Failing over from ${this.currentProvider} to ${nextProvider}`);
-            await this.reinitializeWithProvider(nextProvider, promptToRetry, reason);
+            await this.reinitializeWithProvider(nextProvider, promptToRetry, reason, detail);
           }
           return;
         }
       }
 
       this.pushSystemMessage(
-        `${errorPrefix} on ${this.currentProvider}, all providers unavailable`
+        `${errorPrefix}, all providers unavailable\n\non ${this.currentProvider}, all providers unavailable`
       );
       console.log('[AgentHost] No fallback providers available, error will be surfaced to user');
     }
@@ -578,11 +585,12 @@ export class AgentHost {
     // switch to it. This covers cases like being stuck on a dead fallback provider.
     const nextProvider = this.authResolver.getNextProvider();
     if (nextProvider && nextProvider !== this.currentProvider) {
-      const reason = `${errorPrefix} on ${this.currentProvider}, switching to ${nextProvider}`;
+      const reason = `${errorPrefix}, switched to ${nextProvider}`;
+      const detail = `on ${this.currentProvider}, switching to ${nextProvider}`;
       console.log(
         `[AgentHost] Recovery: switching from ${this.currentProvider} to ${nextProvider}`
       );
-      await this.reinitializeWithProvider(nextProvider, promptToRetry, reason);
+      await this.reinitializeWithProvider(nextProvider, promptToRetry, reason, detail);
       return;
     }
 
@@ -602,7 +610,8 @@ export class AgentHost {
   private async reinitializeWithProvider(
     provider: LlmProvider,
     promptToRetry?: string | null,
-    reason?: string
+    reason?: string,
+    detail?: string
   ): Promise<void> {
     if (this.isReinitializing) {
       console.log('[AgentHost] Already reinitializing, skipping');
@@ -625,7 +634,7 @@ export class AgentHost {
       // Push chat message before init so the user sees the reason even if
       // initialization fails. Only for actual failovers, not compaction recovery.
       if (reason) {
-        this.pushSystemMessage(reason);
+        this.pushSystemMessage(detail ? `${reason}\n\n${detail}` : reason);
       }
 
       // Recreate model registry with updated auth
@@ -662,7 +671,7 @@ export class AgentHost {
       console.error('[AgentHost] Failed to reinitialize:', error);
       if (reason) {
         const msg = error instanceof Error ? error.message : String(error);
-        this.pushSystemMessage(`Failed to switch: ${msg}`);
+        this.pushSystemMessage(`Failed to switch provider\n\n${msg}`);
       }
     } finally {
       this.isReinitializing = false;

--- a/packages/server/src/chat/summarizer.test.ts
+++ b/packages/server/src/chat/summarizer.test.ts
@@ -122,7 +122,7 @@ describe('ConversationSummarizer', () => {
 
       const [content, details] = (guideHost.deliverMessage as ReturnType<typeof vi.fn>).mock
         .calls[0];
-      expect(content).toContain('[Conversation summary: conductor (id=2)]');
+      expect(content).toContain('[Conversation: user <-> conductor_2]');
       expect(content).toContain('mocked summary');
       expect(details.receiver).toBe(1);
       expect(details.sender).toBe(2);

--- a/packages/server/src/chat/summarizer.ts
+++ b/packages/server/src/chat/summarizer.ts
@@ -134,7 +134,7 @@ export class ConversationSummarizer {
 
       // Deliver summary to Guide
       this.guideHost.deliverMessage(
-        `[Conversation summary: ${buffer.agentRole} (id=${agentId})]\n\n${summary}`,
+        `[Conversation: user <-> ${buffer.agentRole}_${agentId}]\n\n${summary}`,
         {
           sender: agentId,
           receiver: this.guideAgentId,


### PR DESCRIPTION
## Summary

- Conversation summaries now titled "Conversation: user <-> conductor_7" (was "Conversation summary: conductor (id=7)") with the summary text in a collapsible block
- Error/failover messages now use a title/body format so the UI renders them as collapsible blocks (e.g., title: "503 server error, switched to anthropic", body: "on claude-3-5-sonnet, switching to anthropic")
- Updated docs (agents.md, ui.md, websocket-protocol.md) to reflect new message formats

No UI changes needed: the existing `SystemMessageBlock` already splits on `\n\n` and renders anything with a body as collapsible.

Closes #61

## Test plan

- [ ] All 433 existing tests pass (updated assertions for new formats)
- [ ] Trigger a failover (e.g., invalid API key) and verify the system message in the UI shows a collapsible block
- [ ] Send a message to a non-Guide agent and verify the Guide receives a summary with the new title format