### PR TITLE
fix: non-blocking Narrator catch-up on startup

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -599,8 +599,11 @@ export class Server {
       intervalMinutes
     );
 
-    // Check if narrator needs catch-up after sleep/shutdown
-    await this.checkNarratorCatchUp();
+    // Check if narrator needs catch-up after sleep/shutdown.
+    // Fire-and-forget: don't block the HTTP server from starting.
+    this.checkNarratorCatchUp().catch((err) =>
+      console.error('[Server] Narrator catch-up failed:', err)
+    );
 
     // Graceful shutdown handlers
     const shutdown = async () => {


### PR DESCRIPTION
Fixes a regression from PR #74 where `await this.checkNarratorCatchUp()` blocked `httpServer.listen()` during startup. If the delivery promise hangs (e.g., invalid API key causing all-providers-exhausted), the server never starts listening.

Changes `checkNarratorCatchUp()` to fire-and-forget with a `.catch()` error handler, so the HTTP server starts immediately and catch-up runs in the background.

Fixes #76