### PR TITLE
feat: add scheduler job execution tracking

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -108,6 +108,23 @@ File artifacts created by agents, displayed in the UI.
 
 **Indices:** `idx_artifact_project` on `project`, `idx_artifact_file_path` on `file_path`
 
+### `job_execution`
+
+Scheduler job execution records.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | INTEGER PK | Auto-incrementing |
+| `job_name` | TEXT NOT NULL | Job identifier (e.g., `daily-summary`, `memory-update`) |
+| `status` | TEXT NOT NULL | `running` \| `completed` \| `failed` |
+| `trigger_type` | TEXT NOT NULL | `cron` \| `catch-up` \| `manual` |
+| `error` | TEXT | Error message if status is `failed` |
+| `started_at` | TEXT NOT NULL | ISO 8601 timestamp when execution began |
+| `ended_at` | TEXT | ISO 8601 timestamp when execution finished |
+| `created_at` / `updated_at` | TEXT | Auto-set |
+
+**Indices:** `idx_job_execution_job_name`, `idx_job_execution_status`, `idx_job_execution_started_at`
+
 ## DatabaseClient (`client.ts`)
 
 The `DatabaseClient` class initializes SQLite with WAL mode and a 5-second busy timeout, then applies the schema.
@@ -120,6 +137,11 @@ The `DatabaseClient` class initializes SQLite with WAL mode and a 5-second busy 
 | `getOrCreateNarratorAgent()` | Returns the singleton narrator agent, creating it if needed |
 | `getAgent(id)` | Get agent by ID |
 | `query(sql)` | Execute a custom SELECT query, returns rows as objects |
+| `createJobExecution(jobName, triggerType)` | Insert a new execution with status `running` |
+| `completeJobExecution(id)` | Mark execution as `completed` with `ended_at` |
+| `failJobExecution(id, error)` | Mark execution as `failed` with error message |
+| `failStaleJobExecutions(error)` | Bulk-fail all `running` rows (startup crash recovery) |
+| `listJobExecutions(filters?)` | List executions with optional `jobName`, `status`, `limit` filters |
 | `close()` | Close the database connection |
 
 Project, task, comment, link, and artifact CRUD methods are also available (`createArtifact`, `getArtifact`, `updateArtifact`, `deleteArtifact`).

--- a/docs/database.md
+++ b/docs/database.md
@@ -123,7 +123,11 @@ Scheduler job execution records.
 | `ended_at` | TEXT | ISO 8601 timestamp when execution finished |
 | `created_at` / `updated_at` | TEXT | Auto-set |
 
-**Indices:** `idx_job_execution_job_name`, `idx_job_execution_status`, `idx_job_execution_started_at`
+**Indices:**
+
+- `idx_job_execution_job_name` on `job_name` (filter by job)
+- `idx_job_execution_status` on `status` (filter by lifecycle state)
+- `idx_job_execution_started_at` on `started_at` (order by recency)
 
 ## DatabaseClient (`client.ts`)
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -123,11 +123,7 @@ Scheduler job execution records.
 | `ended_at` | TEXT | ISO 8601 timestamp when execution finished |
 | `created_at` / `updated_at` | TEXT | Auto-set |
 
-**Indices:**
-
-- `idx_job_execution_job_name` on `job_name` (filter by job)
-- `idx_job_execution_status` on `status` (filter by lifecycle state)
-- `idx_job_execution_started_at` on `started_at` (order by recency)
+**Indices:** `idx_job_execution_job_name` on `job_name`, `idx_job_execution_status` on `status`, `idx_job_execution_started_at` on `started_at`
 
 ## DatabaseClient (`client.ts`)
 

--- a/docs/packages/server.md
+++ b/docs/packages/server.md
@@ -62,10 +62,11 @@ The `Server` class is the main entry point. It accepts a `ServerConfig` and orch
 
 1. Initialize Guide and Narrator agent sessions (`agentHost.initialize()`)
 2. Restore previously active spawned agents (conductors, reviewers, etc.) from the database via `initializeAgentHost()`
-3. Register Narrator scheduled jobs
-4. Check if Narrator needs catch-up (handles server downtime / laptop sleep)
-5. Register SIGTERM/SIGINT shutdown handlers
-6. Start listening on configured port
+3. Recover stale job executions from previous crash (`failStaleJobExecutions`)
+4. Register Narrator scheduled jobs
+5. Check if Narrator needs catch-up (handles server downtime / laptop sleep)
+6. Register SIGTERM/SIGINT shutdown handlers
+7. Start listening on configured port
 
 ### Express Routes
 
@@ -75,6 +76,7 @@ The `Server` class is the main entry point. It accepts a `ServerConfig` and orch
 | `/api/artifacts` | GET | List all registered artifacts with project names (for catalog UI) |
 | `/api/agents` | GET | List all non-archived agents with in-memory busy state (for agents pane) |
 | `/api/kanban` | GET | Kanban board data: all tasks (with project/assignee joins), projects, and active agents |
+| `/api/job-executions` | GET | Scheduler job execution history (query params: `job_name`, `status`, `limit`) |
 | `/api/tasks/:id` | GET | Full task detail: task row, all comments (with author role), and all linked tasks (bidirectional) |
 | `/api/query` | POST | SQL query endpoint for artifact dashboards (SELECT only) |
 | `/*` | GET | UI static files (if `uiDistPath` configured) |

--- a/docs/packages/ui.md
+++ b/docs/packages/ui.md
@@ -21,6 +21,7 @@ src/
 │   ├── ArtifactViewer.tsx    # Tabbed artifact display (iframe + native tabs)
 │   ├── AgentPane.tsx          # Active agent list with busy indicators
 │   ├── ArtifactCatalog.tsx  # Browsable overlay of all registered artifacts
+│   ├── ExecutionHistoryPane.tsx  # Scheduler job execution history panel
 │   ├── KanbanBoard.tsx    # Live kanban dashboard (swimlane layout, native tab)
 │   ├── TaskDetailModal.tsx # Task detail overlay (comments, links, markdown)
 │   ├── ProjectDetailModal.tsx # Project detail overlay (status, labels, dates)
@@ -56,7 +57,7 @@ App (ThemeProvider)
 
 ### Layout
 
