### PR TITLE
fix: update set_reminder delay bounds to 30s-7d

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -182,7 +182,7 @@ Schedule a delayed reminder for the calling agent. After the specified delay, a 
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `delay_minutes` | number | Minutes from now. Must be 1 to 35,791 (~24.8 days max). |
+| `delay_minutes` | number | Minutes from now (accepts fractional values). Must be 0.5 (30s) to 10,080 (7 days). |
 | `message` | string | Reminder text delivered back as a follow-up message when the timer fires. |
 
 - **Non-blocking:** uses `setTimeout` internally; the agent continues working after setting the reminder

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -1,8 +1,8 @@
 # System2
 
-You are part of System2 — a single-user, self-hosted AI data team. System2 automates the full data lifecycle: procurement, transformation, loading, analysis, reporting, and dashboards. Every project produces a traceable record of tasks, decisions, and results in a shared database.
+You are an AI agent of System2, a single-user, self-hosted AI multi-agent system for reasoning with data. System2 automates the full data lifecycle: procurement, transformation, loading, analysis, reporting, and dashboards. Every project produces a traceable record of tasks, conversations, decisions, and artifacts in the app database and log files, ensuring transparent and verifiable analysis.
 
-Your role-specific instructions are in a separate document appended after this one. This reference covers everything that applies to all agents.
+Your role-specific instructions are in a separate document appended after this one. This reference covers instructions that apply to all agents and must be closely considered when operating within system2.
 
 ## Standards
 
@@ -62,7 +62,7 @@ The **Guide** is the primary user-facing agent. However, the user may choose to 
 | `terminate_agent` | Archive an agent — abort its session, unregister, mark archived | Guide, Conductors |
 | `resurrect_agent` | Bring back an archived agent — resume its session from persisted JSONL, re-register | Guide, Conductors |
 | `trigger_project_story` | Signal project completion: server creates story task, collects data, delivers to Narrator | Guide, Conductors |
-| `set_reminder` | Schedule a delayed follow-up message to yourself (1 to ~24.8 days). Non-blocking. | All agents |
+| `set_reminder` | Schedule a delayed follow-up message to yourself (30s to 7 days). Non-blocking. | All agents |
 | `cancel_reminder` | Cancel a pending reminder by ID | All agents |
 | `list_reminders` | List your active pending reminders | All agents |
 | `web_search` | Search the web via Brave Search API | All agents (when configured) |

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -1,8 +1,8 @@
 # System2
 
-You are an AI agent of System2, a single-user, self-hosted AI multi-agent system for reasoning with data. System2 automates the full data lifecycle: procurement, transformation, loading, analysis, reporting, and dashboards. Every project produces a traceable record of tasks, conversations, decisions, and artifacts in the app database and log files, ensuring transparent and verifiable analysis.
+You are part of System2 — a single-user, self-hosted AI data team. System2 automates the full data lifecycle: procurement, transformation, loading, analysis, reporting, and dashboards. Every project produces a traceable record of tasks, decisions, and results in a shared database.
 
-Your role-specific instructions are in a separate document appended after this one. This reference covers instructions that apply to all agents and must be closely considered when operating within system2.
+Your role-specific instructions are in a separate document appended after this one. This reference covers everything that applies to all agents.
 
 ## Standards
 

--- a/packages/server/src/agents/tools/set-reminder.test.ts
+++ b/packages/server/src/agents/tools/set-reminder.test.ts
@@ -28,25 +28,31 @@ describe('set_reminder tool', () => {
     expect((result.content[0] as { text: string }).text).toContain('5 minute(s)');
   });
 
