### PR TITLE
feat(ui): sort indicators + job execution detail modal

### DIFF
--- a/docs/packages/ui.md
+++ b/docs/packages/ui.md
@@ -21,7 +21,7 @@ src/
 │   ├── ArtifactViewer.tsx    # Tabbed artifact display (iframe + native tabs)
 │   ├── AgentPane.tsx          # Active agent list with busy indicators
 │   ├── ArtifactCatalog.tsx  # Browsable overlay of all registered artifacts
-│   ├── ExecutionHistoryPane.tsx  # Scheduler job execution history panel
+│   ├── CronJobsPane.tsx       # Scheduler job execution history panel
 │   ├── KanbanBoard.tsx    # Live kanban dashboard (swimlane layout, native tab)
 │   ├── TaskDetailModal.tsx # Task detail overlay (comments, links, markdown)
 │   ├── ProjectDetailModal.tsx # Project detail overlay (status, labels, dates)
@@ -148,7 +148,7 @@ Side panel showing all non-archived agents with busy/idle indicators. Polls `GET
 
 Clicking an agent row switches the chat panel to that agent. The active agent is highlighted with an accent-colored left border on its ID cell. Switching updates `activeAgentId` in the chat store, which triggers the WebSocket hook to send `switch_agent` to the server. The server responds with the agent's chat history and streaming state.
 
-### ExecutionHistoryPane
+### CronJobsPane
 
 Side panel titled "Cron Jobs" showing scheduler job execution history as a flat sortable table. Polls `GET /api/job-executions` every 2 seconds. Toggled via ClockIcon in the activity bar.
 
@@ -201,7 +201,7 @@ Tab-based artifact state persisted via the Zustand `persist` middleware (key: `s
 | `catalogOpen` | `boolean` | Whether the catalog panel is visible (not persisted) |
 | `agentsOpen` | `boolean` | Whether the agents panel is visible (persisted) |
 | `kanbanOpen` | `boolean` | Whether the kanban board tab is open (persisted) |
-| `executionsOpen` | `boolean` | Whether the execution history panel is visible (persisted) |
+| `cronJobsOpen` | `boolean` | Whether the cron jobs panel is visible (persisted) |
 
 Key behaviors:
 

