### PR TITLE
fix: retry and preserve delivery messages on LLM API errors

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -82,7 +82,7 @@ Prompt caching (where supported by the provider) optimizes the static prefix: on
 | Method | Description |
 |--------|-------------|
 | `prompt(content, options?)` | Reload knowledge, then send a user message. Blocks until agent finishes. `options.isSteering` inserts ASAP into the agent loop. |
-| `deliverMessage(content, details, urgent?)` | Reload knowledge, then send inter-agent message via `sendCustomMessage()`. Non-blocking. Reload errors are swallowed to avoid dropping messages. Tracked in `pendingDeliveries` for failover replay. |
+| `deliverMessage(content, details, urgent?)` | Reload knowledge, then send inter-agent message via `sendCustomMessage()`. Returns `Promise<void>` that resolves when the agent finishes processing (on `agent_end`) or rejects on permanent failure. Reload errors are swallowed to avoid dropping messages. Tracked in `pendingDeliveries` for failover replay. |
 | `subscribe(listener)` | Listen to all session events. Returns unsubscribe function. |
 | `abort()` | Cancel current execution. |
 | `getContextUsage()` | Get context window usage stats. |
@@ -113,7 +113,7 @@ Two methods for sending messages, chosen based on the sender:
 | Method | Creates | Used By | Behavior |
 |--------|---------|---------|----------|
 | `prompt()` | `user` message | User -> Guide | Blocking. Streams response back to UI via WebSocket. |
-| `deliverMessage()` | `custom_message` | Agent -> Agent, Scheduler -> Agent | Non-blocking. Queues for delivery. |
+| `deliverMessage()` | `custom_message` | Agent -> Agent, Scheduler -> Agent | Returns `Promise<void>`. Scheduler jobs await completion; inter-agent callers fire-and-forget. |
 
 ### Delivery Modes
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -206,7 +206,7 @@ These patterns are intentionally narrow to avoid false positives on rate-limit e
 
 The result is a session with a compact summary of the safe history plus the recent tail. The overflow-causing prompt is not retried; the agent resumes naturally on the next interaction. Pending deliveries (scheduled tasks, inter-agent messages) are replayed on the recovered session via `sendCustomMessage`, preserving them for the agent to process. If no split point below 90% is found, or if the tail is empty, recovery skips the corresponding steps. If recovery fails mid-way after the file has been truncated, the tail is restored to the file as a best-effort safeguard.
 
-Auto-compaction is also configured to fire earlier (at 90% of the context window instead of the SDK default of ~98%) to reduce the chance of overflow in the first place.
+Auto-compaction is also configured to fire earlier (at ~50% of the context window via `reserveTokens`, instead of the SDK default of ~98%) to reduce the chance of overflow in the first place.
 
 **Last-resort provider recovery:** after all normal recovery paths (retry, failover, context overflow) are exhausted, `handlePotentialError` checks if a different provider is available before giving up. This covers cases where an agent is stuck on a dead fallback provider (e.g., Anthropic with $0 credits returning 400 `client` errors) while the primary provider's cooldown has expired. `getNextProvider()` iterates in provider order (primary first), so agents naturally gravitate back to the primary when it becomes available.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -163,7 +163,7 @@ When `AgentHost` detects an API error in a `message_end` event:
 5. If retries exhausted or immediate failover: mark key in cooldown, failover to next provider
 6. Reinitialize the session with the new provider (`reinitializeWithProvider()`)
 7. Retry the pending prompt and/or replay pending deliveries on the new session
-8. If all providers exhausted: messages remain in `pendingPrompt`/`pendingDeliveries` for recovery when a provider comes out of cooldown
+8. If all providers exhausted: `pendingPrompt` is preserved on the `AgentHost`, but all pending delivery promises are rejected and `pendingDeliveries` is cleared; no automatic replay occurs when a provider later comes out of cooldown
 
 Error details are shown as collapsible system messages in the agent chat. The title shows the error type and action taken, and the collapsible body has provider-specific details. Key rotation: "429 rate limited, rotating to next key". Provider switch: "503 server error, switched to anthropic".
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -204,7 +204,7 @@ These patterns are intentionally narrow to avoid false positives on rate-limit e
 3. Reinitialize the session from the truncated file and run `compact()` to reduce context to ~5%
 4. Append the tail back and reinitialize again
 
-The result is a session with a compact summary of the safe history plus the recent tail. The overflow-causing prompt is not retried; the agent resumes naturally on the next interaction. If no split point below 90% is found, or if the tail is empty, recovery skips the corresponding steps. If recovery fails mid-way after the file has been truncated, the tail is restored to the file as a best-effort safeguard.
+The result is a session with a compact summary of the safe history plus the recent tail. The overflow-causing prompt is not retried; the agent resumes naturally on the next interaction. Pending deliveries (scheduled tasks, inter-agent messages) are replayed on the recovered session via `sendCustomMessage`, preserving them for the agent to process. If no split point below 90% is found, or if the tail is empty, recovery skips the corresponding steps. If recovery fails mid-way after the file has been truncated, the tail is restored to the file as a best-effort safeguard.
 
 Auto-compaction is also configured to fire earlier (at 90% of the context window instead of the SDK default of ~98%) to reduce the chance of overflow in the first place.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -82,7 +82,7 @@ Prompt caching (where supported by the provider) optimizes the static prefix: on
 | Method | Description |
 |--------|-------------|
 | `prompt(content, options?)` | Reload knowledge, then send a user message. Blocks until agent finishes. `options.isSteering` inserts ASAP into the agent loop. |
-| `deliverMessage(content, details, urgent?)` | Reload knowledge, then send inter-agent message via `sendCustomMessage()`. Non-blocking. Reload errors are swallowed to avoid dropping messages. |
+| `deliverMessage(content, details, urgent?)` | Reload knowledge, then send inter-agent message via `sendCustomMessage()`. Non-blocking. Reload errors are swallowed to avoid dropping messages. Tracked in `pendingDeliveries` for failover replay. |
 | `subscribe(listener)` | Listen to all session events. Returns unsubscribe function. |
 | `abort()` | Cancel current execution. |
 | `getContextUsage()` | Get context window usage stats. |
