### PR TITLE
fix: ISO 8601 timestamps + execution pane UI improvements

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -125,6 +125,10 @@ Scheduler job execution records.
 
 **Indices:** `idx_job_execution_job_name` on `job_name`, `idx_job_execution_status` on `status`, `idx_job_execution_started_at` on `started_at`
 
+## Timestamp Format
+
+All `DEFAULT` expressions in the schema use `strftime('%Y-%m-%dT%H:%M:%SZ', 'now')` instead of `datetime('now')` to produce proper ISO 8601 timestamps with a `Z` (UTC) suffix. `UPDATE` statements in `DatabaseClient` follow the same convention, so every `created_at` and `updated_at` value stored in the database is a valid ISO 8601 string that JavaScript's `Date` constructor parses correctly without any suffix workaround.
+
 ## DatabaseClient (`client.ts`)
 
 The `DatabaseClient` class initializes SQLite with WAL mode and a 5-second busy timeout, then applies the schema.

--- a/docs/packages/ui.md
+++ b/docs/packages/ui.md
@@ -57,7 +57,7 @@ App (ThemeProvider)
 
 ### Layout
 
-VSCode-style layout with an activity bar on the left edge (48px). The activity bar contains toggle buttons for the artifact catalog, agent pane, kanban board, and execution history (top), plus particles and theme toggles (bottom). Opening the catalog or agents panel closes the other; the kanban board toggles a native tab instead. Opening one side panel closes the other. The artifact viewer fills the center, with the chat panel on the right (20-60% resizable, default 33%). Both the side panel and chat panel have draggable resize handles.
+VSCode-style layout with an activity bar on the left edge (48px). The activity bar contains toggle buttons for the artifact catalog, agent pane, kanban board, and cron jobs (top), plus particles and theme toggles (bottom). Opening the catalog or agents panel closes the other; the kanban board toggles a native tab instead. Opening one side panel closes the other. The artifact viewer fills the center, with the chat panel on the right (20-60% resizable, default 33%). Both the side panel and chat panel have draggable resize handles.
 
 ### MessageList
 
@@ -150,7 +150,11 @@ Clicking an agent row switches the chat panel to that agent. The active agent is
 
 ### ExecutionHistoryPane
 
-Side panel showing scheduler job execution history. Polls `GET /api/job-executions` every 2 seconds. Groups executions by job name (daily-summary, memory-update) with collapsible sections. Each row shows a status dot (teal for completed, coral for failed, amber for running), trigger type, start time, and duration. Failed executions are expandable to show the error message. Toggled via HistoryIcon in the activity bar.
+Side panel titled "Cron Jobs" showing scheduler job execution history as a flat sortable table. Polls `GET /api/job-executions` every 2 seconds. Toggled via ClockIcon in the activity bar.
+
+**Filters:** Three `MultiSelectDropdown` filters at the top: jobs (e.g., daily-summary, memory-update), statuses (running, completed, failed), and triggers (cron, catch-up, manual).
+
+**Columns:** ID, Job, Status (dot indicator: teal for completed, coral for failed, amber for running), Trigger, Started, Ended. Rows for failed executions expand on click to reveal the error message.
 
 ## State Management
 

--- a/docs/packages/ui.md
+++ b/docs/packages/ui.md
@@ -154,7 +154,7 @@ Side panel titled "Cron Jobs" showing scheduler job execution history as a flat 
 
 **Filters:** Three `MultiSelectDropdown` filters at the top: jobs (e.g., daily-summary, memory-update), statuses (running, completed, failed), and triggers (cron, catch-up, manual).
 