--- a/packages/ui/src/components/CronJobsPane.tsx
+++ b/packages/ui/src/components/CronJobsPane.tsx
@@ -1,5 +1,5 @@
 /**
- * Execution History Pane
+ * Cron Jobs Pane
  *
  * Toggleable panel showing scheduler job execution history.
  * Flat sortable table with multiselect filters for job, status, and trigger.
@@ -137,7 +137,7 @@ function TableHeaders({ sortKey, sortDir, onSort }: TableHeadersProps) {
   );
 }
 
-export function ExecutionHistoryPane() {
+export function CronJobsPane() {
   const [executions, setExecutions] = useState<JobExecutionInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedId, setSelectedId] = useState<number | null>(null);

--- a/packages/ui/src/components/CronJobsPane.tsx
+++ b/packages/ui/src/components/CronJobsPane.tsx
@@ -291,7 +291,6 @@ export function CronJobsPane() {
                 <Box
                   key={exec.id}
                   as="tr"
-                  role="button"
                   tabIndex={0}
                   onClick={() => setSelectedId(exec.id)}
                   onKeyDown={(e: React.KeyboardEvent) => {

--- a/packages/ui/src/components/ExecutionHistoryPane.tsx
+++ b/packages/ui/src/components/ExecutionHistoryPane.tsx
@@ -8,6 +8,7 @@
 import { TriangleDownIcon, TriangleUpIcon } from '@primer/octicons-react';
 import { Box, Text } from '@primer/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
 import { POLL_ERROR_BACKOFF_MS, POLL_INTERVAL_MS } from '../constants';
 import { colors } from '../theme/colors';
 import { JobExecutionDetailModal } from './JobExecutionDetailModal';
@@ -26,7 +27,7 @@ export interface JobExecutionInfo {
   updated_at: string;
 }
 
-export const statusColor: Record<JobExecutionInfo['status'], string> = {
+const statusColor: Record<JobExecutionInfo['status'], string> = {
   completed: colors.teal,
   failed: colors.coral,
   running: colors.amber,
@@ -195,6 +196,8 @@ export function ExecutionHistoryPane() {
       clearTimeout(timeoutId);
     };
   }, []);
+
+  const closeModal = useCallback(() => setSelectedId(null), []);
 
   const handleSort = useCallback(
     (key: SortKey) => {
@@ -379,9 +382,7 @@ export function ExecutionHistoryPane() {
       {selectedId != null &&
         (() => {
           const exec = executions.find((e) => e.id === selectedId);
-          return exec ? (
-            <JobExecutionDetailModal execution={exec} onClose={() => setSelectedId(null)} />
-          ) : null;
+          return exec ? <JobExecutionDetailModal execution={exec} onClose={closeModal} /> : null;
         })()}
     </Box>
   );

--- a/packages/ui/src/components/ExecutionHistoryPane.tsx
+++ b/packages/ui/src/components/ExecutionHistoryPane.tsx
@@ -14,7 +14,7 @@ import { JobExecutionDetailModal } from './JobExecutionDetailModal';
 import type { MultiSelectOption } from './MultiSelectDropdown';
 import { MultiSelectDropdown } from './MultiSelectDropdown';
 
-interface JobExecutionInfo {
+export interface JobExecutionInfo {
   id: number;
   job_name: string;
   status: 'running' | 'completed' | 'failed';
@@ -26,7 +26,7 @@ interface JobExecutionInfo {
   updated_at: string;
 }
 
-const statusColor: Record<JobExecutionInfo['status'], string> = {
+export const statusColor: Record<JobExecutionInfo['status'], string> = {
   completed: colors.teal,
   failed: colors.coral,
   running: colors.amber,
@@ -139,7 +139,7 @@ function TableHeaders({ sortKey, sortDir, onSort }: TableHeadersProps) {
 export function ExecutionHistoryPane() {
   const [executions, setExecutions] = useState<JobExecutionInfo[]>([]);
   const [loading, setLoading] = useState(true);
-  const [selectedExecution, setSelectedExecution] = useState<JobExecutionInfo | null>(null);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
   const [sortKey, setSortKey] = useState<SortKey>('started_at');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const initialized = useRef(false);
@@ -288,7 +288,7 @@ export function ExecutionHistoryPane() {
                 <Box
                   key={exec.id}
                   as="tr"
-                  onClick={() => setSelectedExecution(exec)}
+                  onClick={() => setSelectedId(exec.id)}
                   sx={{
                     cursor: 'pointer',
                     '&:hover': { backgroundColor: 'canvas.subtle' },
@@ -376,12 +376,13 @@ export function ExecutionHistoryPane() {
         )}
       </Box>
 
-      {selectedExecution && (
-        <JobExecutionDetailModal
-          execution={selectedExecution}
-          onClose={() => setSelectedExecution(null)}
-        />
-      )}
+      {selectedId != null &&
+        (() => {
+          const exec = executions.find((e) => e.id === selectedId);
+          return exec ? (
+            <JobExecutionDetailModal execution={exec} onClose={() => setSelectedId(null)} />
+          ) : null;
+        })()}
     </Box>
   );
 }

--- a/packages/ui/src/components/ExecutionHistoryPane.tsx
+++ b/packages/ui/src/components/ExecutionHistoryPane.tsx
@@ -7,9 +7,10 @@
 
 import { TriangleDownIcon, TriangleUpIcon } from '@primer/octicons-react';
 import { Box, Text } from '@primer/react';
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { POLL_ERROR_BACKOFF_MS, POLL_INTERVAL_MS } from '../constants';
 import { colors } from '../theme/colors';
+import { JobExecutionDetailModal } from './JobExecutionDetailModal';
 import type { MultiSelectOption } from './MultiSelectDropdown';
 import { MultiSelectDropdown } from './MultiSelectDropdown';
 
@@ -88,8 +89,13 @@ const TRIGGER_OPTIONS: MultiSelectOption[] = [
 ];
 
 function SortIndicator({ active, dir }: { active: boolean; dir: SortDir }) {
-  if (!active) return null;
-  return dir === 'asc' ? <TriangleUpIcon size={12} /> : <TriangleDownIcon size={12} />;
+  const icon =
+    active && dir === 'asc' ? <TriangleUpIcon size={12} /> : <TriangleDownIcon size={12} />;
+  return (
+    <Box as="span" sx={{ opacity: active ? 1 : 0.3 }}>
+      {icon}
+    </Box>
+  );
 }
 
 interface TableHeadersProps {
@@ -133,7 +139,7 @@ function TableHeaders({ sortKey, sortDir, onSort }: TableHeadersProps) {
 export function ExecutionHistoryPane() {
   const [executions, setExecutions] = useState<JobExecutionInfo[]>([]);
   const [loading, setLoading] = useState(true);
-  const [expandedErrors, setExpandedErrors] = useState<Set<number>>(new Set());
+  const [selectedExecution, setSelectedExecution] = useState<JobExecutionInfo | null>(null);
   const [sortKey, setSortKey] = useState<SortKey>('started_at');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const initialized = useRef(false);
@@ -188,15 +194,6 @@ export function ExecutionHistoryPane() {
       controller.abort();
       clearTimeout(timeoutId);
     };
-  }, []);
-
-  const toggleError = useCallback((id: number) => {
-    setExpandedErrors((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
   }, []);
 
   const handleSort = useCallback(
@@ -288,118 +285,103 @@ export function ExecutionHistoryPane() {
             </Box>
             <Box as="tbody">
               {filtered.map((exec) => (
-                <Fragment key={exec.id}>
+                <Box
+                  key={exec.id}
+                  as="tr"
+                  onClick={() => setSelectedExecution(exec)}
+                  sx={{
+                    cursor: 'pointer',
+                    '&:hover': { backgroundColor: 'canvas.subtle' },
+                  }}
+                >
                   <Box
-                    as="tr"
-                    onClick={exec.error ? () => toggleError(exec.id) : undefined}
+                    as="td"
                     sx={{
-                      cursor: exec.error ? 'pointer' : 'default',
-                      '&:hover': exec.error ? { backgroundColor: 'canvas.subtle' } : undefined,
+                      px: 2,
+                      py: 1,
+                      borderBottom: '1px solid',
+                      borderColor: 'border.muted',
+                      whiteSpace: 'nowrap',
+                      fontFamily: 'mono',
+                      color: 'fg.muted',
                     }}
                   >
-                    <Box
-                      as="td"
-                      sx={{
-                        px: 2,
-                        py: 1,
-                        borderBottom: '1px solid',
-                        borderColor: 'border.muted',
-                        whiteSpace: 'nowrap',
-                        fontFamily: 'mono',
-                        color: 'fg.muted',
-                      }}
-                    >
-                      {exec.id}
-                    </Box>
-                    <Box
-                      as="td"
-                      sx={{
-                        px: 2,
-                        py: 1,
-                        borderBottom: '1px solid',
-                        borderColor: 'border.muted',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {exec.job_name}
-                    </Box>
-                    <Box
-                      as="td"
-                      sx={{
-                        px: 2,
-                        py: 1,
-                        borderBottom: '1px solid',
-                        borderColor: 'border.muted',
-                        whiteSpace: 'nowrap',
-                        color: statusColor[exec.status],
-                      }}
-                    >
-                      {exec.status}
-                    </Box>
-                    <Box
-                      as="td"
-                      sx={{
-                        px: 2,
-                        py: 1,
-                        borderBottom: '1px solid',
-                        borderColor: 'border.muted',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {exec.trigger_type}
-                    </Box>
-                    <Box
-                      as="td"
-                      sx={{
-                        px: 2,
-                        py: 1,
-                        borderBottom: '1px solid',
-                        borderColor: 'border.muted',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {formatTime(exec.started_at)}
-                    </Box>
-                    <Box
-                      as="td"
-                      sx={{
-                        px: 2,
-                        py: 1,
-                        borderBottom: '1px solid',
-                        borderColor: 'border.muted',
-                        whiteSpace: 'nowrap',
-                      }}
-                    >
-                      {exec.ended_at ? formatTime(exec.ended_at) : '—'}
-                    </Box>
+                    {exec.id}
                   </Box>
-                  {exec.error && expandedErrors.has(exec.id) && (
-                    <Box as="tr">
-                      <Box
-                        as="td"
-                        colSpan={6}
-                        sx={{
-                          px: 2,
-                          py: 1,
-                          borderBottom: '1px solid',
-                          borderColor: 'border.muted',
-                          color: colors.coral,
-                          fontSize: 0,
-                          fontFamily: 'mono',
-                          whiteSpace: 'pre-wrap',
-                          wordBreak: 'break-all',
-                        }}
-                      >
-                        {exec.error}
-                      </Box>
-                    </Box>
-                  )}
-                </Fragment>
+                  <Box
+                    as="td"
+                    sx={{
+                      px: 2,
+                      py: 1,
+                      borderBottom: '1px solid',
+                      borderColor: 'border.muted',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {exec.job_name}
+                  </Box>
+                  <Box
+                    as="td"
+                    sx={{
+                      px: 2,
+                      py: 1,
+                      borderBottom: '1px solid',
+                      borderColor: 'border.muted',
+                      whiteSpace: 'nowrap',
+                      color: statusColor[exec.status],
+                    }}
+                  >
+                    {exec.status}
+                  </Box>
+                  <Box
+                    as="td"
+                    sx={{
+                      px: 2,
+                      py: 1,
+                      borderBottom: '1px solid',
+                      borderColor: 'border.muted',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {exec.trigger_type}
+                  </Box>
+                  <Box
+                    as="td"
+                    sx={{
+                      px: 2,
+                      py: 1,
+                      borderBottom: '1px solid',
+                      borderColor: 'border.muted',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {formatTime(exec.started_at)}
+                  </Box>
+                  <Box
+                    as="td"
+                    sx={{
+                      px: 2,
+                      py: 1,
+                      borderBottom: '1px solid',
+                      borderColor: 'border.muted',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {exec.ended_at ? formatTime(exec.ended_at) : '—'}
+                  </Box>
+                </Box>
               ))}
             </Box>
           </Box>
         )}
       </Box>
+
+      {selectedExecution && (
+        <JobExecutionDetailModal
+          execution={selectedExecution}
+          onClose={() => setSelectedExecution(null)}
+        />
+      )}
     </Box>
   );
 }

--- a/packages/ui/src/components/ExecutionHistoryPane.tsx
+++ b/packages/ui/src/components/ExecutionHistoryPane.tsx
@@ -291,10 +291,19 @@ export function ExecutionHistoryPane() {
                 <Box
                   key={exec.id}
                   as="tr"
+                  role="button"
+                  tabIndex={0}
                   onClick={() => setSelectedId(exec.id)}
+                  onKeyDown={(e: React.KeyboardEvent) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.preventDefault();
+                      setSelectedId(exec.id);
+                    }
+                  }}
                   sx={{
                     cursor: 'pointer',
                     '&:hover': { backgroundColor: 'canvas.subtle' },
+                    '&:focus-visible': { outline: '2px solid', outlineColor: 'accent.fg' },
                   }}
                 >
                   <Box

--- a/packages/ui/src/components/JobExecutionDetailModal.tsx
+++ b/packages/ui/src/components/JobExecutionDetailModal.tsx
@@ -10,7 +10,12 @@ import { Box, IconButton, Text } from '@primer/react';
 import { useEffect, useRef } from 'react';
 import { colors } from '../theme/colors';
 import type { JobExecutionInfo } from './ExecutionHistoryPane';
-import { statusColor } from './ExecutionHistoryPane';
+
+const statusColor: Record<JobExecutionInfo['status'], string> = {
+  completed: colors.teal,
+  failed: colors.coral,
+  running: colors.amber,
+};
 
 function formatDate(iso: string | null): string {
   if (!iso) return '';

--- a/packages/ui/src/components/JobExecutionDetailModal.tsx
+++ b/packages/ui/src/components/JobExecutionDetailModal.tsx
@@ -9,24 +9,8 @@ import { XIcon } from '@primer/octicons-react';
 import { Box, IconButton, Text } from '@primer/react';
 import { useEffect, useRef } from 'react';
 import { colors } from '../theme/colors';
-
-interface JobExecutionInfo {
-  id: number;
-  job_name: string;
-  status: 'running' | 'completed' | 'failed';
-  trigger_type: 'cron' | 'catch-up' | 'manual';
-  error: string | null;
-  started_at: string;
-  ended_at: string | null;
-  created_at: string;
-  updated_at: string;
-}
-
-const statusColor: Record<JobExecutionInfo['status'], string> = {
-  completed: colors.teal,
-  failed: colors.coral,
-  running: colors.amber,
-};
+import type { JobExecutionInfo } from './ExecutionHistoryPane';
+import { statusColor } from './ExecutionHistoryPane';
 
 function formatDate(iso: string | null): string {
   if (!iso) return '';

--- a/packages/ui/src/components/JobExecutionDetailModal.tsx
+++ b/packages/ui/src/components/JobExecutionDetailModal.tsx
@@ -2,14 +2,14 @@
  * JobExecutionDetailModal Component
  *
  * Overlay modal showing full job execution details.
- * Opened from the ExecutionHistoryPane when a row is clicked.
+ * Opened from the CronJobsPane when a row is clicked.
  */
 
 import { XIcon } from '@primer/octicons-react';
 import { Box, IconButton, Text } from '@primer/react';
 import { useEffect, useRef } from 'react';
 import { colors } from '../theme/colors';
