### PR TITLE
fix: lower context-usage color thresholds to 40%/50%

### DIFF
--- a/docs/packages/ui.md
+++ b/docs/packages/ui.md
@@ -76,7 +76,7 @@ Each assistant message shows its turn events (thinking -> tool calls -> response
 
 ### MessageInput
 
-Auto-growing textarea (1-10 lines, then scrolls). Shows the current LLM provider name and context window usage percentage (teal below 50%, accent 50-69%, coral at 70%+) in the status bar. Messages sent while the agent is streaming are delivered immediately as steering messages. Toggles between Send and Stop buttons based on streaming state. Provider changes on failover trigger a system message in the chat timeline.
+Auto-growing textarea (1-10 lines, then scrolls). Shows the current LLM provider name and context window usage percentage (teal below 40%, accent 40-49%, coral at 50%+) in the status bar. Messages sent while the agent is streaming are delivered immediately as steering messages. Toggles between Send and Stop buttons based on streaming state. Provider changes on failover trigger a system message in the chat timeline.
 
 ### ArtifactViewer
 

--- a/packages/ui/src/theme/colors.test.ts
+++ b/packages/ui/src/theme/colors.test.ts
@@ -4,21 +4,21 @@ import { colors, contextColor } from './colors';
 describe('contextColor', () => {
   const accent = '#ffb444';
 
-  it('returns teal below 50%', () => {
+  it('returns teal below 40%', () => {
     expect(contextColor(0, accent)).toBe(colors.teal);
-    expect(contextColor(49, accent)).toBe(colors.teal);
-    expect(contextColor(49.9, accent)).toBe(colors.teal);
+    expect(contextColor(39, accent)).toBe(colors.teal);
+    expect(contextColor(39.9, accent)).toBe(colors.teal);
   });
 
-  it('returns accent from 50% to 69%', () => {
-    expect(contextColor(50, accent)).toBe(accent);
-    expect(contextColor(60, accent)).toBe(accent);
-    expect(contextColor(69.9, accent)).toBe(accent);
+  it('returns accent from 40% to 49%', () => {
+    expect(contextColor(40, accent)).toBe(accent);
+    expect(contextColor(45, accent)).toBe(accent);
+    expect(contextColor(49.9, accent)).toBe(accent);
   });
 
-  it('returns coral at 70% and above', () => {
-    expect(contextColor(70, accent)).toBe(colors.coral);
-    expect(contextColor(85, accent)).toBe(colors.coral);
+  it('returns coral at 50% and above', () => {
+    expect(contextColor(50, accent)).toBe(colors.coral);
+    expect(contextColor(75, accent)).toBe(colors.coral);
     expect(contextColor(100, accent)).toBe(colors.coral);
   });
 });

--- a/packages/ui/src/theme/colors.ts
+++ b/packages/ui/src/theme/colors.ts
@@ -56,7 +56,7 @@ export const palettes = {
 
 /** Map a context-usage percentage to a severity color. */
 export function contextColor(percent: number, accent: string): string {
-  if (percent >= 70) return colors.coral;
-  if (percent >= 50) return accent;
+  if (percent >= 50) return colors.coral;
+  if (percent >= 40) return accent;
   return colors.teal;
 }


### PR DESCRIPTION
## Summary
- Lower context-usage color thresholds: teal < 40%, accent 40-49%, coral >= 50% (was 50/70)
- Update tests and docs to match

## Test plan
- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (433 tests)