### PR TITLE
fix(ui): preserve orphaned turn events and render LLM errors in chat

### DIFF
--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -43,7 +43,7 @@ type ServerMessage =
   | { type: 'thinking_chunk'; content: string; agentId?: number }
   | { type: 'thinking_end'; agentId?: number }
   | { type: 'assistant_chunk'; content: string; agentId?: number }
-  | { type: 'assistant_end'; agentId?: number }
+  | { type: 'assistant_end'; agentId?: number; errorMessage?: string }
   | { type: 'tool_call_start'; name: string; input?: string; agentId?: number }
   | { type: 'tool_call_end'; name: string; result: string; agentId?: number }
   | { type: 'artifact'; url: string; title?: string; filePath?: string }
@@ -61,7 +61,7 @@ type ServerMessage =
 | Message | Description |
 |---------|-------------|
 | `thinking_chunk` / `thinking_end` | Streaming extended thinking blocks |
-| `assistant_chunk` / `assistant_end` | Streaming response text |
+| `assistant_chunk` / `assistant_end` | Streaming response text. `assistant_end` carries `errorMessage` when the LLM stop reason was an error; the UI renders it as a collapsible system message in the chat timeline. |
 | `tool_call_start` / `tool_call_end` | Tool execution lifecycle |
 | `artifact` | Display artifact in a UI tab. Includes `title` (from DB or filename) and `filePath` (absolute path for tab dedup and reload targeting). Also sent on live reload (file watch). |
 | `context_usage` | Context window usage after each agent turn |
@@ -152,7 +152,7 @@ Each WebSocket connection gets its own `WebSocketHandler` instance. It:
 4. Converts Pi SDK events to `ServerMessage` types (all tagged with `agentId`):
    - `message_update` (with thinking) -> `thinking_chunk`; transition to text/tool/end -> `thinking_end`
    - `message_update` (with text) -> `assistant_chunk`
-   - `message_end` -> `assistant_end`
+   - `message_end` -> `assistant_end` (with `errorMessage` when `stopReason` is `'error'`)
    - `tool_execution_start` -> `tool_call_start`
    - `tool_execution_end` -> `tool_call_end`
    - `agent_end` -> `context_usage` + `ready_for_input`

--- a/packages/server/src/websocket/handler.ts
+++ b/packages/server/src/websocket/handler.ts
@@ -238,13 +238,20 @@ export class WebSocketHandler {
         }
         break;
 
-      case 'message_end':
+      case 'message_end': {
         if (this.thinkingAgents.has(agentId)) {
           this.send({ type: 'thinking_end', agentId });
           this.thinkingAgents.delete(agentId);
         }
-        this.send({ type: 'assistant_end', agentId });
+        // Forward error info so the UI can render it in the chat timeline
+        const messageData = (
+          event as unknown as { message?: { stopReason?: string; errorMessage?: string } }
+        ).message;
+        const errorMessage =
+          messageData?.stopReason === 'error' ? messageData.errorMessage : undefined;
+        this.send({ type: 'assistant_end', agentId, errorMessage });
         break;
+      }
 
       case 'tool_execution_start': {
         if (this.thinkingAgents.has(agentId)) {

--- a/packages/shared/src/types/messages.ts
+++ b/packages/shared/src/types/messages.ts
@@ -18,7 +18,7 @@ export type ClientMessage =
 // agentId is optional on streaming messages: when absent, implies the Guide agent.
 export type ServerMessage =
   | { type: 'assistant_chunk'; content: string; agentId?: number }
-  | { type: 'assistant_end'; agentId?: number }
+  | { type: 'assistant_end'; agentId?: number; errorMessage?: string }
   | { type: 'thinking_chunk'; content: string; agentId?: number }
   | { type: 'thinking_end'; agentId?: number }
   | { type: 'tool_call_start'; name: string; input?: string; agentId?: number }

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -92,6 +92,10 @@ export function useWebSocket() {
           if (aid !== null) {
             state.finishThinking(aid);
             state.finishAssistantMessage(aid);
+            // Show LLM errors in the chat timeline as collapsible system messages
+            if (message.errorMessage) {
+              state.addSystemMessage(`LLM error\n\n${message.errorMessage}`, aid);
+            }
           }
           break;
         }

--- a/packages/ui/src/stores/chat.test.ts
+++ b/packages/ui/src/stores/chat.test.ts
@@ -226,6 +226,56 @@ describe('useChatStore', () => {
     });
   });
 