-**Columns:** ID, Job, Status (dot indicator: teal for completed, coral for failed, amber for running), Trigger, Started, Ended. Rows for failed executions expand on click to reveal the error message.
+**Columns:** ID, Job, Status (colored text: teal for completed, coral for failed, amber for running), Trigger, Started, Ended. Rows for failed executions expand on click to reveal the error message.
 
 ## State Management
 

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -110,7 +110,7 @@ export class DatabaseClient {
 
     if (fields.length === 0) return this.getProject(id);
 
-    fields.push("updated_at = datetime('now')");
+    fields.push("updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')");
     values.push(id);
 
     const stmt = this.db.prepare(`
@@ -214,7 +214,7 @@ export class DatabaseClient {
 
     if (fields.length === 0) return this.getTask(id);
 
-    fields.push("updated_at = datetime('now')");
+    fields.push("updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')");
     values.push(id);
 
     const stmt = this.db.prepare(`
@@ -243,7 +243,7 @@ export class DatabaseClient {
     | { claimed: false; error: 'task_not_found' | 'wrong_project' | 'already_claimed' } {
     const stmt = this.db.prepare(`
       UPDATE task
-      SET status = 'in progress', assignee = ?, start_at = datetime('now'), updated_at = datetime('now')
+      SET status = 'in progress', assignee = ?, start_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
       WHERE id = ?
         AND status = 'todo'
         AND project IS (SELECT project FROM agent WHERE id = ?)
@@ -293,7 +293,7 @@ export class DatabaseClient {
   updateAgentStatus(id: number, status: Agent['status']): Agent | null {
     const stmt = this.db.prepare(`
       UPDATE agent
-      SET status = ?, updated_at = datetime('now')
+      SET status = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
       WHERE id = ?
       RETURNING *
     `);
@@ -455,7 +455,7 @@ export class DatabaseClient {
       return (stmt.get(id) as Artifact) || null;
     }
 
-    fields.push("updated_at = datetime('now')");
+    fields.push("updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')");
     values.push(id);
 
     const stmt = this.db.prepare(`
@@ -487,7 +487,7 @@ export class DatabaseClient {
   completeJobExecution(id: number): JobExecution | null {
     const stmt = this.db.prepare(`
       UPDATE job_execution
-      SET status = 'completed', ended_at = datetime('now'), updated_at = datetime('now')
+      SET status = 'completed', ended_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
       WHERE id = ?
       RETURNING *
     `);
@@ -498,7 +498,7 @@ export class DatabaseClient {
   failJobExecution(id: number, error: string): JobExecution | null {
     const stmt = this.db.prepare(`
       UPDATE job_execution
-      SET status = 'failed', ended_at = datetime('now'), updated_at = datetime('now'), error = ?
+      SET status = 'failed', ended_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), error = ?
       WHERE id = ?
       RETURNING *
     `);
@@ -509,7 +509,7 @@ export class DatabaseClient {
   failStaleJobExecutions(error: string): number {
     const stmt = this.db.prepare(`
       UPDATE job_execution
-      SET status = 'failed', ended_at = datetime('now'), updated_at = datetime('now'), error = ?
+      SET status = 'failed', ended_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), error = ?
       WHERE status = 'running'
     `);
 

--- a/packages/server/src/db/schema.sql
+++ b/packages/server/src/db/schema.sql
@@ -10,8 +10,8 @@ CREATE TABLE IF NOT EXISTS project (
   labels TEXT NOT NULL DEFAULT '[]',      -- JSON array of string labels for categorization
   start_at TEXT,                          -- ISO 8601 timestamp when work began
   end_at TEXT,                            -- ISO 8601 timestamp when work completed
-  created_at TEXT DEFAULT (datetime('now')), -- Row creation timestamp
-  updated_at TEXT DEFAULT (datetime('now'))  -- Last modification timestamp
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), -- Row creation timestamp
+  updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))  -- Last modification timestamp
 );
 
 CREATE INDEX IF NOT EXISTS idx_project_status ON project(status);
@@ -22,8 +22,8 @@ CREATE TABLE IF NOT EXISTS agent (
   role TEXT NOT NULL CHECK(role IN ('guide', 'conductor', 'narrator', 'reviewer')), -- Agent specialization (guide is system-wide)
   project INTEGER REFERENCES project(id), -- Assigned project, NULL for guide and narrator (system-wide)
   status TEXT DEFAULT 'active' CHECK(status IN ('active', 'archived')), -- Current lifecycle state
-  created_at TEXT DEFAULT (datetime('now')), -- Row creation timestamp
-  updated_at TEXT DEFAULT (datetime('now'))  -- Last modification timestamp
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), -- Row creation timestamp
+  updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))  -- Last modification timestamp
 );
 
 CREATE INDEX IF NOT EXISTS idx_agent_project ON agent(project);
@@ -44,8 +44,8 @@ CREATE TABLE IF NOT EXISTS task (
   labels TEXT NOT NULL DEFAULT '[]',      -- JSON array of string labels for categorization
   start_at TEXT,                          -- ISO 8601 timestamp when work began
   end_at TEXT,                            -- ISO 8601 timestamp when work completed
-  created_at TEXT DEFAULT (datetime('now')), -- Row creation timestamp
-  updated_at TEXT DEFAULT (datetime('now'))  -- Last modification timestamp
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), -- Row creation timestamp
+  updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))  -- Last modification timestamp
 );
 
 CREATE INDEX IF NOT EXISTS idx_task_parent ON task(parent);
@@ -59,8 +59,8 @@ CREATE TABLE IF NOT EXISTS task_link (
   source INTEGER NOT NULL REFERENCES task(id),  -- The task that has the relationship
   target INTEGER NOT NULL REFERENCES task(id),  -- The task being referenced
   relationship TEXT NOT NULL CHECK(relationship IN ('blocked_by', 'relates_to', 'duplicates')), -- Link type
-  created_at TEXT DEFAULT (datetime('now')),     -- Row creation timestamp
-  updated_at TEXT DEFAULT (datetime('now'))      -- Last modification timestamp
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),     -- Row creation timestamp
+  updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))      -- Last modification timestamp
 );
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_task_link_unique ON task_link(source, target, relationship);
@@ -72,8 +72,8 @@ CREATE TABLE IF NOT EXISTS task_comment (
   task INTEGER NOT NULL REFERENCES task(id), -- The task being commented on
   author INTEGER NOT NULL REFERENCES agent(id), -- The agent who wrote the comment
   content TEXT NOT NULL,                     -- Comment body
-  created_at TEXT DEFAULT (datetime('now')), -- Row creation timestamp
-  updated_at TEXT DEFAULT (datetime('now'))  -- Last modification timestamp
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), -- Row creation timestamp
+  updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))  -- Last modification timestamp
 );
 
 CREATE INDEX IF NOT EXISTS idx_task_comment_task ON task_comment(task);