-VSCode-style layout with an activity bar on the left edge (48px). The activity bar contains toggle buttons for the artifact catalog, agent pane, and kanban board (top), plus particles and theme toggles (bottom). Opening the catalog or agents panel closes the other; the kanban board toggles a native tab instead. Opening one side panel closes the other. The artifact viewer fills the center, with the chat panel on the right (20-60% resizable, default 33%). Both the side panel and chat panel have draggable resize handles.
+VSCode-style layout with an activity bar on the left edge (48px). The activity bar contains toggle buttons for the artifact catalog, agent pane, kanban board, and execution history (top), plus particles and theme toggles (bottom). Opening the catalog or agents panel closes the other; the kanban board toggles a native tab instead. Opening one side panel closes the other. The artifact viewer fills the center, with the chat panel on the right (20-60% resizable, default 33%). Both the side panel and chat panel have draggable resize handles.
 
 ### MessageList
 
@@ -147,6 +148,10 @@ Side panel showing all non-archived agents with busy/idle indicators. Polls `GET
 
 Clicking an agent row switches the chat panel to that agent. The active agent is highlighted with an accent-colored left border on its ID cell. Switching updates `activeAgentId` in the chat store, which triggers the WebSocket hook to send `switch_agent` to the server. The server responds with the agent's chat history and streaming state.
 
+### ExecutionHistoryPane
+
+Side panel showing scheduler job execution history. Polls `GET /api/job-executions` every 2 seconds. Groups executions by job name (daily-summary, memory-update) with collapsible sections. Each row shows a status dot (teal for completed, coral for failed, amber for running), trigger type, start time, and duration. Failed executions are expandable to show the error message. Toggled via HistoryIcon in the activity bar.
+
 ## State Management
 
 Three [Zustand](https://github.com/pmndrs/zustand) stores with no Redux or Context:
@@ -192,6 +197,7 @@ Tab-based artifact state persisted via the Zustand `persist` middleware (key: `s
 | `catalogOpen` | `boolean` | Whether the catalog panel is visible (not persisted) |
 | `agentsOpen` | `boolean` | Whether the agents panel is visible (persisted) |
 | `kanbanOpen` | `boolean` | Whether the kanban board tab is open (persisted) |
+| `executionsOpen` | `boolean` | Whether the execution history panel is visible (persisted) |
 
 Key behaviors:
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -85,11 +85,27 @@ Croner does **not** catch up missed jobs after laptop sleep or server shutdown. 
 2. **Daily summary**: resolve the last daily summary timestamp. If stale by more than `intervalMinutes`, queue `buildAndDeliverDailySummary()`
 3. **Memory update**: read `last_narrator_update_ts` from `memory.md`. If stale by more than 24 hours, queue `buildAndDeliverMemoryUpdate()`
 
-This runs once at server start, after agent sessions are initialized.
+This runs once at server start, after agent sessions are initialized. Catch-up executions are tracked in the `job_execution` table with `trigger_type: 'catch-up'`.
 
 Both checks use `last_narrator_update_ts` as a cursor. This timestamp only advances when the Narrator successfully processes the delivered message and writes it back to the file's frontmatter. If a job is skipped (network down) or fails, the cursor stays stale and the next restart will re-trigger catch-up.
 
 **Within a single server lifecycle:** if the server starts without network, catch-up is skipped entirely. The `daily-summary` job self-recovers within one cron interval (default 30 min) once the network is back, because its staleness check runs on every cron tick. The `memory-update` catch-up is lost until its next scheduled run (daily at 11 AM), since the cron handler only fires once per day. A server restart recovers both.