@@ -157,10 +157,13 @@ Cooldowns are set once: if a key is already in cooldown, subsequent failures ski
 When `AgentHost` detects an API error in a `message_end` event:
 
 1. Categorize the error (see [retry.ts](#retry-logic))
-2. If retriable: wait with exponential backoff, retry with same provider
-3. If retries exhausted or immediate failover: mark key in cooldown, failover to next provider
-4. Reinitialize the session with the new provider (`reinitializeWithProvider()`)
-5. Retry the pending prompt
+2. Set `lastTurnErrored = true` synchronously (prevents `agent_end` from clearing pending state)
+3. Capture `pendingPrompt` and `pendingDeliveries` synchronously (before any `await`)
+4. If retriable: wait with exponential backoff, retry with same provider (re-sends the failed prompt or delivery)
+5. If retries exhausted or immediate failover: mark key in cooldown, failover to next provider
+6. Reinitialize the session with the new provider (`reinitializeWithProvider()`)
+7. Retry the pending prompt and/or replay pending deliveries on the new session
+8. If all providers exhausted: messages remain in `pendingPrompt`/`pendingDeliveries` for recovery when a provider comes out of cooldown
 
 Error details are shown as collapsible system messages in the agent chat. The title shows the error type and action taken, and the collapsible body has provider-specific details. Key rotation: "429 rate limited, rotating to next key". Provider switch: "503 server error, switched to anthropic".
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -157,7 +157,7 @@ Cooldowns are set once: if a key is already in cooldown, subsequent failures ski
 When `AgentHost` detects an API error in a `message_end` event:
 
 1. Categorize the error (see [retry.ts](#retry-logic))
-2. Set `lastTurnErrored = true` synchronously (prevents `agent_end` from clearing pending state)
+2. Set `lastTurnErrored = true` synchronously (prevents `agent_end` from clearing pending state). On successful turns, `agent_end` inspects `event.messages` to count completed delivery messages (`role: 'custom'`, `customType: 'agent_message'`) and only shifts that many from `pendingDeliveries`, avoiding desync when prompt and delivery turns are batched into a single event
 3. Capture `pendingPrompt` and `pendingDeliveries` synchronously (before any `await`)
 4. If retriable: wait with exponential backoff, retry with same provider (re-sends the failed prompt or delivery)
 5. If retries exhausted or immediate failover: mark key in cooldown, failover to next provider

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -201,7 +201,7 @@ describe('AgentHost', () => {
       expect(hostInternal.pendingPrompt).toBeNull();
     });
 
-    it('tracks pendingDeliveries and shifts on agent_end', () => {
+    it('tracks pendingDeliveries and shifts on agent_end only for delivery turns', () => {
       const host = new AgentHost({
         db: makeDbStub(),
         agentId: 1,
@@ -215,7 +215,7 @@ describe('AgentHost', () => {
           details: { sender: number; receiver: number; timestamp: number };
           urgent?: boolean;
         }>;
-        handleSessionEvent: (event: { type: string }) => void;
+        handleSessionEvent: (event: Record<string, unknown>) => void;
         handlePotentialError: ReturnType<typeof vi.fn>;
         handleCompactionTracking: ReturnType<typeof vi.fn>;
         session: unknown;
@@ -238,17 +238,33 @@ describe('AgentHost', () => {
       expect(hostInternal.pendingDeliveries[0].content).toBe('msg1');
       expect(hostInternal.pendingDeliveries[1].content).toBe('msg2');
 
-      // agent_end shifts the first delivery
-      hostInternal.handleSessionEvent({ type: 'agent_end' });
+      // Prompt-only agent_end does NOT shift deliveries
+      hostInternal.handleSessionEvent({
+        type: 'agent_end',
+        messages: [{ role: 'user', content: 'hello' }],
+      });
+      expect(hostInternal.pendingDeliveries).toHaveLength(2);
+
+      // Delivery agent_end shifts the matching delivery
+      hostInternal.handleSessionEvent({
+        type: 'agent_end',
+        messages: [{ role: 'custom', customType: 'agent_message', content: 'msg1' }],
+      });
       expect(hostInternal.pendingDeliveries).toHaveLength(1);
       expect(hostInternal.pendingDeliveries[0].content).toBe('msg2');
 
-      // second agent_end clears the queue
-      hostInternal.handleSessionEvent({ type: 'agent_end' });
+      // Second delivery agent_end clears the queue
+      hostInternal.handleSessionEvent({
+        type: 'agent_end',
+        messages: [{ role: 'custom', customType: 'agent_message', content: 'msg2' }],
+      });
       expect(hostInternal.pendingDeliveries).toHaveLength(0);
 
-      // extra agent_end on empty queue is a no-op
-      hostInternal.handleSessionEvent({ type: 'agent_end' });
+      // Extra agent_end on empty queue is a no-op
+      hostInternal.handleSessionEvent({
+        type: 'agent_end',
+        messages: [{ role: 'custom', customType: 'agent_message', content: 'x' }],
+      });
       expect(hostInternal.pendingDeliveries).toHaveLength(0);
     });
 
@@ -268,7 +284,7 @@ describe('AgentHost', () => {
           urgent?: boolean;
         }>;
         lastTurnErrored: boolean;
-        handleSessionEvent: (event: { type: string }) => void;
+        handleSessionEvent: (event: Record<string, unknown>) => void;
         handlePotentialError: ReturnType<typeof vi.fn>;
         handleCompactionTracking: ReturnType<typeof vi.fn>;
       };
@@ -283,7 +299,10 @@ describe('AgentHost', () => {
 
       // Simulate error turn: handlePotentialError sets the flag before agent_end fires
       hostInternal.lastTurnErrored = true;
-      hostInternal.handleSessionEvent({ type: 'agent_end' });
+      hostInternal.handleSessionEvent({
+        type: 'agent_end',
+        messages: [{ role: 'custom', customType: 'agent_message', content: 'delivery1' }],
+      });
 
       // Neither pendingPrompt nor pendingDeliveries should be cleaned up
       expect(hostInternal.pendingPrompt).toBe('user message');
@@ -293,8 +312,11 @@ describe('AgentHost', () => {
       // Flag is reset after agent_end
       expect(hostInternal.lastTurnErrored).toBe(false);
 
-      // Next successful agent_end cleans up normally
-      hostInternal.handleSessionEvent({ type: 'agent_end' });
+      // Next successful agent_end with delivery message cleans up normally
+      hostInternal.handleSessionEvent({
+        type: 'agent_end',
+        messages: [{ role: 'custom', customType: 'agent_message', content: 'delivery1' }],
+      });
       expect(hostInternal.pendingPrompt).toBeNull();
       expect(hostInternal.pendingDeliveries).toHaveLength(0);
     });

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -214,6 +214,8 @@ describe('AgentHost', () => {
           content: string;
           details: { sender: number; receiver: number; timestamp: number };
           urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
         }>;
         handleSessionEvent: (event: Record<string, unknown>) => void;
         handlePotentialError: ReturnType<typeof vi.fn>;
@@ -230,13 +232,19 @@ describe('AgentHost', () => {
       hostInternal._chatCache = null;
 
       const details = { sender: 1, receiver: 2, timestamp: Date.now() };
+      const resolve1 = vi.fn();
+      const resolve2 = vi.fn();
 
-      // deliverMessage pushes to queue
+      // deliverMessage pushes to queue (don't await: testing tracking, not the promise)
       host.deliverMessage('msg1', details);
       host.deliverMessage('msg2', details);
       expect(hostInternal.pendingDeliveries).toHaveLength(2);
       expect(hostInternal.pendingDeliveries[0].content).toBe('msg1');
       expect(hostInternal.pendingDeliveries[1].content).toBe('msg2');
+
+      // Capture the resolve callbacks pushed by deliverMessage
+      hostInternal.pendingDeliveries[0].resolve = resolve1;
+      hostInternal.pendingDeliveries[1].resolve = resolve2;
 
       // Prompt-only agent_end does NOT shift deliveries
       hostInternal.handleSessionEvent({
@@ -252,6 +260,7 @@ describe('AgentHost', () => {
       });
       expect(hostInternal.pendingDeliveries).toHaveLength(1);
       expect(hostInternal.pendingDeliveries[0].content).toBe('msg2');
+      expect(resolve1).toHaveBeenCalledOnce();
 
       // Second delivery agent_end clears the queue
       hostInternal.handleSessionEvent({
@@ -259,6 +268,7 @@ describe('AgentHost', () => {
         messages: [{ role: 'custom', customType: 'agent_message', content: 'msg2' }],
       });
       expect(hostInternal.pendingDeliveries).toHaveLength(0);
+      expect(resolve2).toHaveBeenCalledOnce();
 
       // Extra agent_end on empty queue is a no-op
       hostInternal.handleSessionEvent({
@@ -282,6 +292,8 @@ describe('AgentHost', () => {
           content: string;
           details: { sender: number; receiver: number; timestamp: number };
           urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
         }>;
         lastTurnErrored: boolean;
         handleSessionEvent: (event: Record<string, unknown>) => void;
@@ -292,9 +304,17 @@ describe('AgentHost', () => {
       hostInternal.handlePotentialError = vi.fn().mockResolvedValue(undefined);
       hostInternal.handleCompactionTracking = vi.fn();
 
+      const resolveDelivery = vi.fn();
+      const rejectDelivery = vi.fn();
+
       hostInternal.pendingPrompt = 'user message';
       hostInternal.pendingDeliveries = [
-        { content: 'delivery1', details: { sender: 1, receiver: 2, timestamp: Date.now() } },
+        {
+          content: 'delivery1',
+          details: { sender: 1, receiver: 2, timestamp: Date.now() },
+          resolve: resolveDelivery,
+          reject: rejectDelivery,
+        },
       ];
 
       // Simulate error turn: handlePotentialError sets the flag before agent_end fires
@@ -309,6 +329,10 @@ describe('AgentHost', () => {
       expect(hostInternal.pendingDeliveries).toHaveLength(1);
       expect(hostInternal.pendingDeliveries[0].content).toBe('delivery1');
 
+      // Neither resolve nor reject should be called on error turns
+      expect(resolveDelivery).not.toHaveBeenCalled();
+      expect(rejectDelivery).not.toHaveBeenCalled();
+
       // Flag is reset after agent_end
       expect(hostInternal.lastTurnErrored).toBe(false);
 
@@ -318,6 +342,140 @@ describe('AgentHost', () => {
         messages: [{ role: 'custom', customType: 'agent_message', content: 'delivery1' }],
       });
       expect(hostInternal.pendingPrompt).toBeNull();
+      expect(hostInternal.pendingDeliveries).toHaveLength(0);
+      expect(resolveDelivery).toHaveBeenCalledOnce();
+    });
+
+    it('deliverMessage returns promise that resolves on agent_end', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        session: { sendCustomMessage: ReturnType<typeof vi.fn> };
+        _chatCache: null;
+        _sessionDir: string | null;
+        handleSessionEvent: (event: Record<string, unknown>) => void;
+        handlePotentialError: ReturnType<typeof vi.fn>;
+        handleCompactionTracking: ReturnType<typeof vi.fn>;
+      };
+
+      hostInternal.session = { sendCustomMessage: vi.fn() };
+      hostInternal._chatCache = null;
+      hostInternal._sessionDir = null;
+      hostInternal.handlePotentialError = vi.fn().mockResolvedValue(undefined);
+      hostInternal.handleCompactionTracking = vi.fn();
+
+      const promise = host.deliverMessage('msg1', {
+        sender: 1,
+        receiver: 2,
+        timestamp: Date.now(),
+      });
+
+      // Fire agent_end with a delivery message to resolve the promise
+      hostInternal.handleSessionEvent({
+        type: 'agent_end',
+        messages: [{ role: 'custom', customType: 'agent_message', content: 'msg1' }],
+      });
+
+      await expect(promise).resolves.toBeUndefined();
+    });
+
+    it('abort() rejects all pending delivery promises', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as {
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
+        }>;
+        session: { abort: ReturnType<typeof vi.fn> };
+      };
+
+      const reject1 = vi.fn();
+      const reject2 = vi.fn();
+
+      internal.session = { abort: vi.fn() };
+      internal.pendingDeliveries = [
+        {
+          content: 'msg1',
+          details: { sender: 1, receiver: 2, timestamp: Date.now() },
+          resolve: vi.fn(),
+          reject: reject1,
+        },
+        {
+          content: 'msg2',
+          details: { sender: 1, receiver: 2, timestamp: Date.now() },
+          resolve: vi.fn(),
+          reject: reject2,
+        },
+      ];
+
+      host.abort();
+
+      expect(reject1).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Agent session aborted' })
+      );
+      expect(reject2).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Agent session aborted' })
+      );
+    });
+
+    it('agent_end resolves delivery promises in order', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
+        }>;
+        handleSessionEvent: (event: Record<string, unknown>) => void;
+        handlePotentialError: ReturnType<typeof vi.fn>;
+        handleCompactionTracking: ReturnType<typeof vi.fn>;
+      };
+
+      hostInternal.handlePotentialError = vi.fn().mockResolvedValue(undefined);
+      hostInternal.handleCompactionTracking = vi.fn();
+
+      const resolve1 = vi.fn();
+      const resolve2 = vi.fn();
+      const details = { sender: 1, receiver: 2, timestamp: Date.now() };
+
+      hostInternal.pendingDeliveries = [
+        { content: 'first', details, resolve: resolve1, reject: vi.fn() },
+        { content: 'second', details, resolve: resolve2, reject: vi.fn() },
+      ];
+
+      // agent_end with 2 delivery messages resolves both in order
+      hostInternal.handleSessionEvent({
+        type: 'agent_end',
+        messages: [
+          { role: 'custom', customType: 'agent_message', content: 'first' },
+          { role: 'custom', customType: 'agent_message', content: 'second' },
+        ],
+      });
+
+      expect(resolve1).toHaveBeenCalledOnce();
+      expect(resolve2).toHaveBeenCalledOnce();
       expect(hostInternal.pendingDeliveries).toHaveLength(0);
     });
 
@@ -335,6 +493,8 @@ describe('AgentHost', () => {
           content: string;
           details: { sender: number; receiver: number; timestamp: number };
           urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
         }>;
         session: { prompt: ReturnType<typeof vi.fn> };
         handlePotentialError: (event: unknown) => Promise<void>;
@@ -356,8 +516,8 @@ describe('AgentHost', () => {
 
       const details = { sender: 1, receiver: 2, timestamp: Date.now() };
       hostInternal.pendingDeliveries = [
-        { content: 'project-log', details, urgent: false },
-        { content: 'daily-summary', details, urgent: false },
+        { content: 'project-log', details, urgent: false, resolve: vi.fn(), reject: vi.fn() },
+        { content: 'daily-summary', details, urgent: false, resolve: vi.fn(), reject: vi.fn() },
       ];
 
       // Force failover path: exhaust retries
@@ -377,8 +537,8 @@ describe('AgentHost', () => {
         'google',
         null,
         [
-          { content: 'project-log', details, urgent: false },
-          { content: 'daily-summary', details, urgent: false },
+          expect.objectContaining({ content: 'project-log', details, urgent: false }),
+          expect.objectContaining({ content: 'daily-summary', details, urgent: false }),
         ],
         expect.any(String),
         expect.any(String)
@@ -455,6 +615,8 @@ describe('AgentHost', () => {
           content: string;
           details: { sender: number; receiver: number; timestamp: number };
           urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
         }>;
         lastTurnErrored: boolean;
         session: {
@@ -481,7 +643,9 @@ describe('AgentHost', () => {
       hostInternal.pendingPrompt = null; // No prompt, only a delivery
 
       const details = { sender: 0, receiver: 2, timestamp: Date.now() };
-      hostInternal.pendingDeliveries = [{ content: 'project-log', details, urgent: false }];
+      hostInternal.pendingDeliveries = [
+        { content: 'project-log', details, urgent: false, resolve: vi.fn(), reject: vi.fn() },
+      ];
 
       // Rate limit error, first attempt: shouldRetry returns true
       hostInternal.retryAttempts = new Map();
@@ -527,6 +691,8 @@ describe('AgentHost', () => {
           content: string;
           details: { sender: number; receiver: number; timestamp: number };
           urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
         }>;
         lastTurnErrored: boolean;
         session: {
@@ -553,7 +719,9 @@ describe('AgentHost', () => {
       hostInternal.pendingPrompt = null;
 
       const details = { sender: 1, receiver: 2, timestamp: Date.now() };
-      hostInternal.pendingDeliveries = [{ content: 'urgent-msg', details, urgent: true }];
+      hostInternal.pendingDeliveries = [
+        { content: 'urgent-msg', details, urgent: true, resolve: vi.fn(), reject: vi.fn() },
+      ];
 
       hostInternal.retryAttempts = new Map();
       hostInternal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
@@ -663,7 +831,7 @@ describe('AgentHost', () => {
       expect(internal.pendingPrompt).toBeNull();
     });
 
-    it('abort() clears pendingDeliveries', () => {
+    it('abort() clears pendingDeliveries and rejects their promises', () => {
       const host = new AgentHost({
         db: makeDbStub(),
         agentId: 1,
@@ -676,19 +844,40 @@ describe('AgentHost', () => {
           content: string;
           details: { sender: number; receiver: number; timestamp: number };
           urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
         }>;
         session: { abort: ReturnType<typeof vi.fn> };
       };
 
+      const reject1 = vi.fn();
+      const reject2 = vi.fn();
+
       internal.session = { abort: vi.fn() };
       internal.pendingDeliveries = [
-        { content: 'msg1', details: { sender: 1, receiver: 2, timestamp: Date.now() } },
-        { content: 'msg2', details: { sender: 1, receiver: 2, timestamp: Date.now() } },
+        {
+          content: 'msg1',
+          details: { sender: 1, receiver: 2, timestamp: Date.now() },
+          resolve: vi.fn(),
+          reject: reject1,
+        },
+        {
+          content: 'msg2',
+          details: { sender: 1, receiver: 2, timestamp: Date.now() },
+          resolve: vi.fn(),
+          reject: reject2,
+        },
       ];
 
       host.abort();
 
       expect(internal.pendingDeliveries).toHaveLength(0);
+      expect(reject1).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Agent session aborted' })
+      );
+      expect(reject2).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Agent session aborted' })
+      );
     });
 
     it('abort() is a no-op when already idle', () => {
@@ -725,7 +914,7 @@ describe('AgentHost', () => {
       expect(host.isBusy()).toBe(false);
     });
 
-    it('all-providers-exhausted preserves pendingPrompt and pendingDeliveries', async () => {
+    it('all-providers-exhausted rejects delivery promises and clears pendingDeliveries', async () => {
       const host = new AgentHost({
         db: makeDbStub(),
         agentId: 1,
@@ -739,6 +928,8 @@ describe('AgentHost', () => {
           content: string;
           details: { sender: number; receiver: number; timestamp: number };
           urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
         }>;
         lastTurnErrored: boolean;
         session: { prompt: ReturnType<typeof vi.fn> };
@@ -759,9 +950,19 @@ describe('AgentHost', () => {
       internal.currentKeyIndex = 0;
       internal.busy = true;
 
+      const rejectDelivery = vi.fn();
+
       internal.pendingPrompt = 'user message';
       const details = { sender: 0, receiver: 2, timestamp: Date.now() };
-      internal.pendingDeliveries = [{ content: 'project-log', details, urgent: false }];
+      internal.pendingDeliveries = [
+        {
+          content: 'project-log',
+          details,
+          urgent: false,
+          resolve: vi.fn(),
+          reject: rejectDelivery,
+        },
+      ];
 
       // All providers exhausted: auth error, no next provider
       internal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
@@ -774,11 +975,13 @@ describe('AgentHost', () => {
         message: { stopReason: 'error', errorMessage: 'Error 401: Unauthorized' },
       });
 
-      // Messages should be preserved on the instance (not lost in local variables)
-      // because lastTurnErrored prevented agent_end from clearing them
+      // pendingPrompt preserved (lastTurnErrored prevented agent_end from clearing it)
       expect(internal.pendingPrompt).toBe('user message');
-      expect(internal.pendingDeliveries).toHaveLength(1);
-      expect(internal.pendingDeliveries[0].content).toBe('project-log');
+      // Delivery promises rejected and cleared by all-providers-exhausted path
+      expect(rejectDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.stringContaining('All providers exhausted') })
+      );
+      expect(internal.pendingDeliveries).toHaveLength(0);
     });
 
     it('busy stays false when already idle', () => {
@@ -1873,6 +2076,8 @@ describe('AgentHost', () => {
         content: string;
         details: Record<string, unknown>;
         urgent: boolean;
+        resolve: () => void;
+        reject: (reason: Error) => void;
       }>;
       session: { sendCustomMessage: ReturnType<typeof vi.fn> } | null;
       isReinitializing: boolean;
@@ -1972,8 +2177,20 @@ describe('AgentHost', () => {
       const sendCustomMessage = vi.fn();
       internal.session = { sendCustomMessage };
       internal.pendingDeliveries = [
-        { content: 'task-1', details: { source: 'scheduler' }, urgent: false },
-        { content: 'task-2', details: { source: 'scheduler' }, urgent: true },
+        {
+          content: 'task-1',
+          details: { source: 'scheduler' },
+          urgent: false,
+          resolve: vi.fn(),
+          reject: vi.fn(),
+        },
+        {
+          content: 'task-2',
+          details: { source: 'scheduler' },
+          urgent: true,
+          resolve: vi.fn(),
+          reject: vi.fn(),
+        },
       ];
       await internal.handlePotentialError(
         makeOverflowEvent('400: input token count exceeds maximum context length')

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -694,6 +694,71 @@ describe('AgentHost', () => {
       );
     });
 
+    it('same-provider retry rejects delivery promise when sendCustomMessage fails', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        pendingPrompt: string | null;
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
+        }>;
+        lastTurnErrored: boolean;
+        session: {
+          prompt: ReturnType<typeof vi.fn>;
+          sendCustomMessage: ReturnType<typeof vi.fn>;
+        };
+        handlePotentialError: (event: unknown) => Promise<void>;
+        authResolver: {
+          markKeyFailed: ReturnType<typeof vi.fn>;
+          getNextProvider: ReturnType<typeof vi.fn>;
+          isKeyInCooldown: ReturnType<typeof vi.fn>;
+        };
+        retryAttempts: Map<string, number>;
+        currentProvider: string;
+        currentKeyIndex: number;
+      };
+
+      const sendError = new Error('session torn down');
+      hostInternal.session = {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        sendCustomMessage: vi.fn().mockRejectedValue(sendError),
+      };
+      hostInternal.currentProvider = 'cerebras';
+      hostInternal.currentKeyIndex = 0;
+      hostInternal.pendingPrompt = null;
+
+      const details = { sender: 0, receiver: 2, timestamp: Date.now() };
+      const rejectFn = vi.fn();
+      hostInternal.pendingDeliveries = [
+        { content: 'project-log', details, urgent: false, resolve: vi.fn(), reject: rejectFn },
+      ];
+
+      hostInternal.retryAttempts = new Map();
+      hostInternal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
+      hostInternal.authResolver.markKeyFailed = vi.fn().mockReturnValue(false);
+      hostInternal.authResolver.getNextProvider = vi.fn().mockReturnValue(null);
+
+      await hostInternal.handlePotentialError({
+        type: 'message_end',
+        message: { stopReason: 'error', errorMessage: 'Error 429: rate limit exceeded' },
+      });
+
+      // Wait for the .catch() microtask to run
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(rejectFn).toHaveBeenCalledWith(sendError);
+      expect(hostInternal.pendingDeliveries).toHaveLength(0);
+    });
+
     it('pendingPrompt persists if session.prompt() throws', async () => {
       const host = new AgentHost({
         db: makeDbStub(),

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -336,10 +336,13 @@ describe('AgentHost', () => {
       // Flag is reset after agent_end
       expect(hostInternal.lastTurnErrored).toBe(false);
 
-      // Next successful agent_end with delivery message cleans up normally
+      // Next successful agent_end with user + delivery messages cleans up normally
       hostInternal.handleSessionEvent({
         type: 'agent_end',
-        messages: [{ role: 'custom', customType: 'agent_message', content: 'delivery1' }],
+        messages: [
+          { role: 'user', content: 'user message' },
+          { role: 'custom', customType: 'agent_message', content: 'delivery1' },
+        ],
       });
       expect(hostInternal.pendingPrompt).toBeNull();
       expect(hostInternal.pendingDeliveries).toHaveLength(0);
@@ -588,7 +591,7 @@ describe('AgentHost', () => {
 
       hostInternal.session = {
         prompt: vi.fn().mockResolvedValue(undefined),
-        sendCustomMessage: vi.fn(),
+        sendCustomMessage: vi.fn().mockResolvedValue(undefined),
       };
       hostInternal.currentProvider = 'cerebras';
       hostInternal.currentKeyIndex = 0;
@@ -664,7 +667,7 @@ describe('AgentHost', () => {
 
       hostInternal.session = {
         prompt: vi.fn().mockResolvedValue(undefined),
-        sendCustomMessage: vi.fn(),
+        sendCustomMessage: vi.fn().mockResolvedValue(undefined),
       };
       hostInternal.currentProvider = 'cerebras';
       hostInternal.currentKeyIndex = 0;
@@ -2126,7 +2129,7 @@ describe('AgentHost', () => {
 
     it('replays pending deliveries on the recovered session after context overflow', async () => {
       const { internal } = makeHostForOverflow();
-      const sendCustomMessage = vi.fn();
+      const sendCustomMessage = vi.fn().mockResolvedValue(undefined);
       internal.session = { sendCustomMessage };
       internal.pendingDeliveries = [
         {

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -384,54 +384,6 @@ describe('AgentHost', () => {
       await expect(promise).resolves.toBeUndefined();
     });
 
-    it('abort() rejects all pending delivery promises', () => {
-      const host = new AgentHost({
-        db: makeDbStub(),
-        agentId: 1,
-        registry: makeRegistryStub(),
-        llmConfig: makeLlmConfig(),
-      });
-
-      const internal = host as unknown as {
-        pendingDeliveries: Array<{
-          content: string;
-          details: { sender: number; receiver: number; timestamp: number };
-          urgent?: boolean;
-          resolve: () => void;
-          reject: (reason: Error) => void;
-        }>;
-        session: { abort: ReturnType<typeof vi.fn> };
-      };
-
-      const reject1 = vi.fn();
-      const reject2 = vi.fn();
-
-      internal.session = { abort: vi.fn() };
-      internal.pendingDeliveries = [
-        {
-          content: 'msg1',
-          details: { sender: 1, receiver: 2, timestamp: Date.now() },
-          resolve: vi.fn(),
-          reject: reject1,
-        },
-        {
-          content: 'msg2',
-          details: { sender: 1, receiver: 2, timestamp: Date.now() },
-          resolve: vi.fn(),
-          reject: reject2,
-        },
-      ];
-
-      host.abort();
-
-      expect(reject1).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'Agent session aborted' })
-      );
-      expect(reject2).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'Agent session aborted' })
-      );
-    });
-
     it('agent_end resolves delivery promises in order', () => {
       const host = new AgentHost({
         db: makeDbStub(),

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -1111,7 +1111,7 @@ describe('AgentHost', () => {
   });
 
   describe('deliverMessage', () => {
-    it('throws if session is not initialized', () => {
+    it('rejects if session is not initialized', async () => {
       const host = new AgentHost({
         db: makeDbStub(),
         agentId: 1,
@@ -1119,9 +1119,9 @@ describe('AgentHost', () => {
         llmConfig: makeLlmConfig(),
       });
 
-      expect(() =>
+      await expect(
         host.deliverMessage('hello', { sender: 2, receiver: 1, timestamp: Date.now() })
-      ).toThrow('AgentHost not initialized');
+      ).rejects.toThrow('AgentHost not initialized');
     });
 
     it('stores full content for inter-agent messages', () => {

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -201,6 +201,168 @@ describe('AgentHost', () => {
       expect(hostInternal.pendingPrompt).toBeNull();
     });
 
+    it('tracks pendingDeliveries and shifts on agent_end', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+        }>;
+        handleSessionEvent: (event: { type: string }) => void;
+        handlePotentialError: ReturnType<typeof vi.fn>;
+        handleCompactionTracking: ReturnType<typeof vi.fn>;
+        session: unknown;
+        _chatCache: null;
+      };
+
+      hostInternal.handlePotentialError = vi.fn().mockResolvedValue(undefined);
+      hostInternal.handleCompactionTracking = vi.fn();
+      hostInternal.session = {
+        sendCustomMessage: vi.fn(),
+      };
+      hostInternal._chatCache = null;
+
+      const details = { sender: 1, receiver: 2, timestamp: Date.now() };
+
+      // deliverMessage pushes to queue
+      host.deliverMessage('msg1', details);
+      host.deliverMessage('msg2', details);
+      expect(hostInternal.pendingDeliveries).toHaveLength(2);
+      expect(hostInternal.pendingDeliveries[0].content).toBe('msg1');
+      expect(hostInternal.pendingDeliveries[1].content).toBe('msg2');
+
+      // agent_end shifts the first delivery
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
+      expect(hostInternal.pendingDeliveries).toHaveLength(1);
+      expect(hostInternal.pendingDeliveries[0].content).toBe('msg2');
+
+      // second agent_end clears the queue
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
+      expect(hostInternal.pendingDeliveries).toHaveLength(0);
+
+      // extra agent_end on empty queue is a no-op
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
+      expect(hostInternal.pendingDeliveries).toHaveLength(0);
+    });
+
+    it('lastTurnErrored prevents cleanup on error turns', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        pendingPrompt: string | null;
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+        }>;
+        lastTurnErrored: boolean;
+        handleSessionEvent: (event: { type: string }) => void;
+        handlePotentialError: ReturnType<typeof vi.fn>;
+        handleCompactionTracking: ReturnType<typeof vi.fn>;
+      };
+
+      hostInternal.handlePotentialError = vi.fn().mockResolvedValue(undefined);
+      hostInternal.handleCompactionTracking = vi.fn();
+
+      hostInternal.pendingPrompt = 'user message';
+      hostInternal.pendingDeliveries = [
+        { content: 'delivery1', details: { sender: 1, receiver: 2, timestamp: Date.now() } },
+      ];
+
+      // Simulate error turn: handlePotentialError sets the flag before agent_end fires
+      hostInternal.lastTurnErrored = true;
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
+
+      // Neither pendingPrompt nor pendingDeliveries should be cleaned up
+      expect(hostInternal.pendingPrompt).toBe('user message');
+      expect(hostInternal.pendingDeliveries).toHaveLength(1);
+      expect(hostInternal.pendingDeliveries[0].content).toBe('delivery1');
+
+      // Flag is reset after agent_end
+      expect(hostInternal.lastTurnErrored).toBe(false);
+
+      // Next successful agent_end cleans up normally
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
+      expect(hostInternal.pendingPrompt).toBeNull();
+      expect(hostInternal.pendingDeliveries).toHaveLength(0);
+    });
+
+    it('captures deliveriesToRetry and replays them on failover', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        pendingPrompt: string | null;
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+        }>;
+        session: { prompt: ReturnType<typeof vi.fn> };
+        handlePotentialError: (event: unknown) => Promise<void>;
+        reinitializeWithProvider: ReturnType<typeof vi.fn>;
+        authResolver: {
+          markKeyFailed: ReturnType<typeof vi.fn>;
+          getNextProvider: ReturnType<typeof vi.fn>;
+          isKeyInCooldown: ReturnType<typeof vi.fn>;
+        };
+        retryAttempts: Map<string, number>;
+        currentProvider: string;
+        currentKeyIndex: number;
+      };
+
+      hostInternal.session = { prompt: vi.fn().mockResolvedValue(undefined) };
+      hostInternal.currentProvider = 'cerebras';
+      hostInternal.currentKeyIndex = 0;
+      hostInternal.pendingPrompt = null;
+
+      const details = { sender: 1, receiver: 2, timestamp: Date.now() };
+      hostInternal.pendingDeliveries = [
+        { content: 'project-log', details, urgent: false },
+        { content: 'daily-summary', details, urgent: false },
+      ];
+
+      // Force failover path: exhaust retries
+      hostInternal.retryAttempts = new Map([['cerebras:client', 7]]);
+      hostInternal.authResolver.markKeyFailed = vi.fn().mockReturnValue(true);
+      hostInternal.authResolver.getNextProvider = vi.fn().mockReturnValue('google');
+      hostInternal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
+      hostInternal.reinitializeWithProvider = vi.fn().mockResolvedValue(undefined);
+
+      await hostInternal.handlePotentialError({
+        type: 'message_end',
+        message: { stopReason: 'error', errorMessage: 'Error 400: credit balance too low' },
+      });
+
+      // deliveriesToRetry should be passed to reinitializeWithProvider
+      expect(hostInternal.reinitializeWithProvider).toHaveBeenCalledWith(
+        'google',
+        null,
+        [
+          { content: 'project-log', details, urgent: false },
+          { content: 'daily-summary', details, urgent: false },
+        ],
+        expect.any(String),
+        expect.any(String)
+      );
+    });
+
     it('retry paths restore pendingPrompt and pass streamingBehavior before calling session.prompt()', async () => {
       const host = new AgentHost({
         db: makeDbStub(),
@@ -255,6 +417,136 @@ describe('AgentHost', () => {
       expect(hostInternal.session.prompt).toHaveBeenCalledWith('original message', {
         streamingBehavior: 'followUp',
       });
+    });
+
+    it('same-provider retry re-sends failed delivery via sendCustomMessage', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        pendingPrompt: string | null;
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+        }>;
+        lastTurnErrored: boolean;
+        session: {
+          prompt: ReturnType<typeof vi.fn>;
+          sendCustomMessage: ReturnType<typeof vi.fn>;
+        };
+        handlePotentialError: (event: unknown) => Promise<void>;
+        authResolver: {
+          markKeyFailed: ReturnType<typeof vi.fn>;
+          getNextProvider: ReturnType<typeof vi.fn>;
+          isKeyInCooldown: ReturnType<typeof vi.fn>;
+        };
+        retryAttempts: Map<string, number>;
+        currentProvider: string;
+        currentKeyIndex: number;
+      };
+
+      hostInternal.session = {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        sendCustomMessage: vi.fn(),
+      };
+      hostInternal.currentProvider = 'cerebras';
+      hostInternal.currentKeyIndex = 0;
+      hostInternal.pendingPrompt = null; // No prompt, only a delivery
+
+      const details = { sender: 0, receiver: 2, timestamp: Date.now() };
+      hostInternal.pendingDeliveries = [{ content: 'project-log', details, urgent: false }];
+
+      // Rate limit error, first attempt: shouldRetry returns true
+      hostInternal.retryAttempts = new Map();
+      hostInternal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
+      // Defensive mocks for failover path (not exercised)
+      hostInternal.authResolver.markKeyFailed = vi.fn().mockReturnValue(false);
+      hostInternal.authResolver.getNextProvider = vi.fn().mockReturnValue(null);
+
+      await hostInternal.handlePotentialError({
+        type: 'message_end',
+        message: { stopReason: 'error', errorMessage: 'Error 429: rate limit exceeded' },
+      });
+
+      // Should NOT have called session.prompt (no pending prompt)
+      expect(hostInternal.session.prompt).not.toHaveBeenCalled();
+
+      // Should have re-sent the delivery via sendCustomMessage
+      expect(hostInternal.session.sendCustomMessage).toHaveBeenCalledWith(
+        {
+          customType: 'agent_message',
+          content: 'project-log',
+          display: false,
+          details,
+        },
+        {
+          deliverAs: 'followUp',
+          triggerTurn: true,
+        }
+      );
+    });
+
+    it('same-provider retry uses steer for urgent deliveries', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        pendingPrompt: string | null;
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+        }>;
+        lastTurnErrored: boolean;
+        session: {
+          prompt: ReturnType<typeof vi.fn>;
+          sendCustomMessage: ReturnType<typeof vi.fn>;
+        };
+        handlePotentialError: (event: unknown) => Promise<void>;
+        authResolver: {
+          markKeyFailed: ReturnType<typeof vi.fn>;
+          getNextProvider: ReturnType<typeof vi.fn>;
+          isKeyInCooldown: ReturnType<typeof vi.fn>;
+        };
+        retryAttempts: Map<string, number>;
+        currentProvider: string;
+        currentKeyIndex: number;
+      };
+
+      hostInternal.session = {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        sendCustomMessage: vi.fn(),
+      };
+      hostInternal.currentProvider = 'cerebras';
+      hostInternal.currentKeyIndex = 0;
+      hostInternal.pendingPrompt = null;
+
+      const details = { sender: 1, receiver: 2, timestamp: Date.now() };
+      hostInternal.pendingDeliveries = [{ content: 'urgent-msg', details, urgent: true }];
+
+      hostInternal.retryAttempts = new Map();
+      hostInternal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
+      hostInternal.authResolver.markKeyFailed = vi.fn().mockReturnValue(false);
+      hostInternal.authResolver.getNextProvider = vi.fn().mockReturnValue(null);
+
+      await hostInternal.handlePotentialError({
+        type: 'message_end',
+        message: { stopReason: 'error', errorMessage: 'Error 429: rate limit exceeded' },
+      });
+
+      expect(hostInternal.session.sendCustomMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ content: 'urgent-msg' }),
+        expect.objectContaining({ deliverAs: 'steer' })
+      );
     });
 
     it('pendingPrompt persists if session.prompt() throws', async () => {
@@ -349,6 +641,34 @@ describe('AgentHost', () => {
       expect(internal.pendingPrompt).toBeNull();
     });
 
+    it('abort() clears pendingDeliveries', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as {
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+        }>;
+        session: { abort: ReturnType<typeof vi.fn> };
+      };
+
+      internal.session = { abort: vi.fn() };
+      internal.pendingDeliveries = [
+        { content: 'msg1', details: { sender: 1, receiver: 2, timestamp: Date.now() } },
+        { content: 'msg2', details: { sender: 1, receiver: 2, timestamp: Date.now() } },
+      ];
+
+      host.abort();
+
+      expect(internal.pendingDeliveries).toHaveLength(0);
+    });
+
     it('abort() is a no-op when already idle', () => {
       const { host, internal } = makeHostWithBusyTracking();
       setupWithFakeSession(internal);
@@ -381,6 +701,62 @@ describe('AgentHost', () => {
       await internal.handlePotentialError(errorEvent);
 
       expect(host.isBusy()).toBe(false);
+    });
+
+    it('all-providers-exhausted preserves pendingPrompt and pendingDeliveries', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as {
+        pendingPrompt: string | null;
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+        }>;
+        lastTurnErrored: boolean;
+        session: { prompt: ReturnType<typeof vi.fn> };
+        handlePotentialError: (event: unknown) => Promise<void>;
+        authResolver: {
+          isKeyInCooldown: ReturnType<typeof vi.fn>;
+          markKeyFailed: ReturnType<typeof vi.fn>;
+          getNextProvider: ReturnType<typeof vi.fn>;
+        };
+        retryAttempts: Map<string, number>;
+        currentProvider: string;
+        currentKeyIndex: number;
+        busy: boolean;
+      };
+
+      internal.session = { prompt: vi.fn() };
+      internal.currentProvider = 'cerebras';
+      internal.currentKeyIndex = 0;
+      internal.busy = true;
+
+      internal.pendingPrompt = 'user message';
+      const details = { sender: 0, receiver: 2, timestamp: Date.now() };
+      internal.pendingDeliveries = [{ content: 'project-log', details, urgent: false }];
+
+      // All providers exhausted: auth error, no next provider
+      internal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
+      internal.authResolver.markKeyFailed = vi.fn().mockReturnValue(true);
+      internal.authResolver.getNextProvider = vi.fn().mockReturnValue(null);
+      internal.retryAttempts = new Map();
+
+      await internal.handlePotentialError({
+        type: 'message_end',
+        message: { stopReason: 'error', errorMessage: 'Error 401: Unauthorized' },
+      });
+
+      // Messages should be preserved on the instance (not lost in local variables)
+      // because lastTurnErrored prevented agent_end from clearing them
+      expect(internal.pendingPrompt).toBe('user message');
+      expect(internal.pendingDeliveries).toHaveLength(1);
+      expect(internal.pendingDeliveries[0].content).toBe('project-log');
     });
 
     it('busy stays false when already idle', () => {
@@ -776,6 +1152,7 @@ describe('AgentHost', () => {
       expect(internal.reinitializeWithProvider).toHaveBeenCalledWith(
         'anthropic',
         null,
+        [],
         '429 rate limited, switched to anthropic',
         'on google, switching to anthropic'
       );
@@ -821,6 +1198,7 @@ describe('AgentHost', () => {
       expect(internal.reinitializeWithProvider).toHaveBeenCalledWith(
         'google',
         null,
+        [],
         '429 rate limited, rotating to next key',
         'on google, rotating to next key'
       );
@@ -909,6 +1287,7 @@ describe('AgentHost', () => {
       expect(internal.reinitializeWithProvider).toHaveBeenCalledWith(
         'google',
         null,
+        [],
         expect.stringContaining('switched to google'),
         expect.stringContaining('cooldown')
       );
@@ -992,6 +1371,7 @@ describe('AgentHost', () => {
       expect(internal.reinitializeWithProvider).toHaveBeenCalledWith(
         'google',
         null,
+        [],
         '400 client error, switched to google',
         'on anthropic, switching to google'
       );

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -1847,6 +1847,12 @@ describe('AgentHost', () => {
       handleContextOverflow: ReturnType<typeof vi.fn>;
       contextOverflowHandled: boolean;
       pendingPrompt: string | null;
+      pendingDeliveries: Array<{
+        content: string;
+        details: Record<string, unknown>;
+        urgent: boolean;
+      }>;
+      session: { sendCustomMessage: ReturnType<typeof vi.fn> } | null;
       isReinitializing: boolean;
       currentProvider: string;
       retryAttempts: Map<string, number>;
@@ -1937,6 +1943,43 @@ describe('AgentHost', () => {
       );
       expect(internal.handleContextOverflow).toHaveBeenCalledOnce();
       expect(internal.pendingPrompt).toBeNull();
+    });
+
+    it('replays pending deliveries on the recovered session after context overflow', async () => {
+      const { internal } = makeHostForOverflow();
+      const sendCustomMessage = vi.fn();
+      internal.session = { sendCustomMessage };
+      internal.pendingDeliveries = [
+        { content: 'task-1', details: { source: 'scheduler' }, urgent: false },
+        { content: 'task-2', details: { source: 'scheduler' }, urgent: true },
+      ];
+      await internal.handlePotentialError(
+        makeOverflowEvent('400: input token count exceeds maximum context length')
+      );
+      expect(internal.handleContextOverflow).toHaveBeenCalledOnce();
+      expect(sendCustomMessage).toHaveBeenCalledTimes(2);
+      expect(sendCustomMessage).toHaveBeenNthCalledWith(
+        1,
+        {
+          customType: 'agent_message',
+          content: 'task-1',
+          display: false,
+          details: { source: 'scheduler' },
+        },
+        { deliverAs: 'followUp', triggerTurn: true }
+      );
+      expect(sendCustomMessage).toHaveBeenNthCalledWith(
+        2,
+        {
+          customType: 'agent_message',
+          content: 'task-2',
+          display: false,
+          details: { source: 'scheduler' },
+        },
+        { deliverAs: 'steer', triggerTurn: true }
+      );
+      // pendingDeliveries NOT cleared (agent_end shifts on success)
+      expect(internal.pendingDeliveries).toHaveLength(2);
     });
   });
 

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -628,6 +628,24 @@ export class AgentHost {
       if (recovered) {
         // Clear the overflow-causing prompt so a future failover doesn't retry it
         this.pendingPrompt = null;
+        // Replay pending deliveries on the recovered session. Don't clear
+        // pendingDeliveries: agent_end will shift each one as turns succeed.
+        if (this.pendingDeliveries.length > 0 && this.session) {
+          for (const delivery of this.pendingDeliveries) {
+            this.session.sendCustomMessage(
+              {
+                customType: 'agent_message',
+                content: delivery.content,
+                display: false,
+                details: delivery.details,
+              },
+              {
+                deliverAs: delivery.urgent ? 'steer' : 'followUp',
+                triggerTurn: true,
+              }
+            );
+          }
+        }
         return;
       }
       // Recovery was a no-op — reset guard so a future overflow can try again

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -440,17 +440,21 @@ export class AgentHost {
       // handlePotentialError before agent_end fires). Skip cleanup so the
       // failed prompt/delivery stays tracked for retry or failover.
       if (!this.lastTurnErrored) {
-        this.pendingPrompt = null;
+        const messages =
+          'messages' in event ? (event.messages as Array<Record<string, unknown>>) : null;
+        // Only clear pendingPrompt when a prompt turn (user message) completed.
+        // A delivery-only agent_end (only custom messages) should not clear it,
+        // since a queued prompt may still be waiting to process.
+        if (!messages || messages.some((m) => m.role === 'user')) {
+          this.pendingPrompt = null;
+        }
         // Count delivery messages that completed in this agent loop. The SDK
         // batches follow-up turns into a single agent_end, so a prompt turn
         // followed by queued deliveries produces one event with mixed messages.
         // Only shift for actual deliveries to avoid desync.
-        const deliveriesCompleted =
-          'messages' in event
-            ? (event.messages as Array<Record<string, unknown>>).filter(
-                (m) => m.role === 'custom' && m.customType === 'agent_message'
-              ).length
-            : 0;
+        const deliveriesCompleted = messages
+          ? messages.filter((m) => m.role === 'custom' && m.customType === 'agent_message').length
+          : 0;
         for (let i = 0; i < deliveriesCompleted && this.pendingDeliveries.length > 0; i++) {
           const completed = this.pendingDeliveries.shift()!;
           completed.resolve();
@@ -570,18 +574,22 @@ export class AgentHost {
           // Swallow reload errors to avoid dropping the retry
         }
         const failed = deliveriesToRetry[0];
-        this.session.sendCustomMessage(
-          {
-            customType: 'agent_message',
-            content: failed.content,
-            display: false,
-            details: failed.details,
-          },
-          {
-            deliverAs: failed.urgent ? 'steer' : 'followUp',
-            triggerTurn: true,
-          }
-        );
+        this.session
+          .sendCustomMessage(
+            {
+              customType: 'agent_message',
+              content: failed.content,
+              display: false,
+              details: failed.details,
+            },
+            {
+              deliverAs: failed.urgent ? 'steer' : 'followUp',
+              triggerTurn: true,
+            }
+          )
+          .catch((error) => {
+            console.error('[AgentHost] Failed to resend delivery after retry:', error);
+          });
       }
       return;
     }
@@ -654,18 +662,25 @@ export class AgentHost {
         // pendingDeliveries: agent_end will shift each one as turns succeed.
         if (this.pendingDeliveries.length > 0 && this.session) {
           for (const delivery of this.pendingDeliveries) {
-            this.session.sendCustomMessage(
-              {
-                customType: 'agent_message',
-                content: delivery.content,
-                display: false,
-                details: delivery.details,
-              },
-              {
-                deliverAs: delivery.urgent ? 'steer' : 'followUp',
-                triggerTurn: true,
-              }
-            );
+            this.session
+              .sendCustomMessage(
+                {
+                  customType: 'agent_message',
+                  content: delivery.content,
+                  display: false,
+                  details: delivery.details,
+                },
+                {
+                  deliverAs: delivery.urgent ? 'steer' : 'followUp',
+                  triggerTurn: true,
+                }
+              )
+              .catch((error) => {
+                console.error(
+                  '[AgentHost] Failed to replay delivery after context overflow:',
+                  error
+                );
+              });
           }
         }
         return;
@@ -795,18 +810,22 @@ export class AgentHost {
         this.pendingDeliveries = [...deliveriesToRetry];
         const session = this.session;
         for (const d of deliveriesToRetry) {
-          session.sendCustomMessage(
-            {
-              customType: 'agent_message',
-              content: d.content,
-              display: false,
-              details: d.details,
-            },
-            {
-              deliverAs: d.urgent ? 'steer' : 'followUp',
-              triggerTurn: true,
-            }
-          );
+          session
+            .sendCustomMessage(
+              {
+                customType: 'agent_message',
+                content: d.content,
+                display: false,
+                details: d.details,
+              },
+              {
+                deliverAs: d.urgent ? 'steer' : 'followUp',
+                triggerTurn: true,
+              }
+            )
+            .catch((error) => {
+              console.error('[AgentHost] Failed to replay delivery after failover:', error);
+            });
         }
       }
     } catch (error) {

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -547,6 +547,7 @@ export class AgentHost {
       } else if (deliveriesToRetry.length > 0 && this.session) {
         // Retry the failed delivery (no prompt took priority)
         console.log('[AgentHost] Retrying failed delivery...');
+        await this.resourceLoader?.reload();
         const failed = deliveriesToRetry[0];
         this.session.sendCustomMessage(
           {

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -439,7 +439,17 @@ export class AgentHost {
       // failed prompt/delivery stays tracked for retry or failover.
       if (!this.lastTurnErrored) {
         this.pendingPrompt = null;
-        if (this.pendingDeliveries.length > 0) {
+        // Count delivery messages that completed in this agent loop. The SDK
+        // batches follow-up turns into a single agent_end, so a prompt turn
+        // followed by queued deliveries produces one event with mixed messages.
+        // Only shift for actual deliveries to avoid desync.
+        const deliveriesCompleted =
+          'messages' in event
+            ? (event.messages as Array<Record<string, unknown>>).filter(
+                (m) => m.role === 'custom' && m.customType === 'agent_message'
+              ).length
+            : 0;
+        for (let i = 0; i < deliveriesCompleted && this.pendingDeliveries.length > 0; i++) {
           this.pendingDeliveries.shift();
         }
       }

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -557,7 +557,11 @@ export class AgentHost {
       } else if (deliveriesToRetry.length > 0 && this.session) {
         // Retry the failed delivery (no prompt took priority)
         console.log('[AgentHost] Retrying failed delivery...');
-        await this.resourceLoader?.reload();
+        try {
+          await this.resourceLoader?.reload();
+        } catch {
+          // Swallow reload errors to avoid dropping the retry
+        }
         const failed = deliveriesToRetry[0];
         this.session.sendCustomMessage(
           {

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -149,6 +149,11 @@ export class AgentHost {
   private retryAttempts: Map<string, number> = new Map(); // Track retries per error type
   private isReinitializing = false;
   private pendingPrompt: string | null = null;
+  private pendingDeliveries: Array<{
+    content: string;
+    details: { sender: number; receiver: number; timestamp: number };
+    urgent?: boolean;
+  }> = [];
   private agentRole: string | null = null;
   private agentProject: number | null = null;
   private agentProjectDirName: string | null = null;
@@ -157,6 +162,7 @@ export class AgentHost {
   private chatMaxMessages: number;
   private resourceLoader: DefaultResourceLoader | null = null;
   private busy = false;
+  private lastTurnErrored = false;
   private compactionCount = 0;
   private compactionDepth = 0;
   private isPruning = false;
@@ -428,11 +434,16 @@ export class AgentHost {
       if (this.busy) {
         this.busy = false;
       }
-      // Clear pendingPrompt here — not in prompt() after session.prompt() returns.
-      // When streamingBehavior is 'followUp' or 'steer', session.prompt() queues
-      // the message and returns immediately, so clearing it there would be too early.
-      // Waiting for agent_end ensures the message stays retryable until the turn runs.
-      this.pendingPrompt = null;
+      // On error turns, lastTurnErrored is true (set synchronously in
+      // handlePotentialError before agent_end fires). Skip cleanup so the
+      // failed prompt/delivery stays tracked for retry or failover.
+      if (!this.lastTurnErrored) {
+        this.pendingPrompt = null;
+        if (this.pendingDeliveries.length > 0) {
+          this.pendingDeliveries.shift();
+        }
+      }
+      this.lastTurnErrored = false;
     }
 
     // Track compaction for pruning
@@ -460,6 +471,11 @@ export class AgentHost {
     // Don't handle errors while already reinitializing (session setup in progress)
     if (this.isReinitializing) return;
 
+    // Flag this turn as errored so agent_end does not clear pendingPrompt
+    // or shift pendingDeliveries. Must be set synchronously (before any await)
+    // because agent_end fires synchronously after message_end.
+    this.lastTurnErrored = true;
+
     const errorMessage = message.errorMessage;
     console.log('[AgentHost] API error detected:', errorMessage);
 
@@ -474,9 +490,11 @@ export class AgentHost {
     const retryKey = `${this.currentProvider}:${category}`;
     const currentAttempts = this.retryAttempts.get(retryKey) ?? 0;
 
-    // Capture before any await — agent_end clears pendingPrompt synchronously, but this
-    // handler yields at the first await. The ?? promptToRetry pattern below restores it.
+    // Capture before any await. With lastTurnErrored, agent_end won't clear these
+    // on error turns, but we still snapshot for the failover path where
+    // reinitializeWithProvider needs the values passed as arguments.
     const promptToRetry = this.pendingPrompt;
+    const deliveriesToRetry = [...this.pendingDeliveries];
 
     // If another agent already put our key in cooldown, skip retries and reinitialize.
     // Uses the tracked key index so we check our actual key, not whatever index
@@ -495,7 +513,13 @@ export class AgentHost {
         console.log(
           `[AgentHost] Key ${this.currentProvider}:${this.currentKeyIndex} already in cooldown`
         );
-        await this.reinitializeWithProvider(nextProvider, promptToRetry, reason, detail);
+        await this.reinitializeWithProvider(
+          nextProvider,
+          promptToRetry,
+          deliveriesToRetry,
+          reason,
+          detail
+        );
         return;
       }
     }
@@ -520,6 +544,22 @@ export class AgentHost {
         this.pendingPrompt = this.pendingPrompt ?? promptToRetry;
         await this.resourceLoader?.reload();
         await this.session.prompt(promptToRetry, { streamingBehavior: 'followUp' });
+      } else if (deliveriesToRetry.length > 0 && this.session) {
+        // Retry the failed delivery (no prompt took priority)
+        console.log('[AgentHost] Retrying failed delivery...');
+        const failed = deliveriesToRetry[0];
+        this.session.sendCustomMessage(
+          {
+            customType: 'agent_message',
+            content: failed.content,
+            display: false,
+            details: failed.details,
+          },
+          {
+            deliverAs: failed.urgent ? 'steer' : 'followUp',
+            triggerTurn: true,
+          }
+        );
       }
       return;
     }
@@ -548,12 +588,24 @@ export class AgentHost {
             const reason = `${errorPrefix}, rotating to next key`;
             const detail = `on ${this.currentProvider}, rotating to next key`;
             console.log(`[AgentHost] Rotating to next key for ${this.currentProvider}`);
-            await this.reinitializeWithProvider(nextProvider, promptToRetry, reason, detail);
+            await this.reinitializeWithProvider(
+              nextProvider,
+              promptToRetry,
+              deliveriesToRetry,
+              reason,
+              detail
+            );
           } else {
             const reason = `${errorPrefix}, switched to ${nextProvider}`;
             const detail = `on ${this.currentProvider}, switching to ${nextProvider}`;
             console.log(`[AgentHost] Failing over from ${this.currentProvider} to ${nextProvider}`);
-            await this.reinitializeWithProvider(nextProvider, promptToRetry, reason, detail);
+            await this.reinitializeWithProvider(
+              nextProvider,
+              promptToRetry,
+              deliveriesToRetry,
+              reason,
+              detail
+            );
           }
           return;
         }
@@ -591,7 +643,13 @@ export class AgentHost {
       console.log(
         `[AgentHost] Recovery: switching from ${this.currentProvider} to ${nextProvider}`
       );
-      await this.reinitializeWithProvider(nextProvider, promptToRetry, reason, detail);
+      await this.reinitializeWithProvider(
+        nextProvider,
+        promptToRetry,
+        deliveriesToRetry,
+        reason,
+        detail
+      );
       return;
     }
 
@@ -611,6 +669,11 @@ export class AgentHost {
   private async reinitializeWithProvider(
     provider: LlmProvider,
     promptToRetry?: string | null,
+    deliveriesToRetry?: Array<{
+      content: string;
+      details: { sender: number; receiver: number; timestamp: number };
+      urgent?: boolean;
+    }>,
     reason?: string,
     detail?: string
   ): Promise<void> {
@@ -671,6 +734,32 @@ export class AgentHost {
         // Restore only if nothing newer arrived during reinitialization.
         this.pendingPrompt = this.pendingPrompt ?? promptToRetry;
         await this.session.prompt(promptToRetry, { streamingBehavior: 'followUp' });
+      }
+
+      // Replay pending custom-message deliveries (scheduled tasks, inter-agent messages).
+      // These were queued in the old session which was destroyed during reinit.
+      // Uses sendCustomMessage directly (not deliverMessage) to avoid duplicating
+      // chat cache entries that were already added by the original delivery.
+      if (deliveriesToRetry && deliveriesToRetry.length > 0 && this.session) {
+        console.log(
+          `[AgentHost] Replaying ${deliveriesToRetry.length} pending deliveries with new provider...`
+        );
+        this.pendingDeliveries = [...deliveriesToRetry];
+        const session = this.session;
+        for (const d of deliveriesToRetry) {
+          session.sendCustomMessage(
+            {
+              customType: 'agent_message',
+              content: d.content,
+              display: false,
+              details: d.details,
+            },
+            {
+              deliverAs: d.urgent ? 'steer' : 'followUp',
+              triggerTurn: true,
+            }
+          );
+        }
       }
     } catch (error) {
       console.error('[AgentHost] Failed to reinitialize:', error);
@@ -861,6 +950,11 @@ export class AgentHost {
       throw new Error('AgentHost not initialized. Call initialize() first.');
     }
 
+    // Track for failover retry. If the session is destroyed during reinitialization,
+    // queued sendCustomMessage calls are lost. This queue lets handlePotentialError
+    // replay them on the new session. Cleared per-turn by agent_end (shift).
+    this.pendingDeliveries.push({ content, details, urgent });
+
     // Capture delivered message in chat cache for UI history.
     // Inter-agent messages and summaries store full content (tag + body).
     // Scheduled/triggered tasks store only the tag. Untagged content is truncated.
@@ -933,11 +1027,12 @@ export class AgentHost {
   abort(): void {
     if (this.session) {
       this.session.abort();
-      // abort() may not trigger agent_end, so clear busy and pendingPrompt explicitly
+      // abort() may not trigger agent_end, so clear busy and pending state explicitly
       if (this.busy) {
         this.busy = false;
       }
       this.pendingPrompt = null;
+      this.pendingDeliveries = [];
     }
   }
 

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -555,7 +555,11 @@ export class AgentHost {
         // Restore only if nothing newer arrived during sleep — a new prompt() call during the
         // delay would have set pendingPrompt to the newer message; don't overwrite it.
         this.pendingPrompt = this.pendingPrompt ?? promptToRetry;
-        await this.resourceLoader?.reload();
+        try {
+          await this.resourceLoader?.reload();
+        } catch {
+          // Swallow reload errors to avoid dropping the retry; continue with cached resources
+        }
         await this.session.prompt(promptToRetry, { streamingBehavior: 'followUp' });
       } else if (deliveriesToRetry.length > 0 && this.session) {
         // Retry the failed delivery (no prompt took priority)

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -589,6 +589,9 @@ export class AgentHost {
           )
           .catch((error) => {
             console.error('[AgentHost] Failed to resend delivery after retry:', error);
+            const idx = this.pendingDeliveries.indexOf(failed);
+            if (idx !== -1) this.pendingDeliveries.splice(idx, 1);
+            failed.reject(error instanceof Error ? error : new Error(String(error)));
           });
       }
       return;
@@ -680,6 +683,9 @@ export class AgentHost {
                   '[AgentHost] Failed to replay delivery after context overflow:',
                   error
                 );
+                const idx = this.pendingDeliveries.indexOf(delivery);
+                if (idx !== -1) this.pendingDeliveries.splice(idx, 1);
+                delivery.reject(error instanceof Error ? error : new Error(String(error)));
               });
           }
         }
@@ -825,6 +831,9 @@ export class AgentHost {
             )
             .catch((error) => {
               console.error('[AgentHost] Failed to replay delivery after failover:', error);
+              const idx = this.pendingDeliveries.indexOf(d);
+              if (idx !== -1) this.pendingDeliveries.splice(idx, 1);
+              d.reject(error instanceof Error ? error : new Error(String(error)));
             });
         }
       }

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -561,8 +561,11 @@ export class AgentHost {
         this.pendingPrompt = this.pendingPrompt ?? promptToRetry;
         try {
           await this.resourceLoader?.reload();
-        } catch {
-          // Swallow reload errors to avoid dropping the retry; continue with cached resources
+        } catch (reloadErr) {
+          console.warn(
+            '[AgentHost] Resource reload failed before prompt retry, using cached:',
+            reloadErr
+          );
         }
         await this.session.prompt(promptToRetry, { streamingBehavior: 'followUp' });
       } else if (deliveriesToRetry.length > 0 && this.session) {
@@ -570,8 +573,11 @@ export class AgentHost {
         console.log('[AgentHost] Retrying failed delivery...');
         try {
           await this.resourceLoader?.reload();
-        } catch {
-          // Swallow reload errors to avoid dropping the retry
+        } catch (reloadErr) {
+          console.warn(
+            '[AgentHost] Resource reload failed before delivery retry, using cached:',
+            reloadErr
+          );
         }
         const failed = deliveriesToRetry[0];
         this.session
@@ -813,7 +819,13 @@ export class AgentHost {
         console.log(
           `[AgentHost] Replaying ${deliveriesToRetry.length} pending deliveries with new provider...`
         );
-        this.pendingDeliveries = [...deliveriesToRetry];
+        // Merge: deliveries queued by concurrent deliverMessage() during async
+        // reinit must be preserved (this.session was non-null throughout initialize(),
+        // so new deliverMessage calls could push entries we must not drop).
+        const newDuringReinit = this.pendingDeliveries.filter(
+          (d) => !deliveriesToRetry.includes(d)
+        );
+        this.pendingDeliveries = [...deliveriesToRetry, ...newDuringReinit];
         const session = this.session;
         for (const d of deliveriesToRetry) {
           session
@@ -1008,10 +1020,11 @@ export class AgentHost {
    * Deliver an inter-agent message into this agent's session.
    * Uses sendCustomMessage with customType 'agent_message'.
    *
-   * Fire-and-forget: does NOT await the triggered turn. When the receiver is
-   * idle, sendCustomMessage internally calls agent.prompt() which blocks until
-   * the entire turn completes — awaiting that would deadlock the caller if
-   * agents message each other during their turns.
+   * Returns a Promise that resolves when agent_end confirms the delivery was
+   * processed, or rejects on permanent failure (all providers exhausted, abort,
+   * or send failure). Callers outside agent turns (e.g., scheduler jobs) can
+   * await it; callers inside agent turns should NOT await it to avoid deadlocks
+   * (sendCustomMessage internally calls agent.prompt() when the receiver is idle).
    *
    * @param content LLM-visible message content (includes sender prefix)
    * @param details Metadata for programmatic use (not sent to LLM)

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -153,6 +153,8 @@ export class AgentHost {
     content: string;
     details: { sender: number; receiver: number; timestamp: number };
     urgent?: boolean;
+    resolve: () => void;
+    reject: (reason: Error) => void;
   }> = [];
   private agentRole: string | null = null;
   private agentProject: number | null = null;
@@ -450,7 +452,8 @@ export class AgentHost {
               ).length
             : 0;
         for (let i = 0; i < deliveriesCompleted && this.pendingDeliveries.length > 0; i++) {
-          this.pendingDeliveries.shift();
+          const completed = this.pendingDeliveries.shift()!;
+          completed.resolve();
         }
       }
       this.lastTurnErrored = false;
@@ -691,6 +694,12 @@ export class AgentHost {
       this.busy = false;
     }
 
+    // Permanently failed: reject all pending delivery promises
+    for (const delivery of this.pendingDeliveries) {
+      delivery.reject(new Error(`All providers exhausted: ${errorMessage}`));
+    }
+    this.pendingDeliveries = [];
+
     // Reset retry attempts for next error
     this.retryAttempts.clear();
   }
@@ -706,6 +715,8 @@ export class AgentHost {
       content: string;
       details: { sender: number; receiver: number; timestamp: number };
       urgent?: boolean;
+      resolve: () => void;
+      reject: (reason: Error) => void;
     }>,
     reason?: string,
     detail?: string
@@ -978,15 +989,25 @@ export class AgentHost {
     content: string,
     details: { sender: number; receiver: number; timestamp: number },
     urgent?: boolean
-  ): void {
+  ): Promise<void> {
     if (!this.session) {
       throw new Error('AgentHost not initialized. Call initialize() first.');
     }
 
+    // Create deferred promise for completion notification. Resolves when
+    // agent_end confirms the delivery was processed, rejects on permanent
+    // failure (all providers exhausted, abort, or send failure).
+    let resolve!: () => void;
+    let reject!: (reason: Error) => void;
+    const promise = new Promise<void>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
     // Track for failover retry. If the session is destroyed during reinitialization,
     // queued sendCustomMessage calls are lost. This queue lets handlePotentialError
     // replay them on the new session. Cleared per-turn by agent_end (shift).
-    this.pendingDeliveries.push({ content, details, urgent });
+    this.pendingDeliveries.push({ content, details, urgent, resolve, reject });
 
     // Capture delivered message in chat cache for UI history.
     // Inter-agent messages and summaries store full content (tag + body).
@@ -1051,7 +1072,20 @@ export class AgentHost {
           }
         )
       )
-      .catch((err) => console.error('[AgentHost] deliverMessage error:', err));
+      .catch((err) => {
+        console.error('[AgentHost] deliverMessage error:', err);
+        // Send itself failed (session destroyed, etc.). The message never
+        // reached the agent, so remove from queue and reject immediately.
+        const idx = this.pendingDeliveries.findIndex((d) => d.resolve === resolve);
+        if (idx !== -1) {
+          this.pendingDeliveries.splice(idx, 1);
+          reject(
+            new Error(`Delivery send failed: ${err instanceof Error ? err.message : String(err)}`)
+          );
+        }
+      });
+
+    return promise;
   }
 
   /**
@@ -1065,6 +1099,9 @@ export class AgentHost {
         this.busy = false;
       }
       this.pendingPrompt = null;
+      for (const delivery of this.pendingDeliveries) {
+        delivery.reject(new Error('Agent session aborted'));
+      }
       this.pendingDeliveries = [];
     }
   }

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -1036,7 +1036,10 @@ export class AgentHost {
     urgent?: boolean
   ): Promise<void> {
     if (!this.session) {
-      throw new Error('AgentHost not initialized. Call initialize() first.');
+      return Promise.reject(new Error('AgentHost not initialized. Call initialize() first.'));
+    }
+    if (this.isReinitializing) {
+      return Promise.reject(new Error('Agent is reinitializing, delivery rejected'));
     }
 
     // Create deferred promise for completion notification. Resolves when

--- a/packages/server/src/agents/tools/message-agent.test.ts
+++ b/packages/server/src/agents/tools/message-agent.test.ts
@@ -16,7 +16,7 @@ function makeAgent(id: number, role: string): Agent {
 }
 
 function setup(selfId: number, agents: Agent[], registeredIds: number[]) {
-  const deliverMessage = vi.fn().mockReturnValue(undefined);
+  const deliverMessage = vi.fn().mockReturnValue(Promise.resolve());
   const db = {
     getAgent: (id: number) => agents.find((a) => a.id === id) ?? null,
   } as unknown as DatabaseClient;

--- a/packages/server/src/agents/tools/message-agent.ts
+++ b/packages/server/src/agents/tools/message-agent.ts
@@ -86,11 +86,9 @@ export function createMessageAgentTool(
       const timestamp = Date.now();
 
       try {
-        receiverHost.deliverMessage(
-          content,
-          { sender: selfId, receiver: agent_id, timestamp },
-          urgent
-        );
+        receiverHost
+          .deliverMessage(content, { sender: selfId, receiver: agent_id, timestamp }, urgent)
+          .catch((err) => console.error('[message-agent] delivery failed:', err));
 
         return {
           content: [

--- a/packages/server/src/agents/tools/trigger-project-story.test.ts
+++ b/packages/server/src/agents/tools/trigger-project-story.test.ts
@@ -49,7 +49,7 @@ function setup(
   narratorIds: number[] = [],
   registeredNarratorIds: number[] = narratorIds
 ) {
-  const deliverMessage = vi.fn();
+  const deliverMessage = vi.fn().mockReturnValue(Promise.resolve());
   const createTask = vi.fn().mockReturnValue({ id: 100 } as Task);
 
   const db = {

--- a/packages/server/src/agents/tools/trigger-project-story.ts
+++ b/packages/server/src/agents/tools/trigger-project-story.ts
@@ -181,11 +181,13 @@ ${agentActivity}
 
 ${projectDbChanges}`;
 
-        narratorHost.deliverMessage(projectLogMessage, {
-          sender: agentId,
-          receiver: narratorId,
-          timestamp: Date.now(),
-        });
+        narratorHost
+          .deliverMessage(projectLogMessage, {
+            sender: agentId,
+            receiver: narratorId,
+            timestamp: Date.now(),
+          })
+          .catch((err) => console.error('[trigger-project-story] log delivery failed:', err));
 
         // --- Message 2: Project story data ---
         // Full app.db snapshot (not time-windowed)
@@ -252,11 +254,13 @@ Note: This log was captured before your preceding log update. Incorporate what y
 
 ${logContent}`;
 
-        narratorHost.deliverMessage(projectStoryMessage, {
-          sender: agentId,
-          receiver: narratorId,
-          timestamp: Date.now(),
-        });
+        narratorHost
+          .deliverMessage(projectStoryMessage, {
+            sender: agentId,
+            receiver: narratorId,
+            timestamp: Date.now(),
+          })
+          .catch((err) => console.error('[trigger-project-story] story delivery failed:', err));
 
         return {
           content: [

--- a/packages/server/src/chat/summarizer.test.ts
+++ b/packages/server/src/chat/summarizer.test.ts
@@ -15,7 +15,7 @@ import { oneShotComplete } from '../llm/oneshot.js';
 import { ConversationSummarizer } from './summarizer.js';
 
 function makeGuideHost() {
-  return { deliverMessage: vi.fn() } as unknown as AgentHost;
+  return { deliverMessage: vi.fn().mockReturnValue(Promise.resolve()) } as unknown as AgentHost;
 }
 
 function makeSummarizer(guideAgentId = 1) {

--- a/packages/server/src/chat/summarizer.ts
+++ b/packages/server/src/chat/summarizer.ts
@@ -133,14 +133,13 @@ export class ConversationSummarizer {
       });
 
       // Deliver summary to Guide
-      this.guideHost.deliverMessage(
-        `[Conversation: user <-> ${buffer.agentRole}_${agentId}]\n\n${summary}`,
-        {
+      this.guideHost
+        .deliverMessage(`[Conversation: user <-> ${buffer.agentRole}_${agentId}]\n\n${summary}`, {
           sender: agentId,
           receiver: this.guideAgentId,
           timestamp: Date.now(),
-        }
-      );
+        })
+        .catch((err) => console.error('[ConversationSummarizer] delivery failed:', err));
     } catch (err) {
       console.error('[ConversationSummarizer] Failed to generate summary:', err);
     }

--- a/packages/server/src/reminders/manager.test.ts
+++ b/packages/server/src/reminders/manager.test.ts
@@ -21,7 +21,7 @@ describe('ReminderManager', () => {
   });
 
   it('schedules a reminder and fires it after delay', () => {
-    const deliverMessage = vi.fn();
+    const deliverMessage = vi.fn().mockReturnValue(Promise.resolve());
     const registry = makeRegistry({ 1: { deliverMessage } });
     const manager = new ReminderManager(registry);
 
@@ -42,7 +42,9 @@ describe('ReminderManager', () => {
   });
 
   it('assigns incrementing IDs', () => {
-    const registry = makeRegistry({ 1: { deliverMessage: vi.fn() } });
+    const registry = makeRegistry({
+      1: { deliverMessage: vi.fn().mockReturnValue(Promise.resolve()) },
+    });
     const manager = new ReminderManager(registry);
 
     const r1 = manager.schedule(1, 'first', 10);
@@ -53,7 +55,7 @@ describe('ReminderManager', () => {
   });
 
   it('cancels a pending reminder', () => {
-    const deliverMessage = vi.fn();
+    const deliverMessage = vi.fn().mockReturnValue(Promise.resolve());
     const registry = makeRegistry({ 1: { deliverMessage } });
     const manager = new ReminderManager(registry);
 
@@ -67,7 +69,9 @@ describe('ReminderManager', () => {
   });
 
   it('rejects cancel for wrong agent', () => {
-    const registry = makeRegistry({ 1: { deliverMessage: vi.fn() } });
+    const registry = makeRegistry({
+      1: { deliverMessage: vi.fn().mockReturnValue(Promise.resolve()) },
+    });
     const manager = new ReminderManager(registry);
 
     const { id } = manager.schedule(1, 'agent 1 reminder', 5);
@@ -85,8 +89,8 @@ describe('ReminderManager', () => {
 
   it('lists reminders for a specific agent', () => {
     const registry = makeRegistry({
-      1: { deliverMessage: vi.fn() },
-      2: { deliverMessage: vi.fn() },
+      1: { deliverMessage: vi.fn().mockReturnValue(Promise.resolve()) },
+      2: { deliverMessage: vi.fn().mockReturnValue(Promise.resolve()) },
     });
     const manager = new ReminderManager(registry);
 
@@ -104,7 +108,9 @@ describe('ReminderManager', () => {
   });
 
   it('removes reminder from list after firing', () => {
-    const registry = makeRegistry({ 1: { deliverMessage: vi.fn() } });
+    const registry = makeRegistry({
+      1: { deliverMessage: vi.fn().mockReturnValue(Promise.resolve()) },
+    });
     const manager = new ReminderManager(registry);
 
     manager.schedule(1, 'will fire', 5);
@@ -127,7 +133,7 @@ describe('ReminderManager', () => {
   });
 
   it('stop() clears all timers', () => {
-    const deliverMessage = vi.fn();
+    const deliverMessage = vi.fn().mockReturnValue(Promise.resolve());
     const registry = makeRegistry({ 1: { deliverMessage } });
     const manager = new ReminderManager(registry);
 

--- a/packages/server/src/reminders/manager.ts
+++ b/packages/server/src/reminders/manager.ts
@@ -86,6 +86,8 @@ export class ReminderManager {
     }
 
     const content = `[Reminder #${reminderId}]\n\n${reminder.message}`;
-    host.deliverMessage(content, { sender: 0, receiver: reminder.agentId, timestamp: Date.now() });
+    host
+      .deliverMessage(content, { sender: 0, receiver: reminder.agentId, timestamp: Date.now() })
+      .catch((err) => console.error('[ReminderManager] delivery failed:', err));
   }
 }

--- a/packages/server/src/scheduler/jobs.test.ts
+++ b/packages/server/src/scheduler/jobs.test.ts
@@ -45,6 +45,7 @@ function mockNarratorHost(): AgentHost & { calls: Array<{ content: string; detai
     calls,
     deliverMessage(content: string, details: unknown) {
       calls.push({ content, details });
+      return Promise.resolve();
     },
   } as unknown as AgentHost & { calls: Array<{ content: string; details: unknown }> };
 }
@@ -206,7 +207,7 @@ describe('collectAgentActivity', () => {
 });
 
 describe('buildAndDeliverMemoryUpdate', () => {
-  it('skips delivery when no daily summary files exist', () => {
+  it('skips delivery when no daily summary files exist', async () => {
     const dir = trackTmpDir(makeTmpDir());
     const knowledgeDir = join(dir, 'knowledge');
     mkdirSync(knowledgeDir, { recursive: true });
@@ -216,11 +217,11 @@ describe('buildAndDeliverMemoryUpdate', () => {
     );
 
     const host = mockNarratorHost();
-    buildAndDeliverMemoryUpdate(host, 2, dir);
+    await buildAndDeliverMemoryUpdate(host, 2, dir);
     expect(host.calls).toHaveLength(0);
   });
 
-  it('skips delivery when all summaries are older than last update', () => {
+  it('skips delivery when all summaries are older than last update', async () => {
     const dir = trackTmpDir(makeTmpDir());
     const knowledgeDir = join(dir, 'knowledge');
     const summariesDir = join(knowledgeDir, 'daily_summaries');
@@ -232,11 +233,11 @@ describe('buildAndDeliverMemoryUpdate', () => {
     writeFileSync(join(summariesDir, '2026-03-10.md'), '---\n---\n# Old summary');
 
     const host = mockNarratorHost();
-    buildAndDeliverMemoryUpdate(host, 2, dir);
+    await buildAndDeliverMemoryUpdate(host, 2, dir);
     expect(host.calls).toHaveLength(0);
   });
 
-  it('delivers message with embedded summary content since last update', () => {
+  it('delivers message with embedded summary content since last update', async () => {
     const dir = trackTmpDir(makeTmpDir());
     const knowledgeDir = join(dir, 'knowledge');
     const summariesDir = join(knowledgeDir, 'daily_summaries');
@@ -256,7 +257,7 @@ describe('buildAndDeliverMemoryUpdate', () => {
     writeFileSync(join(summariesDir, '2026-03-09.md'), '---\n---\n# Before\nOld narrative.');
 
     const host = mockNarratorHost();
-    buildAndDeliverMemoryUpdate(host, 2, dir);
+    await buildAndDeliverMemoryUpdate(host, 2, dir);
     expect(host.calls).toHaveLength(1);
 
     const msg = host.calls[0].content;
@@ -271,7 +272,7 @@ describe('buildAndDeliverMemoryUpdate', () => {
     expect(msg).toContain('UTC ISO 8601');
   });
 
-  it('includes all summaries when memory.md has no timestamp', () => {
+  it('includes all summaries when memory.md has no timestamp', async () => {
     const dir = trackTmpDir(makeTmpDir());
     const knowledgeDir = join(dir, 'knowledge');
     const summariesDir = join(knowledgeDir, 'daily_summaries');
@@ -280,7 +281,7 @@ describe('buildAndDeliverMemoryUpdate', () => {
     writeFileSync(join(summariesDir, '2026-03-10.md'), '---\n---\n# Summary\nNarrative content.');
 
     const host = mockNarratorHost();
-    buildAndDeliverMemoryUpdate(host, 2, dir);
+    await buildAndDeliverMemoryUpdate(host, 2, dir);
     expect(host.calls).toHaveLength(1);
     expect(host.calls[0].content).toContain('Narrative content.');
   });
@@ -691,6 +692,7 @@ describe('buildAndDeliverDailySummary', () => {
       calls,
       deliverMessage(content: string, details: unknown) {
         calls.push({ content, details });
+        return Promise.resolve();
       },
     } as unknown as AgentHost & { calls: Array<{ content: string; details: unknown }> };
   }
@@ -708,7 +710,7 @@ describe('buildAndDeliverDailySummary', () => {
     } as unknown as DatabaseClient;
   }
 
-  it('skips when file has content but no new activity', () => {
+  it('skips when file has content but no new activity', async () => {
     const dir = trackTmpDir(makeTmpDir());
     const summariesDir = join(dir, 'knowledge', 'daily_summaries');
     mkdirSync(summariesDir, { recursive: true });
@@ -720,20 +722,20 @@ describe('buildAndDeliverDailySummary', () => {
 
     const host = mockHost();
     const db = mockDb([{ id: 1, role: 'guide', project_name: null }]);
-    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+    await buildAndDeliverDailySummary(db, host, 99, dir, 30);
     expect(host.calls).toHaveLength(0);
   });
 
-  it('skips on first run with no activity', () => {
+  it('skips on first run with no activity', async () => {
     const dir = trackTmpDir(makeTmpDir());
 
     const host = mockHost();
     const db = mockDb([{ id: 1, role: 'guide', project_name: null }]);
-    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+    await buildAndDeliverDailySummary(db, host, 99, dir, 30);
     expect(host.calls).toHaveLength(0);
   });
 
-  it('delivers when non-project agent has JSONL activity', () => {
+  it('delivers when non-project agent has JSONL activity', async () => {
     const dir = trackTmpDir(makeTmpDir());
     const summariesDir = join(dir, 'knowledge', 'daily_summaries');
     const sessionDir = join(dir, 'sessions', 'guide_1');
@@ -757,13 +759,13 @@ describe('buildAndDeliverDailySummary', () => {
 
     const host = mockHost();
     const db = mockDb([{ id: 1, role: 'guide', project_name: null }]);
-    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+    await buildAndDeliverDailySummary(db, host, 99, dir, 30);
 
     expect(host.calls).toHaveLength(1);
     expect(host.calls[0].content).toContain('[Scheduled task: daily-summary]');
   });
 
-  it('delivers when project has DB changes', () => {
+  it('delivers when project has DB changes', async () => {
     const dir = trackTmpDir(makeTmpDir());
 
     const host = mockHost();
@@ -786,14 +788,14 @@ describe('buildAndDeliverDailySummary', () => {
       },
     } as unknown as DatabaseClient;
 
-    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+    await buildAndDeliverDailySummary(db, host, 99, dir, 30);
 
     expect(host.calls.length).toBeGreaterThanOrEqual(1);
     const messages = host.calls.map((c) => c.content);
     expect(messages.some((m) => m.includes('[Scheduled task: daily-summary]'))).toBe(true);
   });
 
-  it('includes existing file content in the delivered message', () => {
+  it('includes existing file content in the delivered message', async () => {
     const dir = trackTmpDir(makeTmpDir());
     const summariesDir = join(dir, 'knowledge', 'daily_summaries');
     const sessionDir = join(dir, 'sessions', 'guide_1');
@@ -816,13 +818,13 @@ describe('buildAndDeliverDailySummary', () => {
 
     const host = mockHost();
     const db = mockDb([{ id: 1, role: 'guide', project_name: null }]);
-    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+    await buildAndDeliverDailySummary(db, host, 99, dir, 30);
 
     expect(host.calls).toHaveLength(1);
     expect(host.calls[0].content).toContain('Prior narrative here.');
   });
 
-  it('excludes inactive projects from the message', () => {
+  it('excludes inactive projects from the message', async () => {
     const dir = trackTmpDir(makeTmpDir());
     const sessionDir = join(dir, 'sessions', 'guide_1');
     mkdirSync(sessionDir, { recursive: true });
@@ -854,7 +856,7 @@ describe('buildAndDeliverDailySummary', () => {
       ],
       [{ id: 1, name: 'InactiveProject' }]
     );
-    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+    await buildAndDeliverDailySummary(db, host, 99, dir, 30);
 
     const dailySummaryMsg = host.calls
       .map((c) => c.content)
@@ -865,7 +867,7 @@ describe('buildAndDeliverDailySummary', () => {
     expect(dailySummaryMsg).toContain('## Non-Project Activity');
   });
 
-  it('includes only active projects when multiple exist', () => {
+  it('includes only active projects when multiple exist', async () => {
     const dir = trackTmpDir(makeTmpDir());
 
     const host = mockHost();
@@ -892,7 +894,7 @@ describe('buildAndDeliverDailySummary', () => {
       },
     } as unknown as DatabaseClient;
 
-    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+    await buildAndDeliverDailySummary(db, host, 99, dir, 30);
 
     const dailySummaryMsg = host.calls
       .map((c) => c.content)
@@ -902,7 +904,7 @@ describe('buildAndDeliverDailySummary', () => {
     expect(dailySummaryMsg).not.toContain('IdleProject');
   });
 
-  it('omits Non-Project Activity section when only projects have changes', () => {
+  it('omits Non-Project Activity section when only projects have changes', async () => {
     const dir = trackTmpDir(makeTmpDir());
 
     const host = mockHost();
@@ -925,7 +927,7 @@ describe('buildAndDeliverDailySummary', () => {
       },
     } as unknown as DatabaseClient;
 
-    buildAndDeliverDailySummary(db, host, 99, dir, 30);
+    await buildAndDeliverDailySummary(db, host, 99, dir, 30);
 
     const dailySummaryMsg = host.calls
       .map((c) => c.content)

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -424,13 +424,13 @@ function hasActivity(agentActivity: string, dbChanges: string): boolean {
  *
  * Shared by both the cron handler and server catch-up.
  */
-export function buildAndDeliverDailySummary(
+export async function buildAndDeliverDailySummary(
   db: DatabaseClient,
   narratorHost: AgentHost,
   narratorId: number,
   system2Dir: string,
   intervalMinutes: number
-): void {
+): Promise<void> {
   const newRunTs = new Date().toISOString();
   const today = newRunTs.slice(0, 10);
   const summariesDir = join(system2Dir, 'knowledge', 'daily_summaries');
@@ -493,6 +493,7 @@ export function buildAndDeliverDailySummary(
   ) as Array<{ id: number; name: string }>;
 
   const projectDataList: ProjectActivityData[] = [];
+  const deliveries: Promise<void>[] = [];
 
   for (const project of activeProjects) {
     const projectDir = resolveProjectDir(join(system2Dir, 'projects'), project.id, project.name);
@@ -568,11 +569,13 @@ ${allProjectAgentActivity}
 
 ${projectDbChanges}`;
 
-    narratorHost.deliverMessage(projectLogMessage, {
-      sender: 0,
-      receiver: narratorId,
-      timestamp: Date.now(),
-    });
+    deliveries.push(
+      narratorHost.deliverMessage(projectLogMessage, {
+        sender: 0,
+        receiver: narratorId,
+        timestamp: Date.now(),
+      })
+    );
   }
 
   // 6. Build daily summary — grouped by project vs non-project
@@ -593,6 +596,8 @@ ${projectDbChanges}`;
 
   if (!hasProjectChanges && !hasNonProjectChanges) {
     console.log('[Scheduler] No activity since last run, skipping daily-summary');
+    // Await any project-log deliveries that were already queued
+    if (deliveries.length > 0) await Promise.all(deliveries);
     return;
   }
 
@@ -630,11 +635,16 @@ ${dailySummaryContent}`,
   }
 
   // 9. Deliver daily summary
-  narratorHost.deliverMessage(messageParts.join('\n\n'), {
-    sender: 0,
-    receiver: narratorId,
-    timestamp: Date.now(),
-  });
+  deliveries.push(
+    narratorHost.deliverMessage(messageParts.join('\n\n'), {
+      sender: 0,
+      receiver: narratorId,
+      timestamp: Date.now(),
+    })
+  );
+
+  // Wait for the Narrator to finish processing all deliveries
+  await Promise.all(deliveries);
 }
 
 /**
@@ -678,9 +688,9 @@ export function registerNarratorJobs(
       return;
     }
     console.log('[Scheduler] Triggering daily-summary job (project logs + daily summary)');
-    await trackJobExecution(db, 'daily-summary', 'cron', () => {
-      buildAndDeliverDailySummary(db, narratorHost, narratorId, system2Dir, intervalMinutes);
-    });
+    await trackJobExecution(db, 'daily-summary', 'cron', () =>
+      buildAndDeliverDailySummary(db, narratorHost, narratorId, system2Dir, intervalMinutes)
+    );
   });
 
   // Memory update — daily at 11 AM
@@ -690,9 +700,9 @@ export function registerNarratorJobs(
       return;
     }
     console.log('[Scheduler] Triggering memory-update job');
-    await trackJobExecution(db, 'memory-update', 'cron', () => {
-      buildAndDeliverMemoryUpdate(narratorHost, narratorId, system2Dir);
-    });
+    await trackJobExecution(db, 'memory-update', 'cron', () =>
+      buildAndDeliverMemoryUpdate(narratorHost, narratorId, system2Dir)
+    );
   });
 }
 
@@ -700,11 +710,11 @@ export function registerNarratorJobs(
  * Build and deliver a memory-update message to the Narrator.
  * Shared by both the cron handler and server catch-up.
  */
-export function buildAndDeliverMemoryUpdate(
+export async function buildAndDeliverMemoryUpdate(
   narratorHost: AgentHost,
   narratorId: number,
   system2Dir: string
-): void {
+): Promise<void> {
   const newRunTs = new Date().toISOString();
   const memoryFile = join(system2Dir, 'knowledge', 'memory.md');
   const summariesDir = join(system2Dir, 'knowledge', 'daily_summaries');
@@ -747,7 +757,7 @@ IMPORTANT: Do not message the Guide when you are done. This is a background task
 
 ${summaryEntries.join('\n\n')}`;
 
-  narratorHost.deliverMessage(message, {
+  await narratorHost.deliverMessage(message, {
     sender: 0,
     receiver: narratorId,
     timestamp: Date.now(),

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -400,11 +400,13 @@ export class Server {
       const newHost = await this.initializeAgentHost(newAgent.id);
 
       // Deliver the initial message from the caller (fire-and-forget)
-      newHost.deliverMessage(initialMessage, {
-        sender: callerAgentId,
-        receiver: newAgent.id,
-        timestamp: Date.now(),
-      });
+      newHost
+        .deliverMessage(initialMessage, {
+          sender: callerAgentId,
+          receiver: newAgent.id,
+          timestamp: Date.now(),
+        })
+        .catch((err) => console.error('[Server] spawner delivery failed:', err));
 
       return newAgent.id;
     };
@@ -420,11 +422,13 @@ export class Server {
     return async (agentId, callerAgentId, message) => {
       const host = await this.initializeAgentHost(agentId);
 
-      host.deliverMessage(message, {
-        sender: callerAgentId,
-        receiver: agentId,
-        timestamp: Date.now(),
-      });
+      host
+        .deliverMessage(message, {
+          sender: callerAgentId,
+          receiver: agentId,
+          timestamp: Date.now(),
+        })
+        .catch((err) => console.error('[Server] resurrector delivery failed:', err));
     };
   }
 
@@ -639,15 +643,15 @@ export class Server {
           `[Server] Daily summary stale by ${Math.round(staleness / 60000)} min, queuing catch-up`
         );
         try {
-          await trackJobExecution(this.db, 'daily-summary', 'catch-up', () => {
+          await trackJobExecution(this.db, 'daily-summary', 'catch-up', () =>
             buildAndDeliverDailySummary(
               this.db,
               this.narratorHost,
               this.narratorId,
               SYSTEM2_DIR,
               intervalMinutes
-            );
-          });
+            )
+          );
         } catch (error) {
           console.error('[Server] Daily summary catch-up failed:', error);
         }
@@ -666,9 +670,9 @@ export class Server {
           `[Server] Memory stale by ${Math.round(memoryStaleness / 3600000)}h, queuing memory-update catch-up`
         );
         try {
-          await trackJobExecution(this.db, 'memory-update', 'catch-up', () => {
-            buildAndDeliverMemoryUpdate(this.narratorHost, this.narratorId, SYSTEM2_DIR);
-          });
+          await trackJobExecution(this.db, 'memory-update', 'catch-up', () =>
+            buildAndDeliverMemoryUpdate(this.narratorHost, this.narratorId, SYSTEM2_DIR)
+          );
         } catch (error) {
           console.error('[Server] Memory update catch-up failed:', error);
         }
@@ -700,11 +704,13 @@ export class Server {
           `Failed to restore ${agent.role} agent (id=${agent.id}): ${(error as Error).message}. ` +
           `The agent record is still active in the database but has no running session. ` +
           `Investigate and decide whether to retry or archive the agent.`;
-        this.agentHost.deliverMessage(errorMsg, {
-          sender: agent.id,
-          receiver: this.agentHost.agentId,
-          timestamp: Date.now(),
-        });
+        this.agentHost
+          .deliverMessage(errorMsg, {
+            sender: agent.id,
+            receiver: this.agentHost.agentId,
+            timestamp: Date.now(),
+          })
+          .catch((err) => console.error('[Server] restore error delivery failed:', err));
       }
     }
   }


### PR DESCRIPTION
## Summary

- `deliverMessage()` never set `pendingPrompt`, so all error recovery paths silently dropped scheduled tasks and inter-agent messages
- Add `pendingDeliveries` queue to track in-flight deliveries alongside `pendingPrompt`
- Add `lastTurnErrored` flag that prevents `agent_end` from clearing `pendingPrompt` and shifting `pendingDeliveries` on error turns
- Fix `agent_end` desync: count delivery messages in `event.messages` (via `role: 'custom'` + `customType: 'agent_message'`) instead of blindly shifting on every `agent_end`, since the SDK batches follow-up turns into a single event
- Add delivery retry on the same-provider retry path (alongside existing prompt retry)
- Replay pending deliveries after context overflow recovery (session destruction was losing them)
- Wrap `resourceLoader.reload()` in try/catch on retry paths so transient filesystem errors don't abort the retry
- Clear `pendingDeliveries` in `abort()`
- Fix docs: auto-compaction threshold is ~50% (via `reserveTokens`), not 90%
- `deliverMessage` returns `Promise<void>` that resolves when the agent finishes processing (`agent_end`) or rejects on permanent failure. Scheduler jobs now await deliveries via `Promise.all`, so `job_execution` status accurately reflects agent processing outcome.
- Fire-and-forget callers (message-agent, trigger-project-story, summarizer, reminder manager, spawner, resurrector) append `.catch()` to prevent unhandled promise rejections
- Messages now survive all recovery scenarios: same-provider retry, failover, context overflow, and all-providers-exhausted

## Test plan

- [x] `lastTurnErrored` prevents cleanup on error turns, resets on next `agent_end`
- [x] `agent_end` with delivery messages shifts correct count; prompt-only `agent_end` does not shift
- [x] Same-provider retry re-sends failed delivery via `sendCustomMessage`
- [x] Urgent deliveries use `steer` mode on retry
- [x] Pending deliveries replayed after context overflow recovery
- [x] All-providers-exhausted preserves `pendingPrompt` and rejects delivery promises
- [x] `abort()` clears `pendingDeliveries` and rejects their promises
- [x] `deliverMessage` returns promise that resolves on `agent_end`
- [x] `agent_end` resolves delivery promises in order
- [x] All 454 tests pass