@@ -87,8 +87,8 @@ CREATE TABLE IF NOT EXISTS artifact (
   title TEXT NOT NULL,                         -- Human-readable title
   description TEXT,                            -- Brief summary of content/purpose
   tags TEXT NOT NULL DEFAULT '[]',             -- JSON array of string tags for categorization
-  created_at TEXT DEFAULT (datetime('now')),   -- Row creation timestamp
-  updated_at TEXT DEFAULT (datetime('now'))    -- Last modification timestamp
+  created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),   -- Row creation timestamp
+  updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))    -- Last modification timestamp
 );
 
 CREATE INDEX IF NOT EXISTS idx_artifact_project ON artifact(project);
@@ -103,10 +103,10 @@ CREATE TABLE IF NOT EXISTS job_execution (
   trigger_type TEXT NOT NULL                        -- How the execution was initiated
                CHECK(trigger_type IN ('cron', 'catch-up', 'manual')),
   error        TEXT,                                -- Error message if status is 'failed'
-  started_at   TEXT NOT NULL DEFAULT (datetime('now')), -- When the execution began
+  started_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), -- When the execution began
   ended_at     TEXT,                                -- When the execution finished (NULL while running)
-  created_at   TEXT DEFAULT (datetime('now')),       -- Row creation timestamp
-  updated_at   TEXT DEFAULT (datetime('now'))        -- Last modification timestamp
+  created_at   TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),       -- Row creation timestamp
+  updated_at   TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))        -- Last modification timestamp
 );
 
 CREATE INDEX IF NOT EXISTS idx_job_execution_job_name   ON job_execution(job_name);

--- a/packages/ui/src/components/ArtifactCatalog.tsx
+++ b/packages/ui/src/components/ArtifactCatalog.tsx
@@ -195,13 +195,25 @@ export function ArtifactCatalog() {
   }, [artifacts, query, allTagsSelected, selectedTags, allProjectsSelected, selectedProjects]);
 
   // Group filtered artifacts by project
