### PR TITLE
fix: stop orphaned processes and snap chat scroll on agent switch

### DIFF
--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -2,6 +2,7 @@
  * Stop Command
  *
  * Stops the System2 server. Cross-platform: uses signals on Unix, taskkill on Windows.
+ * Uses two strategies: PID file lookup and port-based detection (fallback for orphaned processes).
  */
 
 import { exec } from 'node:child_process';
@@ -14,6 +15,7 @@ const execAsync = promisify(exec);
 
 const SYSTEM2_DIR = join(homedir(), '.system2');
 const PID_FILE = join(SYSTEM2_DIR, 'server.pid');
+const DEFAULT_PORT = 3000;
 const IS_WINDOWS = process.platform === 'win32';
 
 /**
@@ -40,50 +42,100 @@ async function killProcess(pid: number, force: boolean): Promise<void> {
   }
 }
 
+/**
+ * Wait for a process to exit, with a deadline.
+ * Returns true if the process exited, false if it's still running.
+ */
+async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (isProcessRunning(pid) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return !isProcessRunning(pid);
+}
+
+/**
+ * Gracefully stop a process: SIGTERM, wait, then SIGKILL if needed.
+ */
+async function stopProcess(pid: number, label: string): Promise<void> {
+  console.log(`Stopping ${label} (PID: ${pid})...`);
+  await killProcess(pid, false);
+
+  if (await waitForExit(pid, 10_000)) {
+    return;
+  }
+
+  console.log('Process still running, forcing shutdown...');
+  await killProcess(pid, true);
+  await new Promise((resolve) => setTimeout(resolve, 500));
+
+  if (isProcessRunning(pid)) {
+    throw new Error(`Failed to stop process ${pid}`);
+  }
+}
+
+/**
+ * Find the PID of a process listening on a TCP port.
+ * Returns undefined if no process is found or on error.
+ */
+async function findListenerPid(port: number): Promise<number | undefined> {
+  try {
+    if (IS_WINDOWS) {
+      const { stdout } = await execAsync(
+        `netstat -ano | findstr "LISTENING" | findstr ":${port} "`
+      );
+      const match = stdout.trim().split(/\s+/).pop();
+      return match ? parseInt(match, 10) : undefined;
+    }
+    // Unix: lsof returns the PID of the process listening on the port
+    const { stdout } = await execAsync(`lsof -i :${port} -t -s TCP:LISTEN`);
+    const pid = parseInt(stdout.trim(), 10);
+    return Number.isNaN(pid) ? undefined : pid;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function stop(): Promise<void> {
-  // Check if PID file exists
-  if (!existsSync(PID_FILE)) {
+  let stopped = false;
+  let pidFromFile: number | undefined;
+
+  // Strategy 1: PID file
+  if (existsSync(PID_FILE)) {
+    pidFromFile = parseInt(readFileSync(PID_FILE, 'utf-8'), 10);
+
+    if (isProcessRunning(pidFromFile)) {
+      try {
+        await stopProcess(pidFromFile, 'System2');
+        stopped = true;
+      } catch {
+        console.error(`Failed to stop System2 (PID: ${pidFromFile}). Kill it manually.`);
+        process.exit(1);
+      }
+    }
+
+    unlinkSync(PID_FILE);
+  }
+
+  // Strategy 2: check port for orphaned processes the PID file missed
+  const listenerPid = await findListenerPid(DEFAULT_PORT);
+
+  if (listenerPid && listenerPid !== pidFromFile) {
+    console.log(`Found orphaned System2 process on port ${DEFAULT_PORT} (PID: ${listenerPid})`);
+    try {
+      await stopProcess(listenerPid, 'orphaned process');
+      stopped = true;
+    } catch {
+      console.error(`Failed to stop orphaned process (PID: ${listenerPid}). Kill it manually.`);
+      process.exit(1);
+    }
+  }
+
+  if (stopped) {
+    console.log('✓ System2 stopped');
+  } else {
     console.log('System2 is not running');
     console.log('');
     console.log('To start: system2 start');
-    process.exit(0);
-  }
-
-  const pid = parseInt(readFileSync(PID_FILE, 'utf-8'), 10);
-
-  try {
-    // Check if process exists
-    if (!isProcessRunning(pid)) {
-      console.log('System2 was not running (removing stale PID file)');
-      unlinkSync(PID_FILE);
-      return;
-    }
-
-    // Process exists, request graceful shutdown
-    console.log(`Stopping System2 (PID: ${pid})...`);
-    await killProcess(pid, false);
-
-    // Poll for exit (up to 10 seconds) instead of a fixed wait
-    const deadline = Date.now() + 10_000;
-    while (isProcessRunning(pid) && Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, 250));
-    }
-
-    // Force kill if graceful shutdown didn't complete in time
-    if (isProcessRunning(pid)) {
-      console.log('Process still running, forcing shutdown...');
-      await killProcess(pid, true);
-      await new Promise((resolve) => setTimeout(resolve, 500));
-    }
-
-    // Clean up PID file
-    unlinkSync(PID_FILE);
-    console.log('✓ System2 stopped');
-  } catch (_error) {
-    // Process not running or already terminated, clean up stale PID file
-    if (existsSync(PID_FILE)) {
-      unlinkSync(PID_FILE);
-    }
-    console.log('✓ System2 stopped');
   }
 }

--- a/packages/cli/src/commands/stop.ts
+++ b/packages/cli/src/commands/stop.ts
@@ -32,13 +32,22 @@ function isProcessRunning(pid: number): boolean {
 
 /**
  * Kill a process. Uses taskkill on Windows, signals on Unix.
+ * Treats ESRCH (process already exited) as success.
  */
 async function killProcess(pid: number, force: boolean): Promise<void> {
-  if (IS_WINDOWS) {
-    const flag = force ? '/F' : '';
-    await execAsync(`taskkill /PID ${pid} ${flag}`.trim());
-  } else {
-    process.kill(pid, force ? 'SIGKILL' : 'SIGTERM');
+  try {
+    if (IS_WINDOWS) {
+      const flag = force ? '/F' : '';
+      await execAsync(`taskkill /PID ${pid} ${flag}`.trim());
+    } else {
+      process.kill(pid, force ? 'SIGKILL' : 'SIGTERM');
+    }
+  } catch (err: unknown) {
+    // Process already exited between our check and the kill signal: that's fine
+    if (err && typeof err === 'object' && 'code' in err && err.code === 'ESRCH') {
+      return;
+    }
+    throw err;
   }
 }
 
@@ -99,12 +108,15 @@ async function findListenerPid(port: number): Promise<number | undefined> {
 export async function stop(): Promise<void> {
   let stopped = false;
   let pidFromFile: number | undefined;
+  let hadPidFile = false;
 
   // Strategy 1: PID file
   if (existsSync(PID_FILE)) {
-    pidFromFile = parseInt(readFileSync(PID_FILE, 'utf-8'), 10);
+    hadPidFile = true;
+    const raw = parseInt(readFileSync(PID_FILE, 'utf-8'), 10);
+    pidFromFile = Number.isNaN(raw) ? undefined : raw;
 
-    if (isProcessRunning(pidFromFile)) {
+    if (pidFromFile && isProcessRunning(pidFromFile)) {
       try {
         await stopProcess(pidFromFile, 'System2');
         stopped = true;
@@ -117,17 +129,21 @@ export async function stop(): Promise<void> {
     unlinkSync(PID_FILE);
   }
 
-  // Strategy 2: check port for orphaned processes the PID file missed
-  const listenerPid = await findListenerPid(DEFAULT_PORT);
+  // Strategy 2: check port for orphaned processes the PID file missed.
+  // Only runs when a PID file existed (evidence system2 was running), to avoid
+  // killing unrelated services that happen to use the same port.
+  if (hadPidFile) {
+    const listenerPid = await findListenerPid(DEFAULT_PORT);
 
-  if (listenerPid && listenerPid !== pidFromFile) {
-    console.log(`Found orphaned System2 process on port ${DEFAULT_PORT} (PID: ${listenerPid})`);
-    try {
-      await stopProcess(listenerPid, 'orphaned process');
-      stopped = true;
-    } catch {
-      console.error(`Failed to stop orphaned process (PID: ${listenerPid}). Kill it manually.`);
-      process.exit(1);
+    if (listenerPid && listenerPid !== pidFromFile) {
+      console.log(`Found orphaned System2 process on port ${DEFAULT_PORT} (PID: ${listenerPid})`);
+      try {
+        await stopProcess(listenerPid, 'orphaned process');
+        stopped = true;
+      } catch {
+        console.error(`Failed to stop orphaned process (PID: ${listenerPid}). Kill it manually.`);
+        process.exit(1);
+      }
     }
   }
 

--- a/packages/ui/src/components/MessageList.tsx
+++ b/packages/ui/src/components/MessageList.tsx
@@ -566,6 +566,7 @@ function AssistantMessageBlock({
 }
 
 export function MessageList() {
+  const activeAgentId = useChatStore((s) => s.activeAgentId);
   const activeState = useChatStore((s) => {
     if (s.activeAgentId === null) return EMPTY_AGENT_STATE;
     return s.agentStates.get(s.activeAgentId) ?? EMPTY_AGENT_STATE;
@@ -598,6 +599,17 @@ export function MessageList() {
     (isWaitingForResponse ||
       (isStreaming && !hasActiveInProgress && compactionStatus === 'idle')) &&
     !currentAssistantMessage;
+
+  // When the active agent changes, snap to the bottom instantly so the user
+  // sees the most recent messages without watching the whole history scroll by.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only run on agent switch
+  useEffect(() => {
+    isNearBottomRef.current = true;
+    const container = scrollContainerRef.current;
+    if (container) {
+      container.scrollTop = container.scrollHeight;
+    }
+  }, [activeAgentId]);
 
   // Track whether user is near the bottom of the scroll container
   useEffect(() => {

--- a/packages/ui/src/components/MessageList.tsx
+++ b/packages/ui/src/components/MessageList.tsx
@@ -6,7 +6,7 @@
  */
 
 import { Box, Text } from '@primer/react';
-import { Fragment, useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
 import {
   EMPTY_AGENT_STATE,
@@ -602,8 +602,9 @@ export function MessageList() {
 
   // When the active agent changes, snap to the bottom instantly so the user
   // sees the most recent messages without watching the whole history scroll by.
+  // useLayoutEffect runs before paint, avoiding a visible flash of the old scroll position.
   // biome-ignore lint/correctness/useExhaustiveDependencies: only run on agent switch
-  useEffect(() => {
+  useLayoutEffect(() => {
     isNearBottomRef.current = true;
     const container = scrollContainerRef.current;
     if (container) {


### PR DESCRIPTION
## Summary

- **fix(cli):** The `stop` command only checked the PID file, which could get out of sync with the actual running server (e.g., when a start attempt crashed with `EADDRINUSE` and overwrote the PID file with a dead PID). Now `stop` also checks port 3000 via `lsof` (Unix) / `netstat` (Windows) as a fallback to find and kill orphaned processes.
- **fix(ui):** When switching agents, the chat kept the previous agent's scroll position, forcing users to scroll down. Now resets scroll to bottom instantly on agent switch.

## Test plan

- [ ] `system2 stop` still works normally when PID file is correct
- [ ] `system2 stop` detects and kills orphaned processes on port 3000 when PID file is stale
- [ ] `system2 stop` prints "System2 is not running" when nothing is running and no PID file exists
- [ ] `system2 stop && system2 start` reliably starts a fresh server
- [ ] Switching agents in the UI shows the most recent messages immediately