-import type { JobExecutionInfo } from './ExecutionHistoryPane';
+import type { JobExecutionInfo } from './CronJobsPane';
 
 const statusColor: Record<JobExecutionInfo['status'], string> = {
   completed: colors.teal,

--- a/packages/ui/src/components/JobExecutionDetailModal.tsx
+++ b/packages/ui/src/components/JobExecutionDetailModal.tsx
@@ -37,7 +37,7 @@ function formatDuration(startedAt: string, endedAt: string | null): string {
   if (!endedAt) return '—';
   const ms = new Date(endedAt).getTime() - new Date(startedAt).getTime();
   if (ms < 1000) return `${ms}ms`;
-  const seconds = Math.round(ms / 1000);
+  const seconds = Math.floor(ms / 1000);
   if (seconds < 60) return `${seconds}s`;
   const minutes = Math.floor(seconds / 60);
   const remaining = seconds % 60;

--- a/packages/ui/src/components/JobExecutionDetailModal.tsx
+++ b/packages/ui/src/components/JobExecutionDetailModal.tsx
@@ -1,0 +1,251 @@
+/**
+ * JobExecutionDetailModal Component
+ *
+ * Overlay modal showing full job execution details.
+ * Opened from the ExecutionHistoryPane when a row is clicked.
+ */
+
+import { XIcon } from '@primer/octicons-react';
+import { Box, IconButton, Text } from '@primer/react';
+import { useEffect, useRef } from 'react';
+import { colors } from '../theme/colors';
+
+interface JobExecutionInfo {
+  id: number;
+  job_name: string;
+  status: 'running' | 'completed' | 'failed';
+  trigger_type: 'cron' | 'catch-up' | 'manual';
+  error: string | null;
+  started_at: string;
+  ended_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const statusColor: Record<JobExecutionInfo['status'], string> = {
+  completed: colors.teal,
+  failed: colors.coral,
+  running: colors.amber,
+};
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
+
+function formatDuration(startedAt: string, endedAt: string | null): string {
+  if (!endedAt) return '—';
+  const ms = new Date(endedAt).getTime() - new Date(startedAt).getTime();
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  return `${minutes}m ${remaining}s`;
+}
+
+function StatusBadge({ status }: { status: JobExecutionInfo['status'] }) {
+  const bg = statusColor[status];
+  return (
+    <Box
+      sx={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        px: '8px',
+        py: '2px',
+        borderRadius: 10,
+        backgroundColor: `${bg}22`,
+        border: `1px solid ${bg}44`,
+        fontSize: '11px',
+        color: bg,
+        fontWeight: 'semibold',
+        lineHeight: 1.6,
+      }}
+    >
+      {status}
+    </Box>
+  );
+}
+
+export function JobExecutionDetailModal({
+  execution,
+  onClose,
+}: {
+  execution: JobExecutionInfo;
+  onClose: () => void;
+}) {
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+      onClose();
+    }
+  };
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  return (
+    <Box
+      onClick={handleBackdropClick}
+      sx={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 200,
+        backgroundColor: 'rgba(0,0,0,0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        px: 3,
+      }}
+    >
+      <Box
+        ref={panelRef}
+        sx={{
+          width: '100%',
+          maxWidth: 700,
+          maxHeight: '85vh',
+          overflow: 'auto',
+          backgroundColor: 'canvas.default',
+          border: '1px solid',
+          borderColor: 'border.default',
+          borderRadius: 2,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {/* Header */}
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            justifyContent: 'space-between',
+            gap: 2,
+            px: 4,
+            pt: 4,
+            pb: 3,
+            borderBottom: '1px solid',
+            borderColor: 'border.muted',
+            flexShrink: 0,
+          }}
+        >
+          <Box sx={{ flex: 1 }}>
+            <Text sx={{ fontWeight: 'bold', fontSize: 3, color: 'fg.default', lineHeight: 1.3 }}>
+              <Text as="span" sx={{ color: 'fg.muted' }}>
+                #{execution.id}
+              </Text>{' '}
+              {execution.job_name}
+            </Text>
+          </Box>
+          <IconButton
+            aria-label="Close"
+            icon={XIcon}
+            variant="invisible"
+            size="small"
+            onClick={onClose}
+            sx={{ color: 'fg.muted', flexShrink: 0 }}
+          />
+        </Box>
+
+        <Box sx={{ px: 4, py: 3, display: 'flex', flexDirection: 'column', gap: 4 }}>
+          {/* Fields */}
+          <Box
+            as="dl"
+            sx={{
+              display: 'grid',
+              gridTemplateColumns: 'auto 1fr',
+              columnGap: 3,
+              rowGap: 2,
+              m: 0,
+              fontSize: 0,
+              '& dt': {
+                fontSize: '10px',
+                color: 'fg.muted',
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+                lineHeight: '20px',
+              },
+              '& dd': { m: 0, lineHeight: '20px', color: 'fg.default' },
+            }}
+          >
+            <dt>Status:</dt>
+            <dd>
+              <StatusBadge status={execution.status} />
+            </dd>
+            <dt>Trigger:</dt>
+            <dd>{execution.trigger_type}</dd>
+            <dt>Started:</dt>
+            <dd>{formatDate(execution.started_at)}</dd>
+            <dt>Ended:</dt>
+            <dd>
+              {execution.ended_at ? (
+                formatDate(execution.ended_at)
+              ) : (
+                <Text sx={{ color: 'fg.muted', fontSize: '11px' }}>&mdash;</Text>
+              )}
+            </dd>
+            <dt>Duration:</dt>
+            <dd>
+              <Text sx={{ fontFamily: 'mono' }}>
+                {formatDuration(execution.started_at, execution.ended_at)}
+              </Text>
+            </dd>
+            <dt>Created:</dt>
+            <dd>{formatDate(execution.created_at)}</dd>
+            <dt>Updated:</dt>
+            <dd>{formatDate(execution.updated_at)}</dd>
+          </Box>
+
+          {/* Error */}
+          {execution.error && (
+            <Box>
+              <Text
+                sx={{
+                  fontSize: '10px',
+                  color: 'fg.muted',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                  mb: 2,
+                  display: 'block',
+                }}
+              >
+                Error:
+              </Text>
+              <Box
+                sx={{
+                  fontSize: 0,
+                  color: colors.coral,
+                  fontFamily: 'mono',
+                  lineHeight: 1.6,
+                  whiteSpace: 'pre-wrap',
+                  wordBreak: 'break-all',
+                  p: 2,
+                  borderRadius: 1,
+                  backgroundColor: 'canvas.subtle',
+                }}
+              >
+                {execution.error}
+              </Box>
+            </Box>
+          )}
+        </Box>
+      </Box>
+    </Box>
+  );
+}