+  describe('finishAssistantMessage', () => {
+    it('preserves orphaned turn events when content is empty', () => {
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore.getState().loadHistory([], 1);
+
+      // Simulate a tool call with no follow-up text (model returned empty content)
+      useChatStore.getState().startToolCall('read_system2_db', '{"sql":"SELECT 1"}', 1);
+      useChatStore.getState().finishToolCall('read_system2_db', '[{"id":1}]', 1);
+
+      // Finish with no assistant text
+      useChatStore.getState().finishAssistantMessage(1);
+
+      const state = useChatStore.getState().agentStates.get(1);
+      // Should have committed a message with turn events even though content is empty
+      expect(state?.messages).toHaveLength(1);
+      expect(state?.messages[0].role).toBe('assistant');
+      expect(state?.messages[0].content).toBe('');
+      expect(state?.messages[0].turnEvents).toHaveLength(1);
+      expect(state?.messages[0].turnEvents?.[0].type).toBe('tool_call');
+      // Turn events should be cleared from current state
+      expect(state?.currentTurnEvents).toHaveLength(0);
+    });
+
+    it('does nothing when both content and turn events are empty', () => {
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore.getState().loadHistory([], 1);
+
+      useChatStore.getState().finishAssistantMessage(1);
+
+      const state = useChatStore.getState().agentStates.get(1);
+      expect(state?.messages).toHaveLength(0);
+    });
+
+    it('commits normally when content exists', () => {
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore.getState().loadHistory([], 1);
+
+      useChatStore.getState().startAssistantMessage(1);
+      useChatStore.getState().appendAssistantChunk('Hello', 1);
+      useChatStore.getState().startToolCall('bash', '{}', 1);
+      useChatStore.getState().finishToolCall('bash', 'ok', 1);
+      useChatStore.getState().finishAssistantMessage(1);
+
+      const state = useChatStore.getState().agentStates.get(1);
+      expect(state?.messages).toHaveLength(1);
+      expect(state?.messages[0].content).toBe('Hello');
+      expect(state?.messages[0].turnEvents).toHaveLength(1);
+    });
+  });
+
   describe('provider (per-agent state)', () => {
     it('setProvider updates only the specified agent', () => {
       useChatStore.getState().loadHistory([], 1);

--- a/packages/ui/src/stores/chat.ts
+++ b/packages/ui/src/stores/chat.ts
@@ -266,16 +266,18 @@ export const useChatStore = create<ChatState>()(
         if (!agentState) return;
 
         const content = agentState.currentAssistantMessage;
-        if (content) {
+        const hasTurnEvents = agentState.currentTurnEvents.length > 0;
+
+        // Commit a message when there is text content OR orphaned turn events
+        // (e.g. model returned empty content after a tool call). Without this,
+        // turn events would be silently dropped on the next user message.
+        if (content || hasTurnEvents) {
           const message: Message = {
             id: `msg-${Date.now()}`,
             role: 'assistant',
-            content,
+            content: content ?? '',
             timestamp: Date.now(),
-            turnEvents:
-              agentState.currentTurnEvents.length > 0
-                ? [...agentState.currentTurnEvents]
-                : undefined,
+            turnEvents: hasTurnEvents ? [...agentState.currentTurnEvents] : undefined,
           };
           set((state) => ({
             agentStates: updateAgentState(state.agentStates, targetId, (s) => ({


### PR DESCRIPTION
## Summary

- When the model returns empty content after a tool call, `finishAssistantMessage()` now commits a message with the turn events instead of silently dropping them
- LLM errors (`stopReason: "error"`) are forwarded from the server via `assistant_end` and rendered as collapsible system messages in the chat timeline

## Details

**Orphaned turn events:** The guard in `finishAssistantMessage()` changed from `if (content)` to `if (content || hasTurnEvents)`, mirroring the existing steering path that already handles this case. The `AssistantMessageBlock` component already renders turn events independently of content, so no UI changes needed.

**Error rendering:** The server now extracts `errorMessage` from `message_end` events and forwards it on `assistant_end`. The UI renders these using the existing `SystemMessageBlock` collapsible pattern (tag: "LLM error", body: full error string).

## Test plan

- [x] New tests: orphaned turn events preserved, empty state no-op, normal commit unchanged
- [x] All 457 tests pass
- [x] Build, typecheck, lint clean

Fixes #77