-  it('rejects delay_minutes < 1 (including fractional sub-minute values)', async () => {
+  it('accepts 0.5 minutes (30 seconds) as minimum delay', async () => {
     const { tool, reminderManager } = setup();
 
-    const result0 = await exec(tool, { delay_minutes: 0, message: 'bad' });
-    expect(reminderManager.schedule).not.toHaveBeenCalled();
-    expect((result0.content[0] as { text: string }).text).toContain('must be between 1 and');
+    const result = await exec(tool, { delay_minutes: 0.5, message: 'quick check' });
 
-    const result05 = await exec(tool, { delay_minutes: 0.5, message: 'bad' });
-    expect(reminderManager.schedule).not.toHaveBeenCalled();
-    expect((result05.content[0] as { text: string }).text).toContain('must be between 1 and');
+    expect(reminderManager.schedule).toHaveBeenCalledWith(1, 'quick check', 0.5);
+    expect((result.content[0] as { text: string }).text).toContain('Reminder #1 set');
   });
 
-  it('rejects delay_minutes exceeding setTimeout limit (~24.8 days)', async () => {
+  it('rejects delay_minutes below minimum (0.5)', async () => {
     const { tool, reminderManager } = setup();
 
-    const result = await exec(tool, { delay_minutes: 40_000, message: 'too far' });
+    const result = await exec(tool, { delay_minutes: 0.1, message: 'bad' });
 
     expect(reminderManager.schedule).not.toHaveBeenCalled();
-    expect((result.content[0] as { text: string }).text).toContain('must be between 1 and');
+    expect((result.content[0] as { text: string }).text).toContain('must be between');
+  });
+
+  it('rejects delay_minutes exceeding 7 days', async () => {
+    const { tool, reminderManager } = setup();
+
+    const result = await exec(tool, { delay_minutes: 10_081, message: 'too far' });
+
+    expect(reminderManager.schedule).not.toHaveBeenCalled();
+    expect((result.content[0] as { text: string }).text).toContain('must be between');
   });
 
   it('handles manager errors gracefully', async () => {

--- a/packages/server/src/agents/tools/set-reminder.ts
+++ b/packages/server/src/agents/tools/set-reminder.ts
@@ -2,13 +2,13 @@ import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { Type } from '@sinclair/typebox';
 import type { ReminderManager } from '../../reminders/manager.js';
 
-// Node.js setTimeout clamps delays > 2^31-1 ms, causing them to fire immediately.
-const MAX_DELAY_MINUTES = 35_791; // ~24.8 days
+const MIN_DELAY_MINUTES = 0.5; // 30 seconds
+const MAX_DELAY_MINUTES = 10_080; // 7 days
 
 export function createSetReminderTool(agentId: number, reminderManager: ReminderManager) {
   const params = Type.Object({
     delay_minutes: Type.Number({
-      description: `How many minutes from now the reminder should fire. Must be between 1 and ${MAX_DELAY_MINUTES} (~24.8 days).`,
+      description: `How many minutes from now the reminder should fire. Must be between ${MIN_DELAY_MINUTES} (30 seconds) and ${MAX_DELAY_MINUTES} (7 days). Accepts fractional values (e.g. 0.5 for 30s, 1.5 for 90s).`,
     }),
     message: Type.String({
       description:
@@ -25,12 +25,12 @@ export function createSetReminderTool(agentId: number, reminderManager: Reminder
     execute: async (_toolCallId, args) => {
       const { delay_minutes, message } = args;
 
-      if (delay_minutes < 1 || delay_minutes > MAX_DELAY_MINUTES) {
+      if (delay_minutes < MIN_DELAY_MINUTES || delay_minutes > MAX_DELAY_MINUTES) {
         return {
           content: [
             {
               type: 'text' as const,
-              text: `Error: delay_minutes must be between 1 and ${MAX_DELAY_MINUTES} (~24.8 days).`,
+              text: `Error: delay_minutes must be between ${MIN_DELAY_MINUTES} (30 seconds) and ${MAX_DELAY_MINUTES} (7 days).`,
             },
           ],
           details: { error: 'invalid_delay' },


### PR DESCRIPTION
## Summary

- Lower minimum delay from 1 minute to 0.5 (30 seconds)
- Cap maximum delay at 10,080 minutes (7 days) instead of ~24.8 days
- Update tool parameter description to mention fractional values
- Update agents.md tool table and docs/tools.md

## Test plan

- [x] 460 tests pass (updated bounds tests: 0.5 accepted, 0.1 rejected, 10,081 rejected)
- [x] Build, lint, typecheck all pass