+
+## Execution Tracking
+
+Every job execution is recorded in the [`job_execution`](database.md#job_execution) table. When a job fires, a row is inserted with status `running`. On success it transitions to `completed`; on failure it transitions to `failed` with the error message preserved.
+
+The `trigger_type` column distinguishes how the execution was initiated:
+
+| Value | Meaning |
+|-------|---------|
+| `cron` | Normal scheduled cron tick |
+| `catch-up` | Server startup recovery for missed runs |
+| `manual` | Reserved for future manual triggers |
+
+**Startup recovery:** before Croner starts, the server marks any stale `running` rows as `failed` with error `'server shutdown'`. At that point no new jobs have fired, so every `running` row is definitively from the previous (crashed) process.
+
+**Network-skipped runs** do not create rows. The network check happens before execution tracking, so a skip is not an execution attempt.
 
 ## See Also
 

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -206,7 +206,7 @@ Reference these tables when writing queries.
 | created_at | TEXT | Row creation timestamp |
 | updated_at | TEXT | Last modification timestamp |
 
-**Indices:** `idx_job_execution_job_name` on `job_name` (filter by job), `idx_job_execution_status` on `status` (filter by lifecycle state), `idx_job_execution_started_at` on `started_at` (order by recency)
+**Indices:** `idx_job_execution_job_name` on `job_name`, `idx_job_execution_status` on `status`, `idx_job_execution_started_at` on `started_at`
 
 ## Work Management
 

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -192,6 +192,20 @@ Reference these tables when writing queries.
 | created_at | TEXT | Row creation timestamp |
 | updated_at | TEXT | Last modification timestamp |
 
+**job_execution** — A record of a scheduler job execution
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | INTEGER PK | Auto-incrementing identifier |
+| job_name | TEXT | Job identifier (`daily-summary`, `memory-update`) |
+| status | TEXT | `running`, `completed`, `failed` |
+| trigger_type | TEXT | `cron`, `catch-up`, `manual` |
+| error | TEXT | Error message if status is `failed` |
+| started_at | TEXT | ISO 8601 — when execution began |
+| ended_at | TEXT | ISO 8601 — when execution finished (NULL while running) |
+| created_at | TEXT | Row creation timestamp |
+| updated_at | TEXT | Last modification timestamp |
+
 ## Work Management
 
 All planning and tracking happens in app.db. Never create JSON plans, markdown plans, or any other planning artifact outside the database. The task hierarchy in app.db IS the plan.

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -192,19 +192,21 @@ Reference these tables when writing queries.
 | created_at | TEXT | Row creation timestamp |
 | updated_at | TEXT | Last modification timestamp |
 
-**job_execution** — A record of a scheduler job execution
+**job_execution** — A record of a scheduler job execution (written by the server, not by agents)
 
 | Column | Type | Description |
 |--------|------|-------------|
 | id | INTEGER PK | Auto-incrementing identifier |
 | job_name | TEXT | Job identifier (`daily-summary`, `memory-update`) |
-| status | TEXT | `running`, `completed`, `failed` |
-| trigger_type | TEXT | `cron`, `catch-up`, `manual` |
-| error | TEXT | Error message if status is `failed` |
+| status | TEXT | `running` (in progress), `completed` (succeeded), `failed` (error or crash recovery) |
+| trigger_type | TEXT | How the execution was initiated: `cron` (scheduled), `catch-up` (startup recovery), `manual` |
+| error | TEXT | Error message when status is `failed`, NULL otherwise |
 | started_at | TEXT | ISO 8601 — when execution began |
-| ended_at | TEXT | ISO 8601 — when execution finished (NULL while running) |
+| ended_at | TEXT | ISO 8601 — when execution finished (NULL while still running) |
 | created_at | TEXT | Row creation timestamp |
 | updated_at | TEXT | Last modification timestamp |
+
+**Indices:** `idx_job_execution_job_name` on `job_name` (filter by job), `idx_job_execution_status` on `status` (filter by lifecycle state), `idx_job_execution_started_at` on `started_at` (order by recency)
 
 ## Work Management
 

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -7,7 +7,15 @@
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { Agent, Artifact, Project, Task, TaskComment, TaskLink } from '@dscarabelli/shared';
+import type {
+  Agent,
+  Artifact,
+  JobExecution,
+  Project,
+  Task,
+  TaskComment,
+  TaskLink,
+} from '@dscarabelli/shared';
 import Database from 'better-sqlite3';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -463,6 +471,77 @@ export class DatabaseClient {
   deleteArtifact(id: number): boolean {
     const stmt = this.db.prepare('DELETE FROM artifact WHERE id = ?');
     return stmt.run(id).changes > 0;
+  }
+
+  // Job execution operations
+  createJobExecution(jobName: string, triggerType: JobExecution['trigger_type']): JobExecution {
+    const stmt = this.db.prepare(`
+      INSERT INTO job_execution (job_name, trigger_type)
+      VALUES (?, ?)
+      RETURNING *
+    `);
+
+    return stmt.get(jobName, triggerType) as JobExecution;
+  }
+
+  completeJobExecution(id: number): JobExecution | null {
+    const stmt = this.db.prepare(`
+      UPDATE job_execution
+      SET status = 'completed', ended_at = datetime('now'), updated_at = datetime('now')
+      WHERE id = ?
+      RETURNING *
+    `);
+
+    return (stmt.get(id) as JobExecution) || null;
+  }
+
+  failJobExecution(id: number, error: string): JobExecution | null {
+    const stmt = this.db.prepare(`
+      UPDATE job_execution
+      SET status = 'failed', ended_at = datetime('now'), updated_at = datetime('now'), error = ?
+      WHERE id = ?
+      RETURNING *
+    `);
+
+    return (stmt.get(error, id) as JobExecution) || null;
+  }
+
+  failStaleJobExecutions(error: string): number {
+    const stmt = this.db.prepare(`
+      UPDATE job_execution
+      SET status = 'failed', ended_at = datetime('now'), updated_at = datetime('now'), error = ?
+      WHERE status = 'running'
+    `);
+
+    return stmt.run(error).changes;
+  }
+
+  listJobExecutions(filters?: {
+    jobName?: string;
+    status?: JobExecution['status'];
+    limit?: number;
+  }): JobExecution[] {
+    const conditions: string[] = [];
+    const values: (string | number)[] = [];
+
+    if (filters?.jobName) {
+      conditions.push('job_name = ?');
+      values.push(filters.jobName);
+    }
+    if (filters?.status) {
+      conditions.push('status = ?');
+      values.push(filters.status);
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+    const limit = filters?.limit ?? 100;
+    values.push(limit);
+
+    const stmt = this.db.prepare(
+      `SELECT * FROM job_execution ${where} ORDER BY started_at DESC LIMIT ?`
+    );
+
+    return stmt.all(...values) as JobExecution[];
   }
 
   // Query method for custom queries (used by read_system2_db tool and REST endpoints)

--- a/packages/server/src/db/schema.sql
+++ b/packages/server/src/db/schema.sql
@@ -93,3 +93,22 @@ CREATE TABLE IF NOT EXISTS artifact (
 
 CREATE INDEX IF NOT EXISTS idx_artifact_project ON artifact(project);
 CREATE INDEX IF NOT EXISTS idx_artifact_file_path ON artifact(file_path);
+
+-- A record of a scheduler job execution
+CREATE TABLE IF NOT EXISTS job_execution (
+  id           INTEGER PRIMARY KEY,                -- Auto-incrementing unique identifier
+  job_name     TEXT NOT NULL,                       -- Job identifier (e.g., 'daily-summary', 'memory-update')
+  status       TEXT NOT NULL DEFAULT 'running'      -- Execution lifecycle state
+               CHECK(status IN ('running', 'completed', 'failed')),
+  trigger_type TEXT NOT NULL                        -- How the execution was initiated
+               CHECK(trigger_type IN ('cron', 'catch-up', 'manual')),
+  error        TEXT,                                -- Error message if status is 'failed'
+  started_at   TEXT NOT NULL DEFAULT (datetime('now')), -- When the execution began
+  ended_at     TEXT,                                -- When the execution finished (NULL while running)
+  created_at   TEXT DEFAULT (datetime('now')),       -- Row creation timestamp
+  updated_at   TEXT DEFAULT (datetime('now'))        -- Last modification timestamp
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_execution_job_name   ON job_execution(job_name);
+CREATE INDEX IF NOT EXISTS idx_job_execution_status     ON job_execution(status);
+CREATE INDEX IF NOT EXISTS idx_job_execution_started_at ON job_execution(started_at);

--- a/packages/server/src/db/schema.sql
+++ b/packages/server/src/db/schema.sql
@@ -109,6 +109,6 @@ CREATE TABLE IF NOT EXISTS job_execution (
   updated_at   TEXT DEFAULT (datetime('now'))        -- Last modification timestamp
 );
 
-CREATE INDEX IF NOT EXISTS idx_job_execution_job_name   ON job_execution(job_name);
-CREATE INDEX IF NOT EXISTS idx_job_execution_status     ON job_execution(status);
-CREATE INDEX IF NOT EXISTS idx_job_execution_started_at ON job_execution(started_at);
+CREATE INDEX IF NOT EXISTS idx_job_execution_job_name   ON job_execution(job_name);   -- Filter executions by job name
+CREATE INDEX IF NOT EXISTS idx_job_execution_status     ON job_execution(status);     -- Filter executions by lifecycle state
+CREATE INDEX IF NOT EXISTS idx_job_execution_started_at ON job_execution(started_at); -- Order executions by recency

--- a/packages/server/src/db/schema.sql
+++ b/packages/server/src/db/schema.sql
@@ -109,6 +109,6 @@ CREATE TABLE IF NOT EXISTS job_execution (
   updated_at   TEXT DEFAULT (datetime('now'))        -- Last modification timestamp
 );
 
-CREATE INDEX IF NOT EXISTS idx_job_execution_job_name   ON job_execution(job_name);   -- Filter executions by job name
-CREATE INDEX IF NOT EXISTS idx_job_execution_status     ON job_execution(status);     -- Filter executions by lifecycle state
-CREATE INDEX IF NOT EXISTS idx_job_execution_started_at ON job_execution(started_at); -- Order executions by recency
+CREATE INDEX IF NOT EXISTS idx_job_execution_job_name   ON job_execution(job_name);
+CREATE INDEX IF NOT EXISTS idx_job_execution_status     ON job_execution(status);
+CREATE INDEX IF NOT EXISTS idx_job_execution_started_at ON job_execution(started_at);

--- a/packages/server/src/scheduler/jobs.test.ts
+++ b/packages/server/src/scheduler/jobs.test.ts
@@ -968,7 +968,10 @@ describe('trackJobExecution', () => {
     );
 
     expect(db.createJobExecution).toHaveBeenCalledWith('test-job', 'catch-up');
-    expect(db.failJobExecution).toHaveBeenCalledWith(42, 'something broke');
+    expect(db.failJobExecution).toHaveBeenCalledWith(
+      42,
+      expect.stringContaining('something broke')
+    );
     expect(db.completeJobExecution).not.toHaveBeenCalled();
   });
 

--- a/packages/server/src/scheduler/jobs.test.ts
+++ b/packages/server/src/scheduler/jobs.test.ts
@@ -15,6 +15,7 @@ import {
   registerNarratorJobs,
   resolveDailySummaryTimestamp,
   stripSessionEntry,
+  trackJobExecution,
 } from './jobs.js';
 import type { Scheduler } from './scheduler.js';
 
@@ -631,7 +632,11 @@ describe('registerNarratorJobs (network guard)', () => {
     const dir = trackTmpDir(makeTmpDir());
     mkdirSync(join(dir, 'knowledge', 'daily_summaries'), { recursive: true });
 
-    const mockDb = { query: () => [] } as unknown as DatabaseClient;
+    const mockDb = {
+      query: () => [],
+      createJobExecution: () => ({ id: 1 }),
+      completeJobExecution: () => {},
+    } as unknown as DatabaseClient;
 
     registerNarratorJobs(scheduler as unknown as Scheduler, host, 2, mockDb, dir, 30);
 
@@ -655,7 +660,12 @@ describe('registerNarratorJobs (network guard)', () => {
     writeFileSync(join(knowledgeDir, 'memory.md'), '---\nlast_narrator_update_ts:\n---\n');
     writeFileSync(join(summariesDir, '2026-03-24.md'), '---\n---\n# Summary');
 
-    registerNarratorJobs(scheduler as unknown as Scheduler, host, 2, {} as DatabaseClient, dir, 30);
+    const mockDb = {
+      createJobExecution: () => ({ id: 1 }),
+      completeJobExecution: () => {},
+    } as unknown as DatabaseClient;
+
+    registerNarratorJobs(scheduler as unknown as Scheduler, host, 2, mockDb, dir, 30);
 
     await scheduler.handlers['memory-update']();
     expect(host.calls).toHaveLength(1);
@@ -923,5 +933,78 @@ describe('buildAndDeliverDailySummary', () => {
     expect(dailySummaryMsg).toBeDefined();
     expect(dailySummaryMsg).toContain('## Project Activity');
     expect(dailySummaryMsg).not.toContain('## Non-Project Activity');
+  });
+});
+
+describe('trackJobExecution', () => {
+  function mockDbForTracking() {
+    return {
+      createJobExecution: vi.fn(() => ({ id: 42, job_name: 'test-job', status: 'running' })),
+      completeJobExecution: vi.fn(() => ({ id: 42, status: 'completed' })),
+      failJobExecution: vi.fn(() => ({ id: 42, status: 'failed' })),
+    } as unknown as DatabaseClient;
+  }
+
+  it('creates a running record and completes it on success', async () => {
+    const db = mockDbForTracking();
+    const handler = vi.fn();
+
+    await trackJobExecution(db, 'test-job', 'cron', handler);
+
+    expect(db.createJobExecution).toHaveBeenCalledWith('test-job', 'cron');
+    expect(handler).toHaveBeenCalled();
+    expect(db.completeJobExecution).toHaveBeenCalledWith(42);
+    expect(db.failJobExecution).not.toHaveBeenCalled();
+  });
+
+  it('creates a running record and fails it on error', async () => {
+    const db = mockDbForTracking();
+    const handler = vi.fn(() => {
+      throw new Error('something broke');
+    });
+
+    await expect(trackJobExecution(db, 'test-job', 'catch-up', handler)).rejects.toThrow(
+      'something broke'
+    );
+
+    expect(db.createJobExecution).toHaveBeenCalledWith('test-job', 'catch-up');
+    expect(db.failJobExecution).toHaveBeenCalledWith(42, 'something broke');
+    expect(db.completeJobExecution).not.toHaveBeenCalled();
+  });
+
+  it('re-throws the original error after recording failure', async () => {
+    const db = mockDbForTracking();
+    const originalError = new Error('original');
+    const handler = vi.fn(() => {
+      throw originalError;
+    });
+
+    try {
+      await trackJobExecution(db, 'test-job', 'manual', handler);
+    } catch (error) {
+      expect(error).toBe(originalError);
+    }
+  });
+
+  it('handles non-Error thrown values', async () => {
+    const db = mockDbForTracking();
+    const handler = vi.fn(() => {
+      throw 'string error';
+    });
+
+    await expect(trackJobExecution(db, 'test-job', 'cron', handler)).rejects.toThrow();
+
+    expect(db.failJobExecution).toHaveBeenCalledWith(42, 'string error');
+  });
+
+  it('works with async handlers', async () => {
+    const db = mockDbForTracking();
+    const handler = vi.fn(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    });
+
+    await trackJobExecution(db, 'test-job', 'cron', handler);
+
+    expect(db.completeJobExecution).toHaveBeenCalledWith(42);
   });
 });

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -10,6 +10,7 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
+import type { JobExecution } from '@dscarabelli/shared';
 import type { AgentHost } from '../agents/host.js';
 import type { DatabaseClient } from '../db/client.js';
 import { resolveProjectDir } from '../projects/dir.js';
@@ -637,6 +638,27 @@ ${dailySummaryContent}`,
 }
 
 /**
+ * Execute a job with execution tracking: inserts a 'running' record,
+ * calls the handler, then marks it 'completed' or 'failed'.
+ */
+export async function trackJobExecution(
+  db: DatabaseClient,
+  jobName: string,
+  triggerType: JobExecution['trigger_type'],
+  handler: () => void | Promise<void>
+): Promise<void> {
+  const execution = db.createJobExecution(jobName, triggerType);
+  try {
+    await handler();
+    db.completeJobExecution(execution.id);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    db.failJobExecution(execution.id, message);
+    throw error;
+  }
+}
+
+/**
  * Register all Narrator scheduled jobs.
  */
 export function registerNarratorJobs(
@@ -656,7 +678,9 @@ export function registerNarratorJobs(
       return;
     }
     console.log('[Scheduler] Triggering daily-summary job (project logs + daily summary)');
-    buildAndDeliverDailySummary(db, narratorHost, narratorId, system2Dir, intervalMinutes);
+    await trackJobExecution(db, 'daily-summary', 'cron', () => {
+      buildAndDeliverDailySummary(db, narratorHost, narratorId, system2Dir, intervalMinutes);
+    });
   });
 
   // Memory update — daily at 11 AM
@@ -666,7 +690,9 @@ export function registerNarratorJobs(
       return;
     }
     console.log('[Scheduler] Triggering memory-update job');
-    buildAndDeliverMemoryUpdate(narratorHost, narratorId, system2Dir);
+    await trackJobExecution(db, 'memory-update', 'cron', () => {
+      buildAndDeliverMemoryUpdate(narratorHost, narratorId, system2Dir);
+    });
   });
 }
 

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -652,7 +652,7 @@ export async function trackJobExecution(
     await handler();
     db.completeJobExecution(execution.id);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
     db.failJobExecution(execution.id, message);
     throw error;
   }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -240,6 +240,14 @@ export class Server {
         const status = req.query.status as string | undefined;
         const limit = req.query.limit ? Number(req.query.limit) : undefined;
 
+        const validStatuses = ['running', 'completed', 'failed'] as const;
+        if (status && !validStatuses.includes(status as (typeof validStatuses)[number])) {
+          res
+            .status(400)
+            .json({ error: `Invalid status. Must be one of: ${validStatuses.join(', ')}` });
+          return;
+        }
+
         const executions = this.db.listJobExecutions({
           jobName: jobName || undefined,
           status: (status as 'running' | 'completed' | 'failed') || undefined,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -39,6 +39,7 @@ import {
   readFrontmatterField,
   registerNarratorJobs,
   resolveDailySummaryTimestamp,
+  trackJobExecution,
 } from './scheduler/jobs.js';
 import { isNetworkAvailable } from './scheduler/network.js';
 import { Scheduler } from './scheduler/scheduler.js';
@@ -227,6 +228,25 @@ export class Server {
         `);
         const agents = this.db.query('SELECT id, role, project FROM agent');
         res.json({ tasks, projects, agents });
+      } catch (error) {
+        res.status(500).json({ error: (error as Error).message });
+      }
+    });
+
+    // Job execution history
+    this.app.get('/api/job-executions', (req, res) => {
+      try {
+        const jobName = req.query.job_name as string | undefined;
+        const status = req.query.status as string | undefined;
+        const limit = req.query.limit ? Number(req.query.limit) : undefined;
+
+        const executions = this.db.listJobExecutions({
+          jobName: jobName || undefined,
+          status: (status as 'running' | 'completed' | 'failed') || undefined,
+          limit,
+        });
+
+        res.json({ executions });
       } catch (error) {
         res.status(500).json({ error: (error as Error).message });
       }
@@ -545,6 +565,12 @@ export class Server {
     // Restore previously active spawned agents (conductors, reviewers, etc.)
     await this.restoreActiveAgents();
 
+    // Mark any stale 'running' job executions from a previous crash as failed
+    const staleCount = this.db.failStaleJobExecutions('server shutdown');
+    if (staleCount > 0) {
+      console.log(`[Server] Recovered ${staleCount} stale job execution(s) from previous process`);
+    }
+
     // Start scheduled jobs
     const intervalMinutes = this.config.schedulerConfig?.daily_summary_interval_minutes ?? 30;
     registerNarratorJobs(
@@ -599,13 +625,19 @@ export class Server {
         console.log(
           `[Server] Daily summary stale by ${Math.round(staleness / 60000)} min, queuing catch-up`
         );
-        buildAndDeliverDailySummary(
-          this.db,
-          this.narratorHost,
-          this.narratorId,
-          SYSTEM2_DIR,
-          intervalMinutes
-        );
+        try {
+          await trackJobExecution(this.db, 'daily-summary', 'catch-up', () => {
+            buildAndDeliverDailySummary(
+              this.db,
+              this.narratorHost,
+              this.narratorId,
+              SYSTEM2_DIR,
+              intervalMinutes
+            );
+          });
+        } catch (error) {
+          console.error('[Server] Daily summary catch-up failed:', error);
+        }
       }
     }
 
@@ -620,7 +652,13 @@ export class Server {
         console.log(
           `[Server] Memory stale by ${Math.round(memoryStaleness / 3600000)}h, queuing memory-update catch-up`
         );
-        buildAndDeliverMemoryUpdate(this.narratorHost, this.narratorId, SYSTEM2_DIR);
+        try {
+          await trackJobExecution(this.db, 'memory-update', 'catch-up', () => {
+            buildAndDeliverMemoryUpdate(this.narratorHost, this.narratorId, SYSTEM2_DIR);
+          });
+        } catch (error) {
+          console.error('[Server] Memory update catch-up failed:', error);
+        }
       }
     }
   }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -238,7 +238,12 @@ export class Server {
       try {
         const jobName = req.query.job_name as string | undefined;
         const status = req.query.status as string | undefined;
-        const limit = req.query.limit ? Number(req.query.limit) : undefined;
+        const rawLimit = req.query.limit ? Number(req.query.limit) : undefined;
+        if (rawLimit !== undefined && (!Number.isFinite(rawLimit) || rawLimit < 1)) {
+          res.status(400).json({ error: 'Invalid limit. Must be a positive integer.' });
+          return;
+        }
+        const limit = rawLimit !== undefined ? Math.min(rawLimit, 500) : undefined;
 
         const validStatuses = ['running', 'completed', 'failed'] as const;
         if (status && !validStatuses.includes(status as (typeof validStatuses)[number])) {

--- a/packages/shared/src/types/database.ts
+++ b/packages/shared/src/types/database.ts
@@ -69,3 +69,15 @@ export interface Artifact {
   created_at: string;
   updated_at: string;
 }
+
+export interface JobExecution {
+  id: number;
+  job_name: string;
+  status: 'running' | 'completed' | 'failed';
+  trigger_type: 'cron' | 'catch-up' | 'manual';
+  error: string | null;
+  started_at: string;
+  ended_at: string | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/packages/ui/src/components/ExecutionHistoryPane.tsx
+++ b/packages/ui/src/components/ExecutionHistoryPane.tsx
@@ -7,7 +7,7 @@
 
 import { ChevronDownIcon, ChevronRightIcon } from '@primer/octicons-react';
 import { Box, Text } from '@primer/react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { POLL_ERROR_BACKOFF_MS, POLL_INTERVAL_MS } from '../constants';
 import { colors } from '../theme/colors';
 
@@ -236,7 +236,7 @@ export function ExecutionHistoryPane() {
                 {!isCollapsed && (
                   <Box as="tbody">
                     {items.map((exec) => (
-                      <Box key={exec.id}>
+                      <Fragment key={exec.id}>
                         <Box
                           as="tr"
                           onClick={exec.error ? () => toggleError(exec.id) : undefined}
@@ -327,7 +327,7 @@ export function ExecutionHistoryPane() {
                             </Box>
                           </Box>
                         )}
-                      </Box>
+                      </Fragment>
                     ))}
                   </Box>
                 )}

--- a/packages/ui/src/components/ExecutionHistoryPane.tsx
+++ b/packages/ui/src/components/ExecutionHistoryPane.tsx
@@ -1,0 +1,340 @@
+/**
+ * Execution History Pane
+ *
+ * Toggleable panel showing scheduler job execution history.
+ * Groups executions by job name with collapsible sections.
+ */
+
+import { ChevronDownIcon, ChevronRightIcon } from '@primer/octicons-react';
+import { Box, Text } from '@primer/react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { POLL_ERROR_BACKOFF_MS, POLL_INTERVAL_MS } from '../constants';
+import { colors } from '../theme/colors';
+
+interface JobExecutionInfo {
+  id: number;
+  job_name: string;
+  status: 'running' | 'completed' | 'failed';
+  trigger_type: 'cron' | 'catch-up' | 'manual';
+  error: string | null;
+  started_at: string;
+  ended_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const statusColor: Record<JobExecutionInfo['status'], string> = {
+  completed: colors.teal,
+  failed: colors.coral,
+  running: colors.amber,
+};
+
+function formatDuration(startedAt: string, endedAt: string | null): string {
+  if (!endedAt) return '—';
+  const ms = new Date(endedAt).getTime() - new Date(startedAt).getTime();
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  return `${minutes}m ${remaining}s`;
+}
+
+function formatTime(isoString: string): string {
+  const date = new Date(isoString);
+  const now = new Date();
+  const isToday = date.toDateString() === now.toDateString();
+  if (isToday) {
+    return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  }
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+const COLS = ['Status', 'Trigger', 'Started', 'Duration'] as const;
+
+function TableHeaders() {
+  return (
+    <Box as="tr">
+      {COLS.map((col) => (
+        <Box
+          key={col}
+          as="th"
+          sx={{
+            px: 2,
+            py: 1,
+            textAlign: col === 'Status' ? 'center' : 'left',
+            fontWeight: 'bold',
+            color: 'fg.muted',
+            borderBottom: '1px solid',
+            borderColor: 'border.default',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {col}
+        </Box>
+      ))}
+    </Box>
+  );
+}
+
+export function ExecutionHistoryPane() {
+  const [executions, setExecutions] = useState<JobExecutionInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
+  const [expandedErrors, setExpandedErrors] = useState<Set<number>>(new Set());
+  const initialized = useRef(false);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout>;
+
+    const fetchData = () => {
+      if (!initialized.current) setLoading(true);
+
+      fetch('/api/job-executions?limit=50', { signal: controller.signal })
+        .then((res) => res.json())
+        .then((data) => {
+          setExecutions(data.executions || []);
+          initialized.current = true;
+          setLoading(false);
+          timeoutId = setTimeout(fetchData, POLL_INTERVAL_MS);
+        })
+        .catch((err: unknown) => {
+          if ((err as { name?: string }).name !== 'AbortError') {
+            setLoading(false);
+            timeoutId = setTimeout(fetchData, POLL_ERROR_BACKOFF_MS);
+          }
+        });
+    };
+
+    fetchData();
+    return () => {
+      controller.abort();
+      clearTimeout(timeoutId);
+    };
+  }, []);
+
+  const toggleGroupCollapse = useCallback((group: string) => {
+    setCollapsedGroups((prev) => {
+      const next = new Set(prev);
+      if (next.has(group)) next.delete(group);
+      else next.add(group);
+      return next;
+    });
+  }, []);
+
+  const toggleError = useCallback((id: number) => {
+    setExpandedErrors((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const grouped = useMemo(() => {
+    const groups = new Map<string, JobExecutionInfo[]>();
+    for (const exec of executions) {
+      const list = groups.get(exec.job_name) || [];
+      list.push(exec);
+      groups.set(exec.job_name, list);
+    }
+    return groups;
+  }, [executions]);
+
+  return (
+    <Box
+      sx={{
+        backgroundColor: 'canvas.default',
+        display: 'flex',
+        flexDirection: 'column',
+        height: '100%',
+        minHeight: 0,
+      }}
+    >
+      <Box
+        sx={{
+          padding: 2,
+          borderBottom: '1px solid',
+          borderColor: 'border.default',
+          flexShrink: 0,
+        }}
+      >
+        <Box as="h2" sx={{ fontSize: 2, fontWeight: 'bold', margin: 0 }}>
+          Job Executions
+        </Box>
+      </Box>
+
+      <Box sx={{ flex: 1, overflow: 'auto' }}>
+        {loading && (
+          <Text sx={{ color: 'fg.muted', fontSize: 0, p: 2, display: 'block' }}>Loading...</Text>
+        )}
+
+        {!loading && executions.length === 0 && (
+          <Text sx={{ color: 'fg.muted', fontSize: 0, p: 2, display: 'block' }}>
+            No executions recorded.
+          </Text>
+        )}
+
+        {!loading &&
+          executions.length > 0 &&
+          [...grouped.entries()].map(([group, items]) => {
+            const isCollapsed = collapsedGroups.has(group);
+            return (
+              <Box
+                key={group}
+                as="table"
+                sx={{ width: '100%', borderCollapse: 'collapse', fontSize: 0, mb: 3 }}
+              >
+                <Box as="thead">
+                  <Box as="tr">
+                    <Box
+                      as="td"
+                      colSpan={4}
+                      sx={{
+                        borderBottom: '1px solid',
+                        borderColor: 'border.muted',
+                        padding: 0,
+                      }}
+                    >
+                      <Box
+                        as="button"
+                        type="button"
+                        onClick={() => toggleGroupCollapse(group)}
+                        aria-expanded={!isCollapsed}
+                        sx={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 1,
+                          width: '100%',
+                          px: 2,
+                          py: 1,
+                          background: 'none',
+                          border: 'none',
+                          cursor: 'pointer',
+                          color: 'fg.muted',
+                          '&:hover': { color: 'fg.default' },
+                        }}
+                      >
+                        {isCollapsed ? (
+                          <ChevronRightIcon size={12} />
+                        ) : (
+                          <ChevronDownIcon size={12} />
+                        )}
+                        <Text sx={{ fontWeight: 'bold' }}>{group}</Text>
+                        <Text sx={{ ml: 'auto' }}>{items.length}</Text>
+                      </Box>
+                    </Box>
+                  </Box>
+                  {!isCollapsed && <TableHeaders />}
+                </Box>
+                {!isCollapsed && (
+                  <Box as="tbody">
+                    {items.map((exec) => (
+                      <Box key={exec.id}>
+                        <Box
+                          as="tr"
+                          onClick={exec.error ? () => toggleError(exec.id) : undefined}
+                          sx={{
+                            cursor: exec.error ? 'pointer' : 'default',
+                            '&:hover': exec.error
+                              ? { backgroundColor: 'canvas.subtle' }
+                              : undefined,
+                          }}
+                        >
+                          <Box
+                            as="td"
+                            sx={{
+                              px: 2,
+                              py: 1,
+                              textAlign: 'center',
+                              borderBottom: '1px solid',
+                              borderColor: 'border.muted',
+                            }}
+                          >
+                            <Box
+                              sx={{
+                                width: 8,
+                                height: 8,
+                                borderRadius: '50%',
+                                backgroundColor: statusColor[exec.status],
+                                display: 'inline-block',
+                              }}
+                            />
+                          </Box>
+                          <Box
+                            as="td"
+                            sx={{
+                              px: 2,
+                              py: 1,
+                              borderBottom: '1px solid',
+                              borderColor: 'border.muted',
+                              whiteSpace: 'nowrap',
+                            }}
+                          >
+                            {exec.trigger_type}
+                          </Box>
+                          <Box
+                            as="td"
+                            sx={{
+                              px: 2,
+                              py: 1,
+                              borderBottom: '1px solid',
+                              borderColor: 'border.muted',
+                              whiteSpace: 'nowrap',
+                              width: '100%',
+                            }}
+                          >
+                            {formatTime(exec.started_at)}
+                          </Box>
+                          <Box
+                            as="td"
+                            sx={{
+                              px: 2,
+                              py: 1,
+                              borderBottom: '1px solid',
+                              borderColor: 'border.muted',
+                              whiteSpace: 'nowrap',
+                              fontFamily: 'mono',
+                            }}
+                          >
+                            {formatDuration(exec.started_at, exec.ended_at)}
+                          </Box>
+                        </Box>
+                        {exec.error && expandedErrors.has(exec.id) && (
+                          <Box as="tr">
+                            <Box
+                              as="td"
+                              colSpan={4}
+                              sx={{
+                                px: 2,
+                                py: 1,
+                                borderBottom: '1px solid',
+                                borderColor: 'border.muted',
+                                color: colors.coral,
+                                fontSize: 0,
+                                fontFamily: 'mono',
+                                whiteSpace: 'pre-wrap',
+                                wordBreak: 'break-all',
+                              }}
+                            >
+                              {exec.error}
+                            </Box>
+                          </Box>
+                        )}
+                      </Box>
+                    ))}
+                  </Box>
+                )}
+              </Box>
+            );
+          })}
+      </Box>
+    </Box>
+  );
+}

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -5,6 +5,7 @@
  */
 
 import {
+  HistoryIcon,
   MoonIcon,
   PeopleIcon,
   StackIcon,
@@ -21,6 +22,7 @@ import { AgentPane } from './AgentPane';
 import { ArtifactCatalog } from './ArtifactCatalog';
 import { ArtifactViewer } from './ArtifactViewer';
 import { Chat } from './Chat';
+import { ExecutionHistoryPane } from './ExecutionHistoryPane';
 
 const ACTIVITY_BAR_PX = 48;
 
@@ -65,8 +67,10 @@ export function Layout() {
   const kanbanOpen = useArtifactStore((s) => s.kanbanOpen);
   const toggleCatalog = useArtifactStore((s) => s.toggleCatalog);
   const toggleAgents = useArtifactStore((s) => s.toggleAgents);
+  const executionsOpen = useArtifactStore((s) => s.executionsOpen);
+  const toggleExecutions = useArtifactStore((s) => s.toggleExecutions);
   const toggleKanbanTab = useArtifactStore((s) => s.toggleKanbanTab);
-  const sideDrawerOpen = catalogOpen || agentsOpen;
+  const sideDrawerOpen = catalogOpen || agentsOpen || executionsOpen;
 
   const handleMouseDown = useCallback(() => {
     isDragging.current = true;
@@ -223,6 +227,32 @@ export function Layout() {
               }}
             />
           </Box>
+          <Box data-tooltip="Job executions" sx={tooltipWrapperSx}>
+            <IconButton
+              unsafeDisableTooltip
+              aria-label="Job executions"
+              icon={HistoryIcon}
+              variant="invisible"
+              size="medium"
+              onClick={toggleExecutions}
+              sx={{
+                color: executionsOpen ? 'fg.default' : 'fg.muted',
+                position: 'relative',
+                '&::before': executionsOpen
+                  ? {
+                      content: '""',
+                      position: 'absolute',
+                      left: '-8px',
+                      top: '25%',
+                      bottom: '25%',
+                      width: '2px',
+                      backgroundColor: accent,
+                      borderRadius: 1,
+                    }
+                  : {},
+              }}
+            />
+          </Box>
         </Box>
         <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 1 }}>
           <Box
@@ -269,6 +299,7 @@ export function Layout() {
         >
           {catalogOpen && <ArtifactCatalog />}
           {agentsOpen && <AgentPane />}
+          {executionsOpen && <ExecutionHistoryPane />}
         </Box>
       )}
 

--- a/packages/ui/src/stores/artifact.test.ts
+++ b/packages/ui/src/stores/artifact.test.ts
@@ -13,6 +13,7 @@ function resetStore() {
     activeTabId: null,
     catalogOpen: false,
     agentsOpen: false,
+    executionsOpen: false,
     kanbanOpen: false,
   });
 }
@@ -95,6 +96,54 @@ describe('useArtifactStore', () => {
       useArtifactStore.getState().toggleKanbanTab();
 
       expect(useArtifactStore.getState().kanbanOpen).toBe(false);
+    });
+  });
+
+  describe('toggleExecutions', () => {
+    it('opens the executions panel', () => {
+      useArtifactStore.getState().toggleExecutions();
+
+      expect(useArtifactStore.getState().executionsOpen).toBe(true);
+    });
+
+    it('closes the executions panel when already open', () => {
+      useArtifactStore.getState().toggleExecutions();
+      useArtifactStore.getState().toggleExecutions();
+
+      expect(useArtifactStore.getState().executionsOpen).toBe(false);
+    });
+
+    it('closes catalog and agents when opening executions', () => {
+      useArtifactStore.setState({ catalogOpen: true, agentsOpen: true });
+
+      useArtifactStore.getState().toggleExecutions();
+
+      const state = useArtifactStore.getState();
+      expect(state.executionsOpen).toBe(true);
+      expect(state.catalogOpen).toBe(false);
+      expect(state.agentsOpen).toBe(false);
+    });
+  });
+
+  describe('panel mutual exclusivity with executions', () => {
+    it('toggleCatalog closes executions', () => {
+      useArtifactStore.setState({ executionsOpen: true });
+
+      useArtifactStore.getState().toggleCatalog();
+
+      const state = useArtifactStore.getState();
+      expect(state.catalogOpen).toBe(true);
+      expect(state.executionsOpen).toBe(false);
+    });
+
+    it('toggleAgents closes executions', () => {
+      useArtifactStore.setState({ executionsOpen: true });
+
+      useArtifactStore.getState().toggleAgents();
+
+      const state = useArtifactStore.getState();
+      expect(state.agentsOpen).toBe(true);
+      expect(state.executionsOpen).toBe(false);
     });
   });
 

--- a/packages/ui/src/stores/artifact.ts
+++ b/packages/ui/src/stores/artifact.ts
@@ -23,6 +23,7 @@ interface ArtifactState {
   activeTabId: string | null;
   catalogOpen: boolean;
   agentsOpen: boolean;
+  executionsOpen: boolean;
   kanbanOpen: boolean;
   openArtifact: (url: string, title?: string, filePath?: string) => void;
   closeTab: (tabId: string) => void;
@@ -30,6 +31,7 @@ interface ArtifactState {
   reloadTab: (filePath: string, newUrl: string) => void;
   toggleCatalog: () => void;
   toggleAgents: () => void;
+  toggleExecutions: () => void;
   openKanbanTab: () => void;
   toggleKanbanTab: () => void;
 }
@@ -66,6 +68,7 @@ export const useArtifactStore = create<ArtifactState>()(
       activeTabId: null,
       catalogOpen: false,
       agentsOpen: false,
+      executionsOpen: false,
       kanbanOpen: false,
 
       openArtifact: (url: string, title?: string, filePath?: string) => {
@@ -130,11 +133,27 @@ export const useArtifactStore = create<ArtifactState>()(
       },
 
       toggleCatalog: () => {
-        set((state) => ({ catalogOpen: !state.catalogOpen, agentsOpen: false }));
+        set((state) => ({
+          catalogOpen: !state.catalogOpen,
+          agentsOpen: false,
+          executionsOpen: false,
+        }));
       },
 
       toggleAgents: () => {
-        set((state) => ({ agentsOpen: !state.agentsOpen, catalogOpen: false }));
+        set((state) => ({
+          agentsOpen: !state.agentsOpen,
+          catalogOpen: false,
+          executionsOpen: false,
+        }));
+      },
+
+      toggleExecutions: () => {
+        set((state) => ({
+          executionsOpen: !state.executionsOpen,
+          catalogOpen: false,
+          agentsOpen: false,
+        }));
       },
 
       openKanbanTab: () => {
@@ -164,6 +183,7 @@ export const useArtifactStore = create<ArtifactState>()(
           .map((t) => ({ ...t, url: `/api/artifact?path=${encodeURIComponent(t.filePath)}` })),
         activeTabId: state.activeTabId,
         agentsOpen: state.agentsOpen,
+        executionsOpen: state.executionsOpen,
         kanbanOpen: state.kanbanOpen,
       }),
       merge: (persistedState, currentState) => {


### PR DESCRIPTION
## Summary

Closes #64

- Add `job_execution` table to track every Narrator job run with status, trigger type, timing, and error details
- Instrument cron and catch-up handlers with `trackJobExecution` wrapper; recover stale `running` rows on startup
- Add `GET /api/job-executions` endpoint with job_name/status/limit query filters
- Add `ExecutionHistoryPane` UI component (polling, grouped by job, expandable errors) with HistoryIcon toggle in the Activity Bar

## Test plan

- [x] `pnpm check` passes (129 files, no issues)
- [x] `pnpm build` compiles all 4 packages
- [x] `pnpm test` passes (443 tests across 34 files)
- [ ] Manual: start server, wait for a scheduled job or trigger catch-up, verify `curl /api/job-executions` returns records
- [ ] Manual: click HistoryIcon in Activity Bar, verify execution list renders with status colors and duration
- [ ] Manual: verify mutual exclusivity with catalog/agents panels