### PR TITLE
fix(scheduler): track all cron invocations and add skipped status

### DIFF
--- a/docs/database.md
+++ b/docs/database.md
@@ -116,9 +116,9 @@ Scheduler job execution records.
 |--------|------|-------------|
 | `id` | INTEGER PK | Auto-incrementing |
 | `job_name` | TEXT NOT NULL | Job identifier (e.g., `daily-summary`, `memory-update`) |
-| `status` | TEXT NOT NULL | `running` \| `completed` \| `failed` |
+| `status` | TEXT NOT NULL | `running` \| `completed` \| `failed` \| `skipped` |
 | `trigger_type` | TEXT NOT NULL | `cron` \| `catch-up` \| `manual` |
-| `error` | TEXT | Error message if status is `failed` |
+| `error` | TEXT | Error message (`failed`) or skip reason (`skipped`) |
 | `started_at` | TEXT NOT NULL | ISO 8601 timestamp when execution began |
 | `ended_at` | TEXT | ISO 8601 timestamp when execution finished |
 | `created_at` / `updated_at` | TEXT | Auto-set |

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -93,7 +93,7 @@ Both checks use `last_narrator_update_ts` as a cursor. This timestamp only advan
 
 ## Execution Tracking
 
-Every job execution is recorded in the [`job_execution`](database.md#job_execution) table. When a job fires, a row is inserted with status `running`. On success it transitions to `completed`; on failure it transitions to `failed` with the error message preserved.
+Every cron tick creates a row in the [`job_execution`](database.md#job_execution) table with status `running`. It then transitions to one of: `completed` (work done), `skipped` (no work needed, with reason), or `failed` (error, with message preserved).
 
 The `trigger_type` column distinguishes how the execution was initiated:
 
@@ -105,7 +105,9 @@ The `trigger_type` column distinguishes how the execution was initiated:
 
 **Startup recovery:** before Croner starts, the server marks any stale `running` rows as `failed` with error `'server shutdown'`. At that point no new jobs have fired, so every `running` row is definitively from the previous (crashed) process.
 
-**Network-skipped runs** do not create rows. The network check happens before execution tracking, so a skip is not an execution attempt.
+**Skip reasons** are stored in the `error` column when status is `skipped`. Common reasons: `no network connectivity`, `no activity since last run`, `no daily summaries to incorporate`.
+
+**Missing timestamps:** if daily summary files exist but none contain `last_narrator_update_ts` (and memory.md also lacks it), the job fails rather than silently falling back. This catches cases where the Narrator failed to advance the cursor.
 
 ## See Also
 

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -495,6 +495,17 @@ export class DatabaseClient {
     return (stmt.get(id) as JobExecution) || null;
   }
 
+  skipJobExecution(id: number, reason: string): JobExecution | null {
+    const stmt = this.db.prepare(`
+      UPDATE job_execution
+      SET status = 'skipped', ended_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now'), error = ?
+      WHERE id = ?
+      RETURNING *
+    `);
+
+    return (stmt.get(reason, id) as JobExecution) || null;
+  }
+
   failJobExecution(id: number, error: string): JobExecution | null {
     const stmt = this.db.prepare(`
       UPDATE job_execution

--- a/packages/server/src/db/schema.sql
+++ b/packages/server/src/db/schema.sql
@@ -99,7 +99,7 @@ CREATE TABLE IF NOT EXISTS job_execution (
   id           INTEGER PRIMARY KEY,                -- Auto-incrementing unique identifier
   job_name     TEXT NOT NULL,                       -- Job identifier (e.g., 'daily-summary', 'memory-update')
   status       TEXT NOT NULL DEFAULT 'running'      -- Execution lifecycle state
-               CHECK(status IN ('running', 'completed', 'failed')),
+               CHECK(status IN ('running', 'completed', 'failed', 'skipped')),
   trigger_type TEXT NOT NULL                        -- How the execution was initiated
                CHECK(trigger_type IN ('cron', 'catch-up', 'manual')),
   error        TEXT,                                -- Error message if status is 'failed'

--- a/packages/server/src/db/schema.sql
+++ b/packages/server/src/db/schema.sql
@@ -102,7 +102,7 @@ CREATE TABLE IF NOT EXISTS job_execution (
                CHECK(status IN ('running', 'completed', 'failed', 'skipped')),
   trigger_type TEXT NOT NULL                        -- How the execution was initiated
                CHECK(trigger_type IN ('cron', 'catch-up', 'manual')),
-  error        TEXT,                                -- Error message if status is 'failed'
+  error        TEXT,                                -- Error/skip reason (failed: error message, skipped: skip reason)
   started_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')), -- When the execution began
   ended_at     TEXT,                                -- When the execution finished (NULL while running)
   created_at   TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),       -- Row creation timestamp

--- a/packages/server/src/scheduler/jobs.test.ts
+++ b/packages/server/src/scheduler/jobs.test.ts
@@ -10,6 +10,7 @@ import {
   buildAndDeliverMemoryUpdate,
   collectAgentActivity,
   formatMarkdownTable,
+  JobSkipped,
   readFrontmatterField,
   readTailChars,
   registerNarratorJobs,
@@ -207,7 +208,7 @@ describe('collectAgentActivity', () => {
 });
 
 describe('buildAndDeliverMemoryUpdate', () => {
-  it('skips delivery when no daily summary files exist', async () => {
+  it('throws JobSkipped when no daily summary files exist', async () => {
     const dir = trackTmpDir(makeTmpDir());
     const knowledgeDir = join(dir, 'knowledge');
     mkdirSync(knowledgeDir, { recursive: true });
@@ -217,11 +218,11 @@ describe('buildAndDeliverMemoryUpdate', () => {
     );
 
     const host = mockNarratorHost();
-    await buildAndDeliverMemoryUpdate(host, 2, dir);
+    await expect(buildAndDeliverMemoryUpdate(host, 2, dir)).rejects.toThrow(JobSkipped);
     expect(host.calls).toHaveLength(0);
   });
 
-  it('skips delivery when all summaries are older than last update', async () => {
+  it('throws JobSkipped when all summaries are older than last update', async () => {
     const dir = trackTmpDir(makeTmpDir());
     const knowledgeDir = join(dir, 'knowledge');
     const summariesDir = join(knowledgeDir, 'daily_summaries');
@@ -233,7 +234,7 @@ describe('buildAndDeliverMemoryUpdate', () => {
     writeFileSync(join(summariesDir, '2026-03-10.md'), '---\n---\n# Old summary');
 
     const host = mockNarratorHost();
-    await buildAndDeliverMemoryUpdate(host, 2, dir);
+    await expect(buildAndDeliverMemoryUpdate(host, 2, dir)).rejects.toThrow(JobSkipped);
     expect(host.calls).toHaveLength(0);
   });
 
@@ -600,30 +601,42 @@ describe('registerNarratorJobs (network guard)', () => {
     };
   }
 
-  it('skips daily-summary when network is unavailable', async () => {
+  it('records skipped status when network is unavailable (daily-summary)', async () => {
     mockIsNetworkAvailable.mockResolvedValueOnce(false);
     const scheduler = mockScheduler();
     const host = mockNarratorHost();
     const dir = trackTmpDir(makeTmpDir());
 
-    registerNarratorJobs(scheduler as unknown as Scheduler, host, 2, {} as DatabaseClient, dir, 30);
+    const mockDb = {
+      createJobExecution: vi.fn(() => ({ id: 1 })),
+      skipJobExecution: vi.fn(),
+    } as unknown as DatabaseClient;
+
+    registerNarratorJobs(scheduler as unknown as Scheduler, host, 2, mockDb, dir, 30);
 
     await scheduler.handlers['daily-summary']();
     expect(host.calls).toHaveLength(0);
-    expect(mockIsNetworkAvailable).toHaveBeenCalledOnce();
+    expect(mockDb.createJobExecution).toHaveBeenCalledWith('daily-summary', 'cron');
+    expect(mockDb.skipJobExecution).toHaveBeenCalledWith(1, 'no network connectivity');
   });
 
-  it('skips memory-update when network is unavailable', async () => {
+  it('records skipped status when network is unavailable (memory-update)', async () => {
     mockIsNetworkAvailable.mockResolvedValueOnce(false);
     const scheduler = mockScheduler();
     const host = mockNarratorHost();
     const dir = trackTmpDir(makeTmpDir());
 
-    registerNarratorJobs(scheduler as unknown as Scheduler, host, 2, {} as DatabaseClient, dir, 30);
+    const mockDb = {
+      createJobExecution: vi.fn(() => ({ id: 1 })),
+      skipJobExecution: vi.fn(),
+    } as unknown as DatabaseClient;
+
+    registerNarratorJobs(scheduler as unknown as Scheduler, host, 2, mockDb, dir, 30);
 
     await scheduler.handlers['memory-update']();
     expect(host.calls).toHaveLength(0);
-    expect(mockIsNetworkAvailable).toHaveBeenCalledOnce();
+    expect(mockDb.createJobExecution).toHaveBeenCalledWith('memory-update', 'cron');
+    expect(mockDb.skipJobExecution).toHaveBeenCalledWith(1, 'no network connectivity');
   });
 
   it('proceeds with daily-summary when network is available', async () => {
@@ -635,8 +648,8 @@ describe('registerNarratorJobs (network guard)', () => {
 
     const mockDb = {
       query: () => [],
-      createJobExecution: () => ({ id: 1 }),
-      completeJobExecution: () => {},
+      createJobExecution: vi.fn(() => ({ id: 1 })),
+      skipJobExecution: vi.fn(),
     } as unknown as DatabaseClient;
 
     registerNarratorJobs(scheduler as unknown as Scheduler, host, 2, mockDb, dir, 30);
@@ -646,8 +659,9 @@ describe('registerNarratorJobs (network guard)', () => {
     // buildAndDeliverDailySummary was reached: it creates today's summary file
     const today = new Date().toISOString().slice(0, 10);
     expect(existsSync(join(dir, 'knowledge', 'daily_summaries', `${today}.md`))).toBe(true);
-    // With no agents/projects and no activity, delivery is correctly skipped
+    // With no agents/projects and no activity, job is skipped (not completed)
     expect(host.calls).toHaveLength(0);
+    expect(mockDb.skipJobExecution).toHaveBeenCalledWith(1, 'no activity since last run');
   });
 
   it('proceeds with memory-update when network is available', async () => {
@@ -710,7 +724,7 @@ describe('buildAndDeliverDailySummary', () => {
     } as unknown as DatabaseClient;
   }
 
-  it('skips when file has content but no new activity', async () => {
+  it('throws JobSkipped when file has content but no new activity', async () => {
     const dir = trackTmpDir(makeTmpDir());
     const summariesDir = join(dir, 'knowledge', 'daily_summaries');
     mkdirSync(summariesDir, { recursive: true });
@@ -722,17 +736,35 @@ describe('buildAndDeliverDailySummary', () => {
 
     const host = mockHost();
     const db = mockDb([{ id: 1, role: 'guide', project_name: null }]);
-    await buildAndDeliverDailySummary(db, host, 99, dir, 30);
+    await expect(buildAndDeliverDailySummary(db, host, 99, dir, 30)).rejects.toThrow(JobSkipped);
     expect(host.calls).toHaveLength(0);
   });
 
-  it('skips on first run with no activity', async () => {
+  it('throws JobSkipped on first run with no activity', async () => {
     const dir = trackTmpDir(makeTmpDir());
 
     const host = mockHost();
     const db = mockDb([{ id: 1, role: 'guide', project_name: null }]);
-    await buildAndDeliverDailySummary(db, host, 99, dir, 30);
+    await expect(buildAndDeliverDailySummary(db, host, 99, dir, 30)).rejects.toThrow(JobSkipped);
     expect(host.calls).toHaveLength(0);
+  });
+
+  it('fails when prior summaries exist but none have timestamps', async () => {
+    const dir = trackTmpDir(makeTmpDir());
+    const summariesDir = join(dir, 'knowledge', 'daily_summaries');
+    mkdirSync(summariesDir, { recursive: true });
+
+    // A prior summary file with empty frontmatter (no last_narrator_update_ts)
+    writeFileSync(
+      join(summariesDir, '2026-03-10.md'),
+      '---\nlast_narrator_update_ts:\n---\n# Daily Summary\n'
+    );
+
+    const host = mockHost();
+    const db = mockDb([{ id: 1, role: 'guide', project_name: null }]);
+    await expect(buildAndDeliverDailySummary(db, host, 99, dir, 30)).rejects.toThrow(
+      'last_narrator_update_ts not found'
+    );
   });
 
   it('delivers when non-project agent has JSONL activity', async () => {
@@ -944,6 +976,7 @@ describe('trackJobExecution', () => {
       createJobExecution: vi.fn(() => ({ id: 42, job_name: 'test-job', status: 'running' })),
       completeJobExecution: vi.fn(() => ({ id: 42, status: 'completed' })),
       failJobExecution: vi.fn(() => ({ id: 42, status: 'failed' })),
+      skipJobExecution: vi.fn(() => ({ id: 42, status: 'skipped' })),
     } as unknown as DatabaseClient;
   }
 
@@ -975,6 +1008,19 @@ describe('trackJobExecution', () => {
       expect.stringContaining('something broke')
     );
     expect(db.completeJobExecution).not.toHaveBeenCalled();
+  });
+
+  it('records skipped status on JobSkipped and does not re-throw', async () => {
+    const db = mockDbForTracking();
+    const handler = vi.fn(() => {
+      throw new JobSkipped('no activity since last run');
+    });
+
+    await trackJobExecution(db, 'test-job', 'cron', handler);
+
+    expect(db.skipJobExecution).toHaveBeenCalledWith(42, 'no activity since last run');
+    expect(db.completeJobExecution).not.toHaveBeenCalled();
+    expect(db.failJobExecution).not.toHaveBeenCalled();
   });
 
   it('re-throws the original error after recording failure', async () => {

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -465,6 +465,18 @@ export async function buildAndDeliverDailySummary(
     lastRunTs = readFrontmatterField(memoryPath, 'last_narrator_update_ts');
   }
   if (!lastRunTs) {
+    // If daily summary files already exist, the Narrator should have written
+    // last_narrator_update_ts to their frontmatter. Missing timestamps indicate
+    // a problem (e.g., Narrator failed to update the cursor).
+    const hasExistingSummaries =
+      existsSync(summariesDir) &&
+      readdirSync(summariesDir).some((f) => f.endsWith('.md') && f !== `${today}.md`);
+    if (hasExistingSummaries) {
+      throw new Error(
+        'daily summary files exist but last_narrator_update_ts not found in any frontmatter or memory.md'
+      );
+    }
+    // First run: no prior summaries, fall back to interval window
     lastRunTs = new Date(Date.now() - intervalMinutes * 60_000).toISOString();
   }
 
@@ -595,10 +607,9 @@ ${projectDbChanges}`;
   const hasNonProjectChanges = hasActivity(nonProjectAgentActivity, nonProjectDbChanges);
 
   if (!hasProjectChanges && !hasNonProjectChanges) {
-    console.log('[Scheduler] No activity since last run, skipping daily-summary');
     // Await any project-log deliveries that were already queued
     if (deliveries.length > 0) await Promise.all(deliveries);
-    return;
+    throw new JobSkipped('no activity since last run');
   }
 
   // 8. Assemble daily summary message (only sections with activity)
@@ -648,8 +659,19 @@ ${dailySummaryContent}`,
 }
 
 /**
+ * Thrown by job handlers to signal a deliberate skip (no work to do).
+ * The execution is recorded with status 'skipped' and the reason stored.
+ */
+export class JobSkipped extends Error {
+  constructor(public reason: string) {
+    super(reason);
+    this.name = 'JobSkipped';
+  }
+}
+
+/**
  * Execute a job with execution tracking: inserts a 'running' record,
- * calls the handler, then marks it 'completed' or 'failed'.
+ * calls the handler, then marks it 'completed', 'skipped', or 'failed'.
  */
 export async function trackJobExecution(
   db: DatabaseClient,
@@ -662,6 +684,10 @@ export async function trackJobExecution(
     await handler();
     db.completeJobExecution(execution.id);
   } catch (error) {
+    if (error instanceof JobSkipped) {
+      db.skipJobExecution(execution.id, error.reason);
+      return;
+    }
     const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
     db.failJobExecution(execution.id, message);
     throw error;
@@ -683,26 +709,24 @@ export function registerNarratorJobs(
   const cronPattern = 60 % intervalMinutes === 0 ? `*/${intervalMinutes} * * * *` : '*/30 * * * *';
 
   scheduler.schedule('daily-summary', cronPattern, async () => {
-    if (!(await isNetworkAvailable())) {
-      console.log('[Scheduler] No network connectivity, skipping daily-summary');
-      return;
-    }
-    console.log('[Scheduler] Triggering daily-summary job (project logs + daily summary)');
-    await trackJobExecution(db, 'daily-summary', 'cron', () =>
-      buildAndDeliverDailySummary(db, narratorHost, narratorId, system2Dir, intervalMinutes)
-    );
+    await trackJobExecution(db, 'daily-summary', 'cron', async () => {
+      if (!(await isNetworkAvailable())) {
+        throw new JobSkipped('no network connectivity');
+      }
+      console.log('[Scheduler] Triggering daily-summary job (project logs + daily summary)');
+      await buildAndDeliverDailySummary(db, narratorHost, narratorId, system2Dir, intervalMinutes);
+    });
   });
 
   // Memory update — daily at 11 AM
   scheduler.schedule('memory-update', '0 11 * * *', async () => {
-    if (!(await isNetworkAvailable())) {
-      console.log('[Scheduler] No network connectivity, skipping memory-update');
-      return;
-    }
-    console.log('[Scheduler] Triggering memory-update job');
-    await trackJobExecution(db, 'memory-update', 'cron', () =>
-      buildAndDeliverMemoryUpdate(narratorHost, narratorId, system2Dir)
-    );
+    await trackJobExecution(db, 'memory-update', 'cron', async () => {
+      if (!(await isNetworkAvailable())) {
+        throw new JobSkipped('no network connectivity');
+      }
+      console.log('[Scheduler] Triggering memory-update job');
+      await buildAndDeliverMemoryUpdate(narratorHost, narratorId, system2Dir);
+    });
   });
 }
 
@@ -733,8 +757,7 @@ export async function buildAndDeliverMemoryUpdate(
     : [];
 
   if (summaryFiles.length === 0) {
-    console.log('[Scheduler] No daily summaries to incorporate, skipping memory-update');
-    return;
+    throw new JobSkipped('no daily summaries to incorporate');
   }
 
   // Embed summary content inline so the Narrator doesn't need read tool calls

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -13,6 +13,7 @@ import type {
   ChatConfig,
   ChatMessage,
   ChatTurnEvent,
+  JobExecution,
   LlmConfig,
   SchedulerConfig,
   ServicesConfig,
@@ -245,7 +246,7 @@ export class Server {
         }
         const limit = rawLimit !== undefined ? Math.min(rawLimit, 500) : undefined;
 
-        const validStatuses = ['running', 'completed', 'failed'] as const;
+        const validStatuses = ['running', 'completed', 'failed', 'skipped'] as const;
         if (status && !validStatuses.includes(status as (typeof validStatuses)[number])) {
           res
             .status(400)
@@ -255,7 +256,7 @@ export class Server {
 
         const executions = this.db.listJobExecutions({
           jobName: jobName || undefined,
-          status: (status as 'running' | 'completed' | 'failed') || undefined,
+          status: (status as JobExecution['status']) || undefined,
           limit,
         });
 

--- a/packages/shared/src/types/database.ts
+++ b/packages/shared/src/types/database.ts
@@ -73,7 +73,7 @@ export interface Artifact {
 export interface JobExecution {
   id: number;
   job_name: string;
-  status: 'running' | 'completed' | 'failed';
+  status: 'running' | 'completed' | 'failed' | 'skipped';
   trigger_type: 'cron' | 'catch-up' | 'manual';
   error: string | null;
   started_at: string;

--- a/packages/ui/src/components/CronJobsPane.tsx
+++ b/packages/ui/src/components/CronJobsPane.tsx
@@ -18,7 +18,7 @@ import { MultiSelectDropdown } from './MultiSelectDropdown';
 export interface JobExecutionInfo {
   id: number;
   job_name: string;
-  status: 'running' | 'completed' | 'failed';
+  status: 'running' | 'completed' | 'failed' | 'skipped';
   trigger_type: 'cron' | 'catch-up' | 'manual';
   error: string | null;
   started_at: string;
@@ -31,6 +31,7 @@ const statusColor: Record<JobExecutionInfo['status'], string> = {
   completed: colors.teal,
   failed: colors.coral,
   running: colors.amber,
+  skipped: colors.gray,
 };
 
 function formatTime(isoString: string): string {
@@ -81,6 +82,7 @@ const STATUS_OPTIONS: MultiSelectOption[] = [
   { value: 'completed', label: 'completed' },
   { value: 'failed', label: 'failed' },
   { value: 'running', label: 'running' },
+  { value: 'skipped', label: 'skipped' },
 ];
 
 const TRIGGER_OPTIONS: MultiSelectOption[] = [

--- a/packages/ui/src/components/JobExecutionDetailModal.tsx
+++ b/packages/ui/src/components/JobExecutionDetailModal.tsx
@@ -15,6 +15,7 @@ const statusColor: Record<JobExecutionInfo['status'], string> = {
   completed: colors.teal,
   failed: colors.coral,
   running: colors.amber,
+  skipped: colors.gray,
 };
 
 function formatDate(iso: string | null): string {
@@ -207,7 +208,7 @@ export function JobExecutionDetailModal({
             <dd>{formatDate(execution.updated_at)}</dd>
           </Box>
 
-          {/* Error */}
+          {/* Error / Skip reason */}
           {execution.error && (
             <Box>
               <Text
@@ -220,12 +221,12 @@ export function JobExecutionDetailModal({
                   display: 'block',
                 }}
               >
-                Error:
+                {execution.status === 'skipped' ? 'Reason:' : 'Error:'}
               </Text>
               <Box
                 sx={{
                   fontSize: 0,
-                  color: colors.coral,
+                  color: execution.status === 'skipped' ? colors.gray : colors.coral,
                   fontFamily: 'mono',
                   lineHeight: 1.6,
                   whiteSpace: 'pre-wrap',


### PR DESCRIPTION
## Summary

- Every cron tick now creates a `job_execution` record, even when skipped (network down, no activity, no summaries)
- Added `'skipped'` status to `job_execution` schema with skip reason stored in `error` column
- Missing `last_narrator_update_ts` when daily summary files already exist now fails instead of silently falling back
- `JobSkipped` error class for handlers to signal deliberate skips without polluting the failure path

## Test plan

- [x] 459 tests pass (3 new: JobSkipped in trackJobExecution, network skip records, missing timestamps failure)
- [x] Build, lint, typecheck all pass
- [ ] Verify `job_execution` table shows 'skipped' rows after cron ticks with no activity