--- a/packages/ui/src/components/JobExecutionDetailModal.tsx
+++ b/packages/ui/src/components/JobExecutionDetailModal.tsx
@@ -92,6 +92,9 @@ export function JobExecutionDetailModal({
 
   return (
     <Box
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="execution-detail-title"
       onClick={handleBackdropClick}
       sx={{
         position: 'fixed',
@@ -135,7 +138,10 @@ export function JobExecutionDetailModal({
           }}
         >
           <Box sx={{ flex: 1 }}>
-            <Text sx={{ fontWeight: 'bold', fontSize: 3, color: 'fg.default', lineHeight: 1.3 }}>
+            <Text
+              id="execution-detail-title"
+              sx={{ fontWeight: 'bold', fontSize: 3, color: 'fg.default', lineHeight: 1.3 }}
+            >
               <Text as="span" sx={{ color: 'fg.muted' }}>
                 #{execution.id}
               </Text>{' '}

--- a/packages/ui/src/components/Layout.tsx
+++ b/packages/ui/src/components/Layout.tsx
@@ -22,7 +22,7 @@ import { AgentPane } from './AgentPane';
 import { ArtifactCatalog } from './ArtifactCatalog';
 import { ArtifactViewer } from './ArtifactViewer';
 import { Chat } from './Chat';
-import { ExecutionHistoryPane } from './ExecutionHistoryPane';
+import { CronJobsPane } from './CronJobsPane';
 
 const ACTIVITY_BAR_PX = 48;
 
@@ -67,10 +67,10 @@ export function Layout() {
   const kanbanOpen = useArtifactStore((s) => s.kanbanOpen);
   const toggleCatalog = useArtifactStore((s) => s.toggleCatalog);
   const toggleAgents = useArtifactStore((s) => s.toggleAgents);
-  const executionsOpen = useArtifactStore((s) => s.executionsOpen);
-  const toggleExecutions = useArtifactStore((s) => s.toggleExecutions);
+  const cronJobsOpen = useArtifactStore((s) => s.cronJobsOpen);
+  const toggleCronJobs = useArtifactStore((s) => s.toggleCronJobs);
   const toggleKanbanTab = useArtifactStore((s) => s.toggleKanbanTab);
-  const sideDrawerOpen = catalogOpen || agentsOpen || executionsOpen;
+  const sideDrawerOpen = catalogOpen || agentsOpen || cronJobsOpen;
 
   const handleMouseDown = useCallback(() => {
     isDragging.current = true;
@@ -234,11 +234,11 @@ export function Layout() {
               icon={ClockIcon}
               variant="invisible"
               size="medium"
-              onClick={toggleExecutions}
+              onClick={toggleCronJobs}
               sx={{
-                color: executionsOpen ? 'fg.default' : 'fg.muted',
+                color: cronJobsOpen ? 'fg.default' : 'fg.muted',
                 position: 'relative',
-                '&::before': executionsOpen
+                '&::before': cronJobsOpen
                   ? {
                       content: '""',
                       position: 'absolute',
@@ -299,7 +299,7 @@ export function Layout() {
         >
           {catalogOpen && <ArtifactCatalog />}
           {agentsOpen && <AgentPane />}
-          {executionsOpen && <ExecutionHistoryPane />}
+          {cronJobsOpen && <CronJobsPane />}
         </Box>
       )}
 

--- a/packages/ui/src/stores/artifact.test.ts
+++ b/packages/ui/src/stores/artifact.test.ts
@@ -13,7 +13,7 @@ function resetStore() {
     activeTabId: null,
     catalogOpen: false,
     agentsOpen: false,
-    executionsOpen: false,
+    cronJobsOpen: false,
     kanbanOpen: false,
   });
 }
@@ -99,51 +99,51 @@ describe('useArtifactStore', () => {
     });
   });
 
-  describe('toggleExecutions', () => {
-    it('opens the executions panel', () => {
-      useArtifactStore.getState().toggleExecutions();
+  describe('toggleCronJobs', () => {
+    it('opens the cron jobs panel', () => {
+      useArtifactStore.getState().toggleCronJobs();
 
-      expect(useArtifactStore.getState().executionsOpen).toBe(true);
+      expect(useArtifactStore.getState().cronJobsOpen).toBe(true);
     });
 
-    it('closes the executions panel when already open', () => {
-      useArtifactStore.getState().toggleExecutions();
-      useArtifactStore.getState().toggleExecutions();
+    it('closes the cron jobs panel when already open', () => {
+      useArtifactStore.getState().toggleCronJobs();
+      useArtifactStore.getState().toggleCronJobs();
 
-      expect(useArtifactStore.getState().executionsOpen).toBe(false);
+      expect(useArtifactStore.getState().cronJobsOpen).toBe(false);
     });
 
-    it('closes catalog and agents when opening executions', () => {
+    it('closes catalog and agents when opening cron jobs', () => {
       useArtifactStore.setState({ catalogOpen: true, agentsOpen: true });
 
-      useArtifactStore.getState().toggleExecutions();
+      useArtifactStore.getState().toggleCronJobs();
 
       const state = useArtifactStore.getState();
-      expect(state.executionsOpen).toBe(true);
+      expect(state.cronJobsOpen).toBe(true);
       expect(state.catalogOpen).toBe(false);
       expect(state.agentsOpen).toBe(false);
     });
   });
 
-  describe('panel mutual exclusivity with executions', () => {
-    it('toggleCatalog closes executions', () => {
-      useArtifactStore.setState({ executionsOpen: true });
+  describe('panel mutual exclusivity with cron jobs', () => {
+    it('toggleCatalog closes cron jobs', () => {
+      useArtifactStore.setState({ cronJobsOpen: true });
 
       useArtifactStore.getState().toggleCatalog();
 
       const state = useArtifactStore.getState();
       expect(state.catalogOpen).toBe(true);
-      expect(state.executionsOpen).toBe(false);
+      expect(state.cronJobsOpen).toBe(false);
     });
 
-    it('toggleAgents closes executions', () => {
-      useArtifactStore.setState({ executionsOpen: true });
+    it('toggleAgents closes cron jobs', () => {
+      useArtifactStore.setState({ cronJobsOpen: true });
 
       useArtifactStore.getState().toggleAgents();
 
       const state = useArtifactStore.getState();
       expect(state.agentsOpen).toBe(true);
-      expect(state.executionsOpen).toBe(false);
+      expect(state.cronJobsOpen).toBe(false);
     });
   });
 

--- a/packages/ui/src/stores/artifact.ts
+++ b/packages/ui/src/stores/artifact.ts
@@ -23,7 +23,7 @@ interface ArtifactState {
   activeTabId: string | null;
   catalogOpen: boolean;
   agentsOpen: boolean;
-  executionsOpen: boolean;
+  cronJobsOpen: boolean;
   kanbanOpen: boolean;
   openArtifact: (url: string, title?: string, filePath?: string) => void;
   closeTab: (tabId: string) => void;
@@ -31,7 +31,7 @@ interface ArtifactState {
   reloadTab: (filePath: string, newUrl: string) => void;
   toggleCatalog: () => void;
   toggleAgents: () => void;
-  toggleExecutions: () => void;
+  toggleCronJobs: () => void;
   openKanbanTab: () => void;
   toggleKanbanTab: () => void;
 }
@@ -68,7 +68,7 @@ export const useArtifactStore = create<ArtifactState>()(
       activeTabId: null,
       catalogOpen: false,
       agentsOpen: false,
-      executionsOpen: false,
+      cronJobsOpen: false,
       kanbanOpen: false,
 
       openArtifact: (url: string, title?: string, filePath?: string) => {
@@ -136,7 +136,7 @@ export const useArtifactStore = create<ArtifactState>()(
         set((state) => ({
           catalogOpen: !state.catalogOpen,
           agentsOpen: false,
-          executionsOpen: false,
+          cronJobsOpen: false,
         }));
       },
 
@@ -144,13 +144,13 @@ export const useArtifactStore = create<ArtifactState>()(
         set((state) => ({
           agentsOpen: !state.agentsOpen,
           catalogOpen: false,
-          executionsOpen: false,
+          cronJobsOpen: false,
         }));
       },
 
-      toggleExecutions: () => {
+      toggleCronJobs: () => {
         set((state) => ({
-          executionsOpen: !state.executionsOpen,
+          cronJobsOpen: !state.cronJobsOpen,
           catalogOpen: false,
           agentsOpen: false,
         }));
@@ -183,7 +183,7 @@ export const useArtifactStore = create<ArtifactState>()(
           .map((t) => ({ ...t, url: `/api/artifact?path=${encodeURIComponent(t.filePath)}` })),
         activeTabId: state.activeTabId,
         agentsOpen: state.agentsOpen,
-        executionsOpen: state.executionsOpen,
+        cronJobsOpen: state.cronJobsOpen,
         kanbanOpen: state.kanbanOpen,
       }),
       merge: (persistedState, currentState) => {


### PR DESCRIPTION
## Summary

- Sort indicators now visible on all columns (30% opacity on inactive, full on active) so columns are clearly sortable
- Clicking any row opens a detail modal showing all execution fields: status badge, trigger, started/ended timestamps, computed duration, created/updated, and error message if present
- Removed inline error row expansion (replaced by the modal)

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes  
- [x] 443 tests pass
- [ ] Verify sort arrows visible on all column headers
- [ ] Verify clicking a row opens the detail modal
- [ ] Verify modal shows all fields including error for failed executions
- [ ] Verify Escape and backdrop click close the modal