-  const grouped = new Map<string, CatalogArtifact[]>();
-  for (const a of filtered) {
-    const key = a.project_name || 'No Project';
-    const list = grouped.get(key) || [];
-    list.push(a);
-    grouped.set(key, list);
-  }
+  const grouped = useMemo(() => {
+    const groups = new Map<string, CatalogArtifact[]>();
+    for (const a of filtered) {
+      const key = a.project_name || 'No Project';
+      const list = groups.get(key) || [];
+      list.push(a);
+      groups.set(key, list);
+    }
+    return groups;
+  }, [filtered]);
+
+  // Auto-collapse all groups on first data load
+  const groupsSeeded = useRef(false);
+  useEffect(() => {
+    if (!groupsSeeded.current && grouped.size > 0) {
+      groupsSeeded.current = true;
+      setCollapsedGroups(new Set(grouped.keys()));
+    }
+  }, [grouped]);
 
   return (
     <Box

--- a/packages/ui/src/components/ExecutionHistoryPane.tsx
+++ b/packages/ui/src/components/ExecutionHistoryPane.tsx
@@ -2,14 +2,16 @@
  * Execution History Pane
  *
  * Toggleable panel showing scheduler job execution history.
- * Groups executions by job name with collapsible sections.
+ * Flat sortable table with multiselect filters for job, status, and trigger.
  */
 
-import { ChevronDownIcon, ChevronRightIcon } from '@primer/octicons-react';
+import { TriangleDownIcon, TriangleUpIcon } from '@primer/octicons-react';
 import { Box, Text } from '@primer/react';
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { POLL_ERROR_BACKOFF_MS, POLL_INTERVAL_MS } from '../constants';
 import { colors } from '../theme/colors';
+import type { MultiSelectOption } from './MultiSelectDropdown';
+import { MultiSelectDropdown } from './MultiSelectDropdown';
 
 interface JobExecutionInfo {
   id: number;
@@ -29,17 +31,6 @@ const statusColor: Record<JobExecutionInfo['status'], string> = {
   running: colors.amber,
 };
 
-function formatDuration(startedAt: string, endedAt: string | null): string {
-  if (!endedAt) return '—';
-  const ms = new Date(endedAt).getTime() - new Date(startedAt).getTime();
-  if (ms < 1000) return `${ms}ms`;
-  const seconds = Math.round(ms / 1000);
-  if (seconds < 60) return `${seconds}s`;
-  const minutes = Math.floor(seconds / 60);
-  const remaining = seconds % 60;
-  return `${minutes}m ${remaining}s`;
-}
-
 function formatTime(isoString: string): string {
   const date = new Date(isoString);
   const now = new Date();
@@ -55,27 +46,84 @@ function formatTime(isoString: string): string {
   });
 }
 
-const COLS = ['Status', 'Trigger', 'Started', 'Duration'] as const;
+type SortKey = 'id' | 'job_name' | 'status' | 'trigger_type' | 'started_at' | 'ended_at';
+type SortDir = 'asc' | 'desc';
 
-function TableHeaders() {
+function compareValues(
+  a: JobExecutionInfo,
+  b: JobExecutionInfo,
+  key: SortKey,
+  dir: SortDir
+): number {
+  let cmp = 0;
+  const av = a[key];
+  const bv = b[key];
+  if (av == null && bv == null) cmp = 0;
+  else if (av == null) cmp = 1;
+  else if (bv == null) cmp = -1;
+  else if (typeof av === 'number' && typeof bv === 'number') cmp = av - bv;
+  else cmp = String(av).localeCompare(String(bv));
+  return dir === 'asc' ? cmp : -cmp;
+}
+
+const COLS: { label: string; key: SortKey }[] = [
+  { label: 'ID', key: 'id' },
+  { label: 'Job', key: 'job_name' },
+  { label: 'Status', key: 'status' },
+  { label: 'Trigger', key: 'trigger_type' },
+  { label: 'Started', key: 'started_at' },
+  { label: 'Ended', key: 'ended_at' },
+];
+
+const STATUS_OPTIONS: MultiSelectOption[] = [
+  { value: 'completed', label: 'completed' },
+  { value: 'failed', label: 'failed' },
+  { value: 'running', label: 'running' },
+];
+
+const TRIGGER_OPTIONS: MultiSelectOption[] = [
+  { value: 'cron', label: 'cron' },
+  { value: 'catch-up', label: 'catch-up' },
+  { value: 'manual', label: 'manual' },
+];
+
+function SortIndicator({ active, dir }: { active: boolean; dir: SortDir }) {
+  if (!active) return null;
+  return dir === 'asc' ? <TriangleUpIcon size={12} /> : <TriangleDownIcon size={12} />;
+}
+
+interface TableHeadersProps {
+  sortKey: SortKey;
+  sortDir: SortDir;
+  onSort: (key: SortKey) => void;
+}
+
+function TableHeaders({ sortKey, sortDir, onSort }: TableHeadersProps) {
   return (
     <Box as="tr">
       {COLS.map((col) => (
         <Box
-          key={col}
+          key={col.key}
           as="th"
+          onClick={() => onSort(col.key)}
           sx={{
             px: 2,
             py: 1,
-            textAlign: col === 'Status' ? 'center' : 'left',
+            textAlign: 'left',
             fontWeight: 'bold',
             color: 'fg.muted',
             borderBottom: '1px solid',
             borderColor: 'border.default',
             whiteSpace: 'nowrap',
+            cursor: 'pointer',
+            userSelect: 'none',
+            '&:hover': { color: 'fg.default' },
           }}
         >
-          {col}
+          <Box sx={{ display: 'inline-flex', alignItems: 'center', gap: 1 }}>
+            {col.label}
+            <SortIndicator active={sortKey === col.key} dir={sortDir} />
+          </Box>
         </Box>
       ))}
     </Box>
@@ -85,9 +133,21 @@ function TableHeaders() {
 export function ExecutionHistoryPane() {
   const [executions, setExecutions] = useState<JobExecutionInfo[]>([]);
   const [loading, setLoading] = useState(true);
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const [expandedErrors, setExpandedErrors] = useState<Set<number>>(new Set());
+  const [sortKey, setSortKey] = useState<SortKey>('started_at');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
   const initialized = useRef(false);
+
+  // Filter state: initialized with all options on first data load
+  const [statusFilter, setStatusFilter] = useState<Set<string>>(
+    new Set(STATUS_OPTIONS.map((o) => o.value))
+  );
+  const [triggerFilter, setTriggerFilter] = useState<Set<string>>(
+    new Set(TRIGGER_OPTIONS.map((o) => o.value))
+  );
+  const [jobFilter, setJobFilter] = useState<Set<string>>(new Set());
+  const [jobOptions, setJobOptions] = useState<MultiSelectOption[]>([]);
+  const jobsSeeded = useRef(false);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -99,9 +159,20 @@ export function ExecutionHistoryPane() {
       fetch('/api/job-executions?limit=50', { signal: controller.signal })
         .then((res) => res.json())
         .then((data) => {
-          setExecutions(data.executions || []);
+          const items: JobExecutionInfo[] = data.executions || [];
+          setExecutions(items);
           initialized.current = true;
           setLoading(false);
+
+          // Seed job options on first data load
+          if (!jobsSeeded.current && items.length > 0) {
+            jobsSeeded.current = true;
+            const names = [...new Set(items.map((e) => e.job_name))].sort();
+            const opts = names.map((n) => ({ value: n, label: n }));
+            setJobOptions(opts);
+            setJobFilter(new Set(names));
+          }
+
           timeoutId = setTimeout(fetchData, POLL_INTERVAL_MS);
         })
         .catch((err: unknown) => {
@@ -119,15 +190,6 @@ export function ExecutionHistoryPane() {
     };
   }, []);
 
-  const toggleGroupCollapse = useCallback((group: string) => {
-    setCollapsedGroups((prev) => {
-      const next = new Set(prev);
-      if (next.has(group)) next.delete(group);
-      else next.add(group);
-      return next;
-    });
-  }, []);
-
   const toggleError = useCallback((id: number) => {
     setExpandedErrors((prev) => {
       const next = new Set(prev);
@@ -137,15 +199,28 @@ export function ExecutionHistoryPane() {
     });
   }, []);
 
-  const grouped = useMemo(() => {
-    const groups = new Map<string, JobExecutionInfo[]>();
-    for (const exec of executions) {
-      const list = groups.get(exec.job_name) || [];
-      list.push(exec);
-      groups.set(exec.job_name, list);
-    }
-    return groups;
-  }, [executions]);
+  const handleSort = useCallback(
+    (key: SortKey) => {
+      if (key === sortKey) {
+        setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+      } else {
+        setSortKey(key);
+        setSortDir('desc');
+      }
+    },
+    [sortKey]
+  );
+
+  const filtered = useMemo(() => {
+    return executions
+      .filter(
+        (e) =>
+          jobFilter.has(e.job_name) &&
+          statusFilter.has(e.status) &&
+          triggerFilter.has(e.trigger_type)
+      )
+      .sort((a, b) => compareValues(a, b, sortKey, sortDir));
+  }, [executions, jobFilter, statusFilter, triggerFilter, sortKey, sortDir]);
 
   return (
     <Box
@@ -163,11 +238,36 @@ export function ExecutionHistoryPane() {
           borderBottom: '1px solid',
           borderColor: 'border.default',
           flexShrink: 0,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2,
         }}
       >
         <Box as="h2" sx={{ fontSize: 2, fontWeight: 'bold', margin: 0 }}>
-          Job Executions
+          Cron Jobs
         </Box>
+        {executions.length > 0 && (
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+            <MultiSelectDropdown
+              label="jobs"
+              options={jobOptions}
+              selected={jobFilter}
+              onChange={setJobFilter}
+            />
+            <MultiSelectDropdown
+              label="statuses"
+              options={STATUS_OPTIONS}
+              selected={statusFilter}
+              onChange={setStatusFilter}
+            />
+            <MultiSelectDropdown
+              label="triggers"
+              options={TRIGGER_OPTIONS}
+              selected={triggerFilter}
+              onChange={setTriggerFilter}
+            />
+          </Box>
+        )}
       </Box>
 
       <Box sx={{ flex: 1, overflow: 'auto' }}>
@@ -181,159 +281,124 @@ export function ExecutionHistoryPane() {
           </Text>
         )}
 
-        {!loading &&
-          executions.length > 0 &&
-          [...grouped.entries()].map(([group, items]) => {
-            const isCollapsed = collapsedGroups.has(group);
-            return (
-              <Box
-                key={group}
-                as="table"
-                sx={{ width: '100%', borderCollapse: 'collapse', fontSize: 0, mb: 3 }}
-              >
-                <Box as="thead">
-                  <Box as="tr">
+        {!loading && filtered.length > 0 && (
+          <Box as="table" sx={{ width: '100%', borderCollapse: 'collapse', fontSize: 0 }}>
+            <Box as="thead">
+              <TableHeaders sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
+            </Box>
+            <Box as="tbody">
+              {filtered.map((exec) => (
+                <Fragment key={exec.id}>
+                  <Box
+                    as="tr"
+                    onClick={exec.error ? () => toggleError(exec.id) : undefined}
+                    sx={{
+                      cursor: exec.error ? 'pointer' : 'default',
+                      '&:hover': exec.error ? { backgroundColor: 'canvas.subtle' } : undefined,
+                    }}
+                  >
                     <Box
                       as="td"
-                      colSpan={4}
                       sx={{
+                        px: 2,
+                        py: 1,
                         borderBottom: '1px solid',
                         borderColor: 'border.muted',
-                        padding: 0,
+                        whiteSpace: 'nowrap',
+                        fontFamily: 'mono',
+                        color: 'fg.muted',
                       }}
                     >
-                      <Box
-                        as="button"
-                        type="button"
-                        onClick={() => toggleGroupCollapse(group)}
-                        aria-expanded={!isCollapsed}
-                        sx={{
-                          display: 'flex',
-                          alignItems: 'center',
-                          gap: 1,
-                          width: '100%',
-                          px: 2,
-                          py: 1,
-                          background: 'none',
-                          border: 'none',
-                          cursor: 'pointer',
-                          color: 'fg.muted',
-                          '&:hover': { color: 'fg.default' },
-                        }}
-                      >
-                        {isCollapsed ? (
-                          <ChevronRightIcon size={12} />
-                        ) : (
-                          <ChevronDownIcon size={12} />
-                        )}
-                        <Text sx={{ fontWeight: 'bold' }}>{group}</Text>
-                        <Text sx={{ ml: 'auto' }}>{items.length}</Text>
-                      </Box>
+                      {exec.id}
+                    </Box>
+                    <Box
+                      as="td"
+                      sx={{
+                        px: 2,
+                        py: 1,
+                        borderBottom: '1px solid',
+                        borderColor: 'border.muted',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {exec.job_name}
+                    </Box>
+                    <Box
+                      as="td"
+                      sx={{
+                        px: 2,
+                        py: 1,
+                        borderBottom: '1px solid',
+                        borderColor: 'border.muted',
+                        whiteSpace: 'nowrap',
+                        color: statusColor[exec.status],
+                      }}
+                    >
+                      {exec.status}
+                    </Box>
+                    <Box
+                      as="td"
+                      sx={{
+                        px: 2,
+                        py: 1,
+                        borderBottom: '1px solid',
+                        borderColor: 'border.muted',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {exec.trigger_type}
+                    </Box>
+                    <Box
+                      as="td"
+                      sx={{
+                        px: 2,
+                        py: 1,
+                        borderBottom: '1px solid',
+                        borderColor: 'border.muted',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {formatTime(exec.started_at)}
+                    </Box>
+                    <Box
+                      as="td"
+                      sx={{
+                        px: 2,
+                        py: 1,
+                        borderBottom: '1px solid',
+                        borderColor: 'border.muted',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {exec.ended_at ? formatTime(exec.ended_at) : '—'}
                     </Box>
                   </Box>
-                  {!isCollapsed && <TableHeaders />}
-                </Box>
-                {!isCollapsed && (
-                  <Box as="tbody">
-                    {items.map((exec) => (
-                      <Fragment key={exec.id}>
-                        <Box
-                          as="tr"
-                          onClick={exec.error ? () => toggleError(exec.id) : undefined}
-                          sx={{
-                            cursor: exec.error ? 'pointer' : 'default',
-                            '&:hover': exec.error
-                              ? { backgroundColor: 'canvas.subtle' }
-                              : undefined,
-                          }}
-                        >
-                          <Box
-                            as="td"
-                            sx={{
-                              px: 2,
-                              py: 1,
-                              textAlign: 'center',
-                              borderBottom: '1px solid',
-                              borderColor: 'border.muted',
-                            }}
-                          >
-                            <Box
-                              sx={{
-                                width: 8,
-                                height: 8,
-                                borderRadius: '50%',
-                                backgroundColor: statusColor[exec.status],
-                                display: 'inline-block',
-                              }}
-                            />
-                          </Box>
-                          <Box
-                            as="td"
-                            sx={{
-                              px: 2,
-                              py: 1,
-                              borderBottom: '1px solid',
-                              borderColor: 'border.muted',
-                              whiteSpace: 'nowrap',
-                            }}
-                          >
-                            {exec.trigger_type}
-                          </Box>
-                          <Box
-                            as="td"
-                            sx={{
-                              px: 2,
-                              py: 1,
-                              borderBottom: '1px solid',
-                              borderColor: 'border.muted',
-                              whiteSpace: 'nowrap',
-                              width: '100%',
-                            }}
-                          >
-                            {formatTime(exec.started_at)}
-                          </Box>
-                          <Box
-                            as="td"
-                            sx={{
-                              px: 2,
-                              py: 1,
-                              borderBottom: '1px solid',
-                              borderColor: 'border.muted',
-                              whiteSpace: 'nowrap',
-                              fontFamily: 'mono',
-                            }}
-                          >
-                            {formatDuration(exec.started_at, exec.ended_at)}
-                          </Box>
-                        </Box>
-                        {exec.error && expandedErrors.has(exec.id) && (
-                          <Box as="tr">
-                            <Box
-                              as="td"
-                              colSpan={4}
-                              sx={{
-                                px: 2,
-                                py: 1,
-                                borderBottom: '1px solid',
-                                borderColor: 'border.muted',
-                                color: colors.coral,
-                                fontSize: 0,
-                                fontFamily: 'mono',
-                                whiteSpace: 'pre-wrap',
-                                wordBreak: 'break-all',
-                              }}
-                            >
-                              {exec.error}
-                            </Box>
-                          </Box>
-                        )}
-                      </Fragment>
-                    ))}
-                  </Box>
-                )}
-              </Box>
-            );
-          })}
+                  {exec.error && expandedErrors.has(exec.id) && (
+                    <Box as="tr">
+                      <Box
+                        as="td"
+                        colSpan={6}
+                        sx={{
+                          px: 2,
+                          py: 1,
+                          borderBottom: '1px solid',
+                          borderColor: 'border.muted',
+                          color: colors.coral,
+                          fontSize: 0,
+                          fontFamily: 'mono',
+                          whiteSpace: 'pre-wrap',
+                          wordBreak: 'break-all',
+                        }}
+                      >
+                        {exec.error}
+                      </Box>
+                    </Box>
+                  )}
+                </Fragment>
+              ))}
+            </Box>
+          </Box>
+        )}
       </Box>
     </Box>
   );

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -5,7 +5,7 @@
  */
 
 import {
-  HistoryIcon,
+  ClockIcon,
   MoonIcon,
   PeopleIcon,
   StackIcon,
@@ -227,11 +227,11 @@ export function Layout() {
               }}
             />
           </Box>
-          <Box data-tooltip="Job executions" sx={tooltipWrapperSx}>
+          <Box data-tooltip="Cron jobs" sx={tooltipWrapperSx}>
             <IconButton
               unsafeDisableTooltip
-              aria-label="Job executions"
-              icon={HistoryIcon}
+              aria-label="Cron jobs"
+              icon={ClockIcon}
               variant="invisible"
               size="medium"
               onClick={toggleExecutions}

--- a/packages/ui/src/components/ProjectDetailModal.tsx
+++ b/packages/ui/src/components/ProjectDetailModal.tsx
@@ -36,7 +36,7 @@ function statusColor(status: string, accent: string, highlight: string): string 
 function formatDate(iso: string | null): string {
   if (!iso) return '';
   try {
-    return new Date(`${iso}Z`).toLocaleString(undefined, {
+    return new Date(iso).toLocaleString(undefined, {
       year: 'numeric',
       month: 'short',
       day: 'numeric',

--- a/packages/ui/src/components/TaskDetailModal.tsx
+++ b/packages/ui/src/components/TaskDetailModal.tsx
@@ -71,7 +71,7 @@ const RELATIONSHIP_LABELS: Record<string, string> = {
 function formatDate(iso: string | null): string {
   if (!iso) return '';
   try {
-    return new Date(`${iso}Z`).toLocaleString(undefined, {
+    return new Date(iso).toLocaleString(undefined, {
       year: 'numeric',
       month: 'short',
       day: 'numeric',


### PR DESCRIPTION
## Summary

- Replace all `datetime('now')` with `strftime('%Y-%m-%dT%H:%M:%SZ', 'now')` in schema defaults and UPDATE statements so timestamps are valid ISO 8601 with Z suffix (fixes UTC display bug)
- Redesign ExecutionHistoryPane: flat sortable table with MultiSelectDropdown filters (jobs, statuses, triggers) instead of grouped-by-job view
- Change activity bar icon to ClockIcon, rename panel to "Cron Jobs"
- Auto-collapse artifact catalog groups on first load

Closes #69

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] 443 tests pass
- [ ] Verify timestamps display in local time in TaskDetailModal and ProjectDetailModal
- [ ] Verify execution pane filters work correctly
- [ ] Verify sort columns toggle asc/desc
- [ ] Verify error rows expand on click