### PR TITLE
feat: add skills system for reusable agent workflow instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ The [`docs/`](docs/) directory contains in-depth documentation. Start with [`doc
 | [`database.md`](docs/database.md) | SQLite schema, WAL mode, better-sqlite3 usage |
 | [`websocket-protocol.md`](docs/websocket-protocol.md) | Real-time UI–server communication protocol |
 | [`knowledge-system.md`](docs/knowledge-system.md) | Persistent knowledge files, git-tracked, dynamic prompt injection |
+| [`skills.md`](docs/skills.md) | Reusable agent workflow instructions, SKILL.md format, discovery and injection |
 | [`scheduler.md`](docs/scheduler.md) | Cron-based Narrator jobs via Croner |
 | [`configuration.md`](docs/configuration.md) | `config.toml` settings and API keys |
 | [`packages/cli.md`](docs/packages/cli.md) | CLI: onboarding, daemon management, status |

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ For installation and usage, see the [project README](../README.md).
 - [Database](database.md): The SQLite schema that stores projects, tasks, agents, and comments, with table definitions, indices, and common query patterns.
 - [WebSocket Protocol](websocket-protocol.md): The message format between the UI and server, covering how chat messages, tool calls, and agent events are exchanged in real time.
 - [Knowledge System](knowledge-system.md): How agents persist and share memory, including knowledge files, daily summaries, project logs, project stories, and git tracking of `~/.system2/`.
+- [Skills](skills.md): Reusable workflow instructions for agents, including the SKILL.md format, discovery from built-in and user directories, role filtering, and XML index injection.
 - [Scheduler](scheduler.md): The background job system, covering what runs on schedule (daily summaries, memory updates), how missed jobs are caught up, and how to add new ones.
 
 ## Reference

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -8,7 +8,7 @@ System2's agents are built on the [pi-coding-agent](https://github.com/badlogic/
 - `packages/server/src/agents/auth-resolver.ts`: AuthResolver
 - `packages/server/src/agents/library/`: agent identity and system instructions (Markdown + YAML frontmatter)
 - `packages/server/src/agents/agents.md`: shared reference prepended to all system prompts
-- `packages/server/src/skills/loader.ts`: skill discovery, parsing, and XML index compilation
+- `packages/server/src/skills/loader.ts`: role-based skill filtering (`extractRoles`, `filterByRole`); discovery and XML injection are handled by the pi-coding-agent SDK
 
 ## Agent Roles
 
@@ -58,7 +58,7 @@ Each agent's system prompt is assembled from five layers:
 | Role-aware context | Project log (`projects/{id}_{name}/log.md`) for project-scoped agents, or last 2 daily summaries for system-wide agents | **Every LLM call** |
 | Skills index | Built-in (`agents/skills/`) + user (`~/.system2/skills/`), filtered by role, compiled as XML | **Every LLM call** |
 
-The static layers are concatenated into `staticPrompt`. The dynamic layers are loaded via `loadKnowledgeContext()` and `loadSkillsContext()`, which are called from the `systemPromptOverride` callback passed to the Pi SDK's `DefaultResourceLoader`. Since the SDK only invokes this callback during `reload()` (not on every `prompt()` call), `AgentHost` explicitly calls `resourceLoader.reload()` before each prompt to ensure knowledge files and skills are re-read. This means knowledge and skill updates take effect immediately without server restarts.
+The static layers are concatenated into `staticPrompt`. Knowledge is loaded via `loadKnowledgeContext()`, called from the `systemPromptOverride` callback passed to the Pi SDK's `DefaultResourceLoader`. Skills are wired through the SDK via `additionalSkillPaths` (providing both skill directories) and `skillsOverride` (filtering by agent role). Since the SDK only invokes these callbacks during `reload()` (not on every `prompt()` call), `AgentHost` explicitly calls `resourceLoader.reload()` before each prompt to ensure knowledge files and skills are re-read. This means knowledge and skill updates take effect immediately without server restarts.
 
 Empty files are skipped.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -8,6 +8,7 @@ System2's agents are built on the [pi-coding-agent](https://github.com/badlogic/
 - `packages/server/src/agents/auth-resolver.ts`: AuthResolver
 - `packages/server/src/agents/library/`: agent identity and system instructions (Markdown + YAML frontmatter)
 - `packages/server/src/agents/agents.md`: shared reference prepended to all system prompts
+- `packages/server/src/skills/loader.ts`: skill discovery, parsing, and XML index compilation
 
 ## Agent Roles
 
@@ -47,16 +48,17 @@ The `models` map specifies which model to use for each LLM provider.
 
 ## System Prompt Construction
 
-Each agent's system prompt is assembled from four layers:
+Each agent's system prompt is assembled from five layers:
 
 | Layer | Source | Loaded |
-|-------|--------|--------|
+| ----- | ------ | ------ |
 | Shared reference | `agents/agents.md` | Once at init |
 | Agent instructions | `agents/library/{role}.md` (body after frontmatter) | Once at init |
 | Knowledge files | `~/.system2/knowledge/` (infrastructure.md, user.md, memory.md) | **Every LLM call** |
 | Role-aware context | Project log (`projects/{id}_{name}/log.md`) for project-scoped agents, or last 2 daily summaries for system-wide agents | **Every LLM call** |
+| Skills index | Built-in (`agents/skills/`) + user (`~/.system2/skills/`), filtered by role, compiled as XML | **Every LLM call** |
 
-The static layers are concatenated into `staticPrompt`. The dynamic layers are loaded via `loadKnowledgeContext()`, which is called from the `systemPromptOverride` callback passed to the Pi SDK's `DefaultResourceLoader`. Since the SDK only invokes this callback during `reload()` (not on every `prompt()` call), `AgentHost` explicitly calls `resourceLoader.reload()` before each prompt to ensure knowledge files are re-read. This means knowledge updates take effect immediately without server restarts.
+The static layers are concatenated into `staticPrompt`. The dynamic layers are loaded via `loadKnowledgeContext()` and `loadSkillsContext()`, which are called from the `systemPromptOverride` callback passed to the Pi SDK's `DefaultResourceLoader`. Since the SDK only invokes this callback during `reload()` (not on every `prompt()` call), `AgentHost` explicitly calls `resourceLoader.reload()` before each prompt to ensure knowledge files and skills are re-read. This means knowledge and skill updates take effect immediately without server restarts.
 
 Empty files are skipped.
 

--- a/docs/knowledge-system.md
+++ b/docs/knowledge-system.md
@@ -6,8 +6,8 @@ System2 maintains persistent knowledge in `~/.system2/knowledge/`, git-tracked f
 - `packages/server/src/knowledge/init.ts`: directory initialization
 - `packages/server/src/knowledge/templates.ts`: default file templates
 - `packages/server/src/knowledge/git.ts`: git repo setup
-- `packages/server/src/agents/host.ts`: `loadKnowledgeContext()` and `loadSkillsContext()` methods
-- `packages/server/src/skills/loader.ts`: skill discovery, parsing, and XML index compilation
+- `packages/server/src/agents/host.ts`: `loadKnowledgeContext()` method and SDK skill wiring via `additionalSkillPaths`/`skillsOverride`
+- `packages/server/src/skills/loader.ts`: role-based skill filtering (`extractRoles`, `filterByRole`)
 
 ## Knowledge Directory
 
@@ -82,7 +82,7 @@ Project-scoped files live outside `knowledge/`:
    - **System-wide agents** (Guide, Narrator): loads the 2 most recent daily summary files (sorted by filename, chronological order)
 5. Returns all content under a `## Knowledge Base` header, separated by `---`
 
-Each section is prefixed with a `### ~/.system2/...` heading so agents can identify the source of each piece of context. The block ends with `---\n\nConversation history follows.` to mark the boundary between instructions and the messages array.
+Each section is prefixed with a `### ~/.system2/...` heading so agents can identify the source of each piece of context. After the knowledge block, the SDK appends the skills XML index (filtered by role) and current date/working directory metadata.
 
 ### Examples
 
@@ -110,12 +110,15 @@ SYSTEM PROMPT (rebuilt on every LLM call):
        ---
        ### ~/.system2/knowledge/daily_summaries/2026-03-11.md
        [content]
-  4. ## Available Skills (dynamic, re-read every call)
+  4. Skills XML index (SDK-appended, filtered by role)
        <available_skills>
-       <skill name="..." path="..." description="..." />
+         <skill>
+           <name>...</name>
+           <description>...</description>
+           <location>...</location>
+         </skill>
        </available_skills>
-       ---
-       Conversation history follows.
+  5. Current date and working directory (SDK-appended)
 
 MESSAGES (from JSONL session, ~/.system2/sessions/guide_1/):
   [turn 1] user: ...
@@ -149,12 +152,15 @@ SYSTEM PROMPT (rebuilt on every LLM call):
        ---
        ### ~/.system2/projects/1_linkedin-campaign/log.md
        [content]
-  4. ## Available Skills (dynamic, re-read every call)
+  4. Skills XML index (SDK-appended, filtered by role)
        <available_skills>
-       <skill name="..." path="..." description="..." />
+         <skill>
+           <name>...</name>
+           <description>...</description>
+           <location>...</location>
+         </skill>
        </available_skills>
-       ---
-       Conversation history follows.
+  5. Current date and working directory (SDK-appended)
 
 MESSAGES (from JSONL session, ~/.system2/sessions/conductor_3/):
   [turn 1] user: [Message from guide agent (id=1)] Here is your project...
@@ -165,7 +171,7 @@ CURRENT TURN:
   [inbound agent message / task assignment]
 ```
 
-Empty files are skipped. If no knowledge files have content, the `## Knowledge Base` block is omitted but `Conversation history follows.` is still appended. The `user` role in agent JSONL is used for all inbound messages: from the user, other agents, or the scheduler.
+Empty files are skipped. If no knowledge files have content, the `## Knowledge Base` block is omitted. The `user` role in agent JSONL is used for all inbound messages: from the user, other agents, or the scheduler.
 
 ## memory.md
 

--- a/docs/knowledge-system.md
+++ b/docs/knowledge-system.md
@@ -6,7 +6,8 @@ System2 maintains persistent knowledge in `~/.system2/knowledge/`, git-tracked f
 - `packages/server/src/knowledge/init.ts`: directory initialization
 - `packages/server/src/knowledge/templates.ts`: default file templates
 - `packages/server/src/knowledge/git.ts`: git repo setup
-- `packages/server/src/agents/host.ts`: `loadKnowledgeContext()` method
+- `packages/server/src/agents/host.ts`: `loadKnowledgeContext()` and `loadSkillsContext()` methods
+- `packages/server/src/skills/loader.ts`: skill discovery, parsing, and XML index compilation
 
 ## Knowledge Directory
 
@@ -109,6 +110,10 @@ SYSTEM PROMPT (rebuilt on every LLM call):
        ---
        ### ~/.system2/knowledge/daily_summaries/2026-03-11.md
        [content]
+  4. ## Available Skills (dynamic, re-read every call)
+       <available_skills>
+       <skill name="..." path="..." description="..." />
+       </available_skills>
        ---
        Conversation history follows.
 
@@ -144,6 +149,10 @@ SYSTEM PROMPT (rebuilt on every LLM call):
        ---
        ### ~/.system2/projects/1_linkedin-campaign/log.md
        [content]
+  4. ## Available Skills (dynamic, re-read every call)
+       <available_skills>
+       <skill name="..." path="..." description="..." />
+       </available_skills>
        ---
        Conversation history follows.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -45,7 +45,7 @@ Skills are loaded from two directories:
 
 When a user skill has the same `name` as a built-in skill, the user skill takes precedence. This allows users (or agents) to override or customize built-in workflows.
 
-The `~/.system2/skills/` directory is created automatically during server initialization and is git-tracked in the `~/.system2` repository.
+The `~/.system2/skills/` directory is created automatically during server initialization. Skill files placed here are tracked by the `~/.system2` git repository once they exist (git does not track empty directories).
 
 ## Discovery and Injection
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,6 +1,6 @@
 # Skills
 
-Skills are reusable workflow instructions stored as SKILL.md files. They fill the gap between tools (single actions) and knowledge (accumulated facts) by capturing multi-step procedures that agents can follow when performing recurring tasks.
+Skills are reusable workflow instructions stored as `.md` files (one per skill) in the skills directories. They fill the gap between tools (single actions) and knowledge (accumulated facts) by capturing multi-step procedures that agents can follow when performing recurring tasks.
 
 **Key source files:**
 - `packages/server/src/skills/loader.ts`: skill discovery, parsing, merging, filtering, and XML compilation

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,86 @@
+# Skills
+
+Skills are reusable workflow instructions stored as SKILL.md files. They fill the gap between tools (single actions) and knowledge (accumulated facts) by capturing multi-step procedures that agents can follow when performing recurring tasks.
+
+**Key source files:**
+- `packages/server/src/skills/loader.ts`: skill discovery, parsing, merging, filtering, and XML compilation
+- `packages/server/src/agents/host.ts`: `loadSkillsContext()` method and prompt integration
+- `packages/server/src/agents/agents.md`: agent-facing documentation (## Skills section)
+- `packages/server/src/knowledge/init.ts`: `~/.system2/skills/` directory creation
+
+## SKILL.md Format
+
+Each skill is a single `.md` file with YAML frontmatter:
+
+```yaml
+---
+name: deploy-pipeline
+description: Deploy a data pipeline to DiegoTower with validation
+roles: [conductor]
+---
+
+# Deploy Pipeline
+
+1. SSH into DiegoTower...
+2. Run validation checks...
+3. ...
+```
+
+### Frontmatter Fields
+
+| Field | Required | Type | Description |
+| ----- | -------- | ---- | ----------- |
+| `name` | Yes | string | Lowercase, hyphenated identifier. Used for override matching. |
+| `description` | Yes | string | One-line summary. Agents read this to decide relevance. |
+| `roles` | No | string[] | Agent roles that can use this skill. Omit or leave empty for all roles. Values are case-insensitive. |
+
+## Skill Directories
+
+Skills are loaded from two directories:
+
+| Source | Path | Precedence |
+| ------ | ---- | ---------- |
+| Built-in | `packages/server/src/agents/skills/` (copied to `dist/agents/skills/` at build) | Lower |
+| User | `~/.system2/skills/` | Higher |
+
+When a user skill has the same `name` as a built-in skill, the user skill takes precedence. This allows users (or agents) to override or customize built-in workflows.
+
+The `~/.system2/skills/` directory is created automatically during server initialization and is git-tracked in the `~/.system2` repository.
+
+## Discovery and Injection
+
+On every LLM call, `AgentHost.loadSkillsContext()`:
+
+1. Scans both directories for `.md` files (flat, non-recursive)
+2. Parses YAML frontmatter with `gray-matter`
+3. Merges skills by name (user overrides built-in)
+4. Filters to skills eligible for the current agent's role
+5. Compiles a compact XML index
+6. Returns the index under a `## Available Skills` heading
+
+The XML is appended to the system prompt after the Knowledge Base section:
+
+```xml
+<available_skills>
+<skill name="deploy-pipeline" path="~/.system2/skills/deploy-pipeline.md" description="Deploy a data pipeline to DiegoTower with validation" />
+<skill name="code-review" path="/path/to/dist/agents/skills/code-review.md" description="Run a structured code review" />
+</available_skills>
+```
+
+Agents use the `read` tool to load the full SKILL.md content when a skill is relevant to their current task. Skills are not read preemptively.
+
+## Skill Creation by Agents
+
+Guide and Conductor agents are instructed to proactively create skills in `~/.system2/skills/` when they recognize reusable patterns. They use the `write` tool with `commit_message` to create the file, which auto-commits to the `~/.system2` git repository.
+
+The litmus test agents apply: "Am I writing down a fact, or a workflow I'd want to follow again?" Facts go in knowledge files; procedures become skills.
+
+## Build Configuration
+
+Built-in skill files are copied from `src/agents/skills/` to `dist/agents/skills/` during the tsup build (`packages/server/tsup.config.ts`). The copy is dynamic (reads the directory at build time), so adding a new built-in skill only requires placing the file in the source directory.
+
+## See Also
+
+- [Agents](agents.md): system prompt construction layers (includes skills index)
+- [Knowledge System](knowledge-system.md): the knowledge files that coexist with skills in agent prompts
+- [Tools](tools.md): the tools agents use to read and create skills (`read`, `write`)

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -3,8 +3,8 @@
 Skills are reusable workflow instructions stored as `.md` files (one per skill) in the skills directories. They fill the gap between tools (single actions) and knowledge (accumulated facts) by capturing multi-step procedures that agents can follow when performing recurring tasks.
 
 **Key source files:**
-- `packages/server/src/skills/loader.ts`: skill discovery, parsing, merging, filtering, and XML compilation
-- `packages/server/src/agents/host.ts`: `loadSkillsContext()` method and prompt integration
+- `packages/server/src/skills/loader.ts`: role-based skill filtering (`extractRoles`, `filterByRole`)
+- `packages/server/src/agents/host.ts`: SDK wiring via `additionalSkillPaths` and `skillsOverride`
 - `packages/server/src/agents/agents.md`: agent-facing documentation (## Skills section)
 - `packages/server/src/knowledge/init.ts`: `~/.system2/skills/` directory creation
 
@@ -49,25 +49,27 @@ The `~/.system2/skills/` directory is created automatically during server initia
 
 ## Discovery and Injection
 
-On every LLM call, `AgentHost.loadSkillsContext()`:
+Skill discovery, frontmatter parsing, XML compilation, and prompt injection are delegated to the pi-coding-agent SDK. The server configures the SDK with two custom skill paths via `additionalSkillPaths` (user directory listed first for precedence) and a `skillsOverride` callback that filters skills by agent role.
 
-1. Scans both directories for `.md` files (flat, non-recursive)
-2. Parses YAML frontmatter with `gray-matter`
-3. Merges skills by name (user overrides built-in)
-4. Filters to skills eligible for the current agent's role
-5. Compiles a compact XML index
-6. Returns the index under a `## Available Skills` heading
+On every LLM call, the SDK:
 
-The XML is appended to the system prompt after the Knowledge Base section:
+1. Scans both directories for `.md` files
+2. Parses YAML frontmatter (name, description)
+3. Merges skills by name (first path wins, so user overrides built-in)
+4. Calls `skillsOverride`, where `filterByRole` removes skills not eligible for the current agent's role
+5. Appends a compact XML index to the system prompt after the custom prompt sections
 
 ```xml
 <available_skills>
-<skill name="deploy-pipeline" path="~/.system2/skills/deploy-pipeline.md" description="Deploy a data pipeline to DiegoTower with validation" />
-<skill name="code-review" path="/path/to/dist/agents/skills/code-review.md" description="Run a structured code review" />
+  <skill>
+    <name>deploy-pipeline</name>
+    <description>Deploy a data pipeline to DiegoTower with validation</description>
+    <location>~/.system2/skills/deploy-pipeline.md</location>
+  </skill>
 </available_skills>
 ```
 
-Agents use the `read` tool to load the full SKILL.md content when a skill is relevant to their current task. Skills are not read preemptively.
+Agents use the `read` tool to load the full skill content at the given `location` when a skill is relevant to their current task. Skills are not read preemptively.
 
 ## Skill Creation by Agents
 

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -81,7 +81,7 @@ The **Guide** is the primary user-facing agent. However, the user may choose to 
 
 ## Skills
 
-Skills are reusable workflow instructions stored as SKILL.md files. They capture multi-step procedures that go beyond a single tool call but do not belong in the knowledge base (which stores facts and accumulated state, not procedures).
+Skills are reusable workflow instructions stored as `.md` files (one per skill) in the skills directories. They capture multi-step procedures that go beyond a single tool call but do not belong in the knowledge base (which stores facts and accumulated state, not procedures).
 
 **The litmus test:** "Am I writing down a fact, or a workflow I'd want to follow again?" If it is a fact, it is knowledge. If it is a procedure, it is a skill.
 

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -97,11 +97,15 @@ Your system prompt includes an XML index of skills filtered to your role:
 
 ```xml
 <available_skills>
-<skill name="deploy-pipeline" path="~/.system2/skills/deploy-pipeline.md" description="Deploy a data pipeline to DiegoTower" />
+  <skill>
+    <name>deploy-pipeline</name>
+    <description>Deploy a data pipeline to DiegoTower</description>
+    <location>~/.system2/skills/deploy-pipeline.md</location>
+  </skill>
 </available_skills>
 ```
 
-When a skill is relevant to your current task, use `read` to load the full SKILL.md at the given `path`. Follow the instructions as written unless you have a specific reason to deviate (in which case, note the deviation and your reasoning).
+When a skill is relevant to your current task, use `read` to load the full skill file at the given `location`. Follow the instructions as written unless you have a specific reason to deviate (in which case, note the deviation and your reasoning).
 
 Do not read skills preemptively. Read a skill only when you are about to perform the workflow it describes.
 
@@ -445,8 +449,9 @@ SYSTEM PROMPT (rebuilt on every LLM call):
        ---
        ### ~/.system2/knowledge/daily_summaries/2026-03-11.md
        [content]
-       ---
-       Conversation history follows.
+  4. Skills XML index (SDK-appended, filtered by role)
+       <available_skills>...</available_skills>
+  5. Current date and working directory (SDK-appended)
 
 MESSAGES (from JSONL session, ~/.system2/sessions/guide_1/):
   [turn 1] user: ...
@@ -477,8 +482,9 @@ SYSTEM PROMPT (rebuilt on every LLM call):
        ---
        ### ~/.system2/projects/1_linkedin-campaign/log.md
        [content]
-       ---
-       Conversation history follows.
+  4. Skills XML index (SDK-appended, filtered by role)
+       <available_skills>...</available_skills>
+  5. Current date and working directory (SDK-appended)
 
 MESSAGES (from JSONL session, ~/.system2/sessions/conductor_3/):
   [turn 1] user: [Message from guide agent (id=1)] Here is your project...

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -79,6 +79,74 @@ The **Guide** is the primary user-facing agent. However, the user may choose to 
 - `web_search` is only available when a Brave Search API key is configured.
 - `show_artifact` is available to all agents. Any agent can display a file in the user's UI. Accepts an absolute path (or `~/`-prefixed). If the artifact is registered in the database, its title is used for the tab label; otherwise the filename is used. Only one artifact is watched per client connection at a time (for live reload).
 
+## Skills
+
+Skills are reusable workflow instructions stored as SKILL.md files. They capture multi-step procedures that go beyond a single tool call but do not belong in the knowledge base (which stores facts and accumulated state, not procedures).
+
+**The litmus test:** "Am I writing down a fact, or a workflow I'd want to follow again?" If it is a fact, it is knowledge. If it is a procedure, it is a skill.
+
+| Concept | What it is | Example |
+| ------- | ---------- | ------- |
+| **Tool** | A single action you can invoke | `bash`, `read`, `write`, `read_system2_db` |
+| **Knowledge** | Accumulated facts and state | infrastructure.md, user.md, memory.md |
+| **Skill** | A reusable multi-step workflow | How to set up a data pipeline, how to run a code review |
+
+### How Skills Work
+
+Your system prompt includes an XML index of skills filtered to your role:
+
+```xml
+<available_skills>
+<skill name="deploy-pipeline" path="~/.system2/skills/deploy-pipeline.md" description="Deploy a data pipeline to DiegoTower" />
+</available_skills>
+```
+
+When a skill is relevant to your current task, use `read` to load the full SKILL.md at the given `path`. Follow the instructions as written unless you have a specific reason to deviate (in which case, note the deviation and your reasoning).
+
+Do not read skills preemptively. Read a skill only when you are about to perform the workflow it describes.
+
+### SKILL.md Format
+
+Each skill is a single `.md` file with YAML frontmatter:
+
+```yaml
+---
+name: skill-name
+description: One-line summary of when and why to use this skill
+roles: [conductor, reviewer]
+---
+
+# Skill Name
+
+Step-by-step instructions...
+```
+
+- `name` (required): lowercase, hyphenated identifier
+- `description` (required): concise summary (used to decide relevance, so be specific)
+- `roles` (optional): list of agent roles that can use this skill. Omit or leave empty for skills available to all roles.
+
+### Skill Sources and Precedence
+
+- **Built-in skills** ship with System2 and are available to all installations
+- **User skills** live in `~/.system2/skills/` and are created by agents or the user
+- When a user skill has the same `name` as a built-in skill, the user skill takes precedence
+
+### Creating Skills
+
+**Guide and Conductor agents** should proactively create skills in `~/.system2/skills/` when they recognize reusable patterns. Create a skill when:
+
+- You have performed the same multi-step workflow more than once
+- You are explaining a procedure to another agent that could be standardized
+- Information you are about to write to a knowledge file is really a procedure, not a fact
+- A task or project reveals a workflow that will recur
+
+To create a skill:
+
+1. Choose a descriptive name (lowercase, hyphenated)
+2. Write the SKILL.md file using `write` with `commit_message` to `~/.system2/skills/{name}.md`
+3. Set `roles` to restrict to specific agent roles, or omit for all roles
+4. Keep instructions concrete and actionable (tool names, file paths, exact commands)
+
 ## The Database
 
 `~/.system2/app.db` is a SQLite database and the **single source of truth** for all work management. Query it with `read_system2_db` (SELECT only) and write to it with `write_system2_db` (named operations).

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -33,7 +33,7 @@ import { MessageHistory } from '../chat/history.js';
 import type { DatabaseClient } from '../db/client.js';
 import { resolveProjectDir } from '../projects/dir.js';
 import type { ReminderManager } from '../reminders/manager.js';
-import { compileSkillsXml, filterSkillsByRole, loadSkills } from '../skills/loader.js';
+import { filterByRole } from '../skills/loader.js';
 import { AuthResolver } from './auth-resolver.js';
 import type { AgentRegistry } from './registry.js';
 import {
@@ -360,17 +360,22 @@ export class AgentHost {
       compaction: { reserveTokens: Math.floor(model.contextWindow * 0.5) },
     });
 
-    // Create resource loader with custom system prompt
+    // Create resource loader with custom system prompt.
+    // Knowledge files are re-read on every LLM call via reload() before each prompt.
+    // Skills are discovered by the SDK from our two directories, then filtered by agent role.
     this.resourceLoader = new DefaultResourceLoader({
       cwd: SYSTEM2_DIR,
       agentDir: SYSTEM2_DIR,
-      // Static agent instructions (from package) + dynamic context (from ~/.system2/).
-      // Knowledge files and skills index are re-read on every LLM call via reload() before each prompt.
-      systemPromptOverride: () =>
-        `${staticPrompt}${this.loadKnowledgeContext()}${this.loadSkillsContext()}\n\n---\n\nConversation history follows.`,
-      // Disable default resource discovery (we manage our own)
-      noExtensions: true,
+      systemPromptOverride: () => `${staticPrompt}${this.loadKnowledgeContext()}`,
+      // Suppress SDK default skill directories (~/.pi/agent/skills/, .pi/skills/)
+      // but provide our own paths. User dir first for first-wins precedence.
       noSkills: true,
+      additionalSkillPaths: [join(SYSTEM2_DIR, 'skills'), join(AGENT_DIR, 'skills')],
+      skillsOverride: ({ skills, diagnostics }) => ({
+        skills: filterByRole(skills, this.agentRole ?? ''),
+        diagnostics,
+      }),
+      noExtensions: true,
       noPromptTemplates: true,
       noThemes: true,
     });
@@ -938,22 +943,6 @@ export class AgentHost {
 
     if (sections.length === 0) return '';
     return `\n\n## Knowledge Base\n\n${sections.join('\n\n---\n\n')}`;
-  }
-
-  /**
-   * Load skills from built-in and user directories, filter by role,
-   * and return a compact XML index for system prompt injection.
-   * Re-read on every turn so newly created skills are picked up immediately.
-   */
-  private loadSkillsContext(): string {
-    if (!this.agentRole) return '';
-    const builtinDir = join(AGENT_DIR, 'skills');
-    const userDir = join(SYSTEM2_DIR, 'skills');
-    const allSkills = loadSkills(builtinDir, userDir);
-    const eligible = filterSkillsByRole(allSkills, this.agentRole);
-    const xml = compileSkillsXml(eligible);
-    if (!xml) return '';
-    return `\n\n## Available Skills\n\n${xml}`;
   }
 
   /**

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -33,6 +33,7 @@ import { MessageHistory } from '../chat/history.js';
 import type { DatabaseClient } from '../db/client.js';
 import { resolveProjectDir } from '../projects/dir.js';
 import type { ReminderManager } from '../reminders/manager.js';
+import { compileSkillsXml, filterSkillsByRole, loadSkills } from '../skills/loader.js';
 import { AuthResolver } from './auth-resolver.js';
 import type { AgentRegistry } from './registry.js';
 import {
@@ -363,10 +364,10 @@ export class AgentHost {
     this.resourceLoader = new DefaultResourceLoader({
       cwd: SYSTEM2_DIR,
       agentDir: SYSTEM2_DIR,
-      // Static agent instructions (from package) + dynamic knowledge files (from ~/.system2/).
-      // Knowledge files are re-read on every LLM call via reload() before each prompt.
+      // Static agent instructions (from package) + dynamic context (from ~/.system2/).
+      // Knowledge files and skills index are re-read on every LLM call via reload() before each prompt.
       systemPromptOverride: () =>
-        `${staticPrompt}${this.loadKnowledgeContext()}\n\n---\n\nConversation history follows.`,
+        `${staticPrompt}${this.loadKnowledgeContext()}${this.loadSkillsContext()}\n\n---\n\nConversation history follows.`,
       // Disable default resource discovery (we manage our own)
       noExtensions: true,
       noSkills: true,
@@ -937,6 +938,22 @@ export class AgentHost {
 
     if (sections.length === 0) return '';
     return `\n\n## Knowledge Base\n\n${sections.join('\n\n---\n\n')}`;
+  }
+
+  /**
+   * Load skills from built-in and user directories, filter by role,
+   * and return a compact XML index for system prompt injection.
+   * Re-read on every turn so newly created skills are picked up immediately.
+   */
+  private loadSkillsContext(): string {
+    if (!this.agentRole) return '';
+    const builtinDir = join(AGENT_DIR, 'skills');
+    const userDir = join(SYSTEM2_DIR, 'skills');
+    const allSkills = loadSkills(builtinDir, userDir);
+    const eligible = filterSkillsByRole(allSkills, this.agentRole);
+    const xml = compileSkillsXml(eligible);
+    if (!xml) return '';
+    return `\n\n## Available Skills\n\n${xml}`;
   }
 
   /**

--- a/packages/server/src/knowledge/init.ts
+++ b/packages/server/src/knowledge/init.ts
@@ -36,6 +36,10 @@ export function initializeKnowledge(system2Dir: string): void {
   if (!existsSync(projectsDir)) {
     mkdirSync(projectsDir, { recursive: true });
   }
+  const skillsDir = join(system2Dir, 'skills');
+  if (!existsSync(skillsDir)) {
+    mkdirSync(skillsDir, { recursive: true });
+  }
 
   // Write template files (only if they don't exist)
   const templates: [string, string][] = [

--- a/packages/server/src/skills/loader.test.ts
+++ b/packages/server/src/skills/loader.test.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
@@ -117,6 +117,12 @@ describe('parseSkillFile', () => {
     });
     const skill = parseSkillFile(path, 'user');
     expect(skill?.meta.name).toBe('deploy-pipeline');
+  });
+
+  it('returns null for whitespace-only name', () => {
+    const path = join(tempDir, 'spaces.md');
+    writeFileSync(path, '---\nname: "   "\ndescription: Blank name\n---\n\nContent\n');
+    expect(parseSkillFile(path, 'user')).toBeNull();
   });
 
   it('returns null for invalid roles type (number)', () => {
@@ -318,10 +324,11 @@ describe('compileSkillsXml', () => {
   });
 
   it('replaces home directory with ~ in paths', () => {
+    const home = homedir();
     const skills: Skill[] = [
       {
         meta: { name: 'test', description: 'Test', roles: [] },
-        path: join(process.env.HOME ?? '/home/user', '.system2', 'skills', 'test.md'),
+        path: join(home, '.system2', 'skills', 'test.md'),
         source: 'user',
       },
     ];
@@ -330,7 +337,7 @@ describe('compileSkillsXml', () => {
   });
 
   it('does not replace home directory when it appears mid-path', () => {
-    const home = process.env.HOME ?? '/home/user';
+    const home = homedir();
     const skills: Skill[] = [
       {
         meta: { name: 'test', description: 'Test', roles: [] },

--- a/packages/server/src/skills/loader.test.ts
+++ b/packages/server/src/skills/loader.test.ts
@@ -125,6 +125,26 @@ describe('parseSkillFile', () => {
     expect(parseSkillFile(path, 'user')).toBeNull();
   });
 
+  it('trims whitespace from roles string', () => {
+    const path = writeSkill(tempDir, 'trim-role.md', {
+      name: 'trim',
+      description: 'Trimmed role',
+      roles: ' conductor ',
+    });
+    const skill = parseSkillFile(path, 'user');
+    expect(skill?.meta.roles).toEqual(['conductor']);
+  });
+
+  it('trims whitespace from roles array entries', () => {
+    const path = join(tempDir, 'trim-array.md');
+    writeFileSync(
+      path,
+      '---\nname: trim\ndescription: Trimmed array\nroles:\n  - " guide "\n  - " reviewer "\n---\n\nContent\n'
+    );
+    const skill = parseSkillFile(path, 'user');
+    expect(skill?.meta.roles).toEqual(['guide', 'reviewer']);
+  });
+
   it('returns null for invalid roles type (number)', () => {
     const path = join(tempDir, 'bad-roles.md');
     writeFileSync(path, '---\nname: bad\ndescription: Bad roles\nroles: 42\n---\n\nContent\n');

--- a/packages/server/src/skills/loader.test.ts
+++ b/packages/server/src/skills/loader.test.ts
@@ -1,15 +1,9 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { homedir, tmpdir } from 'node:os';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { Skill } from '@mariozechner/pi-coding-agent';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import {
-  compileSkillsXml,
-  filterSkillsByRole,
-  loadSkills,
-  parseSkillFile,
-  type Skill,
-  scanDirectory,
-} from './loader.js';
+import { extractRoles, filterByRole } from './loader.js';
 
 let tempDir: string;
 
@@ -21,368 +15,226 @@ afterEach(() => {
   rmSync(tempDir, { recursive: true, force: true });
 });
 
-function writeSkill(dir: string, filename: string, frontmatter: Record<string, unknown>): string {
-  const fm = Object.entries(frontmatter)
-    .map(([k, v]) => {
-      if (Array.isArray(v)) return `${k}: [${v.map((i) => `"${i}"`).join(', ')}]`;
-      return `${k}: "${v}"`;
-    })
-    .join('\n');
-  const content = `---\n${fm}\n---\n\n# ${frontmatter.name ?? 'Test'}\n\nInstructions here.\n`;
+function writeSkillFile(dir: string, filename: string, content: string): string {
   const filePath = join(dir, filename);
   writeFileSync(filePath, content, 'utf-8');
   return filePath;
 }
 
-describe('parseSkillFile', () => {
-  it('parses a valid skill file', () => {
-    const path = writeSkill(tempDir, 'deploy.md', {
-      name: 'deploy',
-      description: 'Deploy to production',
-      roles: ['conductor'],
-    });
-    const skill = parseSkillFile(path, 'user');
-    expect(skill).not.toBeNull();
-    expect(skill?.meta.name).toBe('deploy');
-    expect(skill?.meta.description).toBe('Deploy to production');
-    expect(skill?.meta.roles).toEqual(['conductor']);
-    expect(skill?.source).toBe('user');
-    expect(skill?.path).toBe(path);
+function makeSdkSkill(overrides: Partial<Skill> & { filePath: string }): Skill {
+  return {
+    name: 'test',
+    description: 'Test skill',
+    baseDir: '/fake',
+    sourceInfo: { type: 'path' },
+    disableModelInvocation: false,
+    ...overrides,
+  } as Skill;
+}
+
+describe('extractRoles', () => {
+  it('returns roles array from valid frontmatter', () => {
+    const path = writeSkillFile(
+      tempDir,
+      'deploy.md',
+      '---\nname: deploy\ndescription: Deploy\nroles: [conductor]\n---\n\nContent\n'
+    );
+    expect(extractRoles(path)).toEqual(['conductor']);
   });
 
-  it('returns null for missing name', () => {
-    const path = writeSkill(tempDir, 'bad.md', {
-      description: 'No name here',
-    });
-    expect(parseSkillFile(path, 'builtin')).toBeNull();
+  it('normalizes roles to lowercase', () => {
+    const path = writeSkillFile(
+      tempDir,
+      'test.md',
+      '---\nname: test\ndescription: Test\nroles: [Conductor, REVIEWER]\n---\n\nContent\n'
+    );
+    expect(extractRoles(path)).toEqual(['conductor', 'reviewer']);
   });
 
-  it('returns null for missing description', () => {
-    const path = writeSkill(tempDir, 'bad.md', {
-      name: 'no-desc',
-    });
-    expect(parseSkillFile(path, 'builtin')).toBeNull();
-  });
-
-  it('returns null for non-existent file', () => {
-    expect(parseSkillFile(join(tempDir, 'nope.md'), 'user')).toBeNull();
-  });
-
-  it('returns null for file with no frontmatter', () => {
-    const path = join(tempDir, 'plain.md');
-    writeFileSync(path, '# Just markdown\n\nNo frontmatter here.\n', 'utf-8');
-    expect(parseSkillFile(path, 'user')).toBeNull();
-  });
-
-  it('normalizes roles string to array', () => {
-    const path = writeSkill(tempDir, 'single-role.md', {
-      name: 'single',
-      description: 'Single role',
-      roles: 'Guide',
-    });
-    const skill = parseSkillFile(path, 'user');
-    expect(skill?.meta.roles).toEqual(['guide']);
-  });
-
-  it('normalizes roles array to lowercase', () => {
-    const path = writeSkill(tempDir, 'mixed.md', {
-      name: 'mixed',
-      description: 'Mixed case roles',
-      roles: ['Conductor', 'REVIEWER'],
-    });
-    const skill = parseSkillFile(path, 'builtin');
-    expect(skill?.meta.roles).toEqual(['conductor', 'reviewer']);
-  });
-
-  it('treats omitted roles as empty array (all roles)', () => {
-    const path = writeSkill(tempDir, 'all.md', {
-      name: 'all-roles',
-      description: 'For everyone',
-    });
-    const skill = parseSkillFile(path, 'user');
-    expect(skill?.meta.roles).toEqual([]);
-  });
-
-  it('treats empty roles array as all roles', () => {
-    const path = join(tempDir, 'empty-roles.md');
-    writeFileSync(path, '---\nname: empty\ndescription: Empty roles\nroles: []\n---\n\nContent\n');
-    const skill = parseSkillFile(path, 'user');
-    expect(skill?.meta.roles).toEqual([]);
-  });
-
-  it('normalizes name to lowercase and trims whitespace', () => {
-    const path = writeSkill(tempDir, 'cased.md', {
-      name: '  Deploy-Pipeline ',
-      description: 'Cased name',
-    });
-    const skill = parseSkillFile(path, 'user');
-    expect(skill?.meta.name).toBe('deploy-pipeline');
-  });
-
-  it('returns null for whitespace-only name', () => {
-    const path = join(tempDir, 'spaces.md');
-    writeFileSync(path, '---\nname: "   "\ndescription: Blank name\n---\n\nContent\n');
-    expect(parseSkillFile(path, 'user')).toBeNull();
+  it('coerces string roles to single-element array', () => {
+    const path = writeSkillFile(
+      tempDir,
+      'test.md',
+      '---\nname: test\ndescription: Test\nroles: Guide\n---\n\nContent\n'
+    );
+    expect(extractRoles(path)).toEqual(['guide']);
   });
 
   it('trims whitespace from roles string', () => {
-    const path = writeSkill(tempDir, 'trim-role.md', {
-      name: 'trim',
-      description: 'Trimmed role',
-      roles: ' conductor ',
-    });
-    const skill = parseSkillFile(path, 'user');
-    expect(skill?.meta.roles).toEqual(['conductor']);
+    const path = writeSkillFile(
+      tempDir,
+      'test.md',
+      '---\nname: test\ndescription: Test\nroles: " conductor "\n---\n\nContent\n'
+    );
+    expect(extractRoles(path)).toEqual(['conductor']);
   });
 
   it('trims whitespace from roles array entries', () => {
-    const path = join(tempDir, 'trim-array.md');
-    writeFileSync(
-      path,
-      '---\nname: trim\ndescription: Trimmed array\nroles:\n  - " guide "\n  - " reviewer "\n---\n\nContent\n'
+    const path = writeSkillFile(
+      tempDir,
+      'test.md',
+      '---\nname: test\ndescription: Test\nroles:\n  - " guide "\n  - " reviewer "\n---\n\nContent\n'
     );
-    const skill = parseSkillFile(path, 'user');
-    expect(skill?.meta.roles).toEqual(['guide', 'reviewer']);
+    expect(extractRoles(path)).toEqual(['guide', 'reviewer']);
+  });
+
+  it('returns empty array when roles is omitted', () => {
+    const path = writeSkillFile(
+      tempDir,
+      'test.md',
+      '---\nname: test\ndescription: Test\n---\n\nContent\n'
+    );
+    expect(extractRoles(path)).toEqual([]);
+  });
+
+  it('returns empty array for empty roles array', () => {
+    const path = writeSkillFile(
+      tempDir,
+      'test.md',
+      '---\nname: test\ndescription: Test\nroles: []\n---\n\nContent\n'
+    );
+    expect(extractRoles(path)).toEqual([]);
   });
 
   it('returns null for whitespace-only roles string', () => {
-    const path = join(tempDir, 'ws-role.md');
-    writeFileSync(path, '---\nname: ws\ndescription: WS role\nroles: "   "\n---\n\nContent\n');
-    expect(parseSkillFile(path, 'user')).toBeNull();
-  });
-
-  it('filters out empty-string roles from array after trimming', () => {
-    const path = join(tempDir, 'empty-entry.md');
-    writeFileSync(
-      path,
-      '---\nname: mixed\ndescription: Mixed\nroles:\n  - "guide"\n  - "   "\n---\n\nContent\n'
+    const path = writeSkillFile(
+      tempDir,
+      'test.md',
+      '---\nname: test\ndescription: Test\nroles: "   "\n---\n\nContent\n'
     );
-    const skill = parseSkillFile(path, 'user');
-    expect(skill?.meta.roles).toEqual(['guide']);
+    expect(extractRoles(path)).toBeNull();
   });
 
   it('returns null for invalid roles type (number)', () => {
-    const path = join(tempDir, 'bad-roles.md');
-    writeFileSync(path, '---\nname: bad\ndescription: Bad roles\nroles: 42\n---\n\nContent\n');
-    expect(parseSkillFile(path, 'user')).toBeNull();
-  });
-
-  it('returns null for roles array with only non-string entries', () => {
-    const path = join(tempDir, 'bad-array.md');
-    writeFileSync(
-      path,
-      '---\nname: bad\ndescription: Bad array\nroles:\n  - 1\n  - 2\n---\n\nContent\n'
+    const path = writeSkillFile(
+      tempDir,
+      'test.md',
+      '---\nname: test\ndescription: Test\nroles: 42\n---\n\nContent\n'
     );
-    expect(parseSkillFile(path, 'user')).toBeNull();
-  });
-});
-
-describe('scanDirectory', () => {
-  it('returns empty array for non-existent directory', () => {
-    expect(scanDirectory(join(tempDir, 'nope'), 'user')).toEqual([]);
+    expect(extractRoles(path)).toBeNull();
   });
 
-  it('returns empty array for empty directory', () => {
-    const dir = join(tempDir, 'empty');
-    mkdirSync(dir);
-    expect(scanDirectory(dir, 'builtin')).toEqual([]);
-  });
-
-  it('scans valid skill files', () => {
-    writeSkill(tempDir, 'a.md', { name: 'alpha', description: 'Alpha skill' });
-    writeSkill(tempDir, 'b.md', { name: 'beta', description: 'Beta skill' });
-    const skills = scanDirectory(tempDir, 'user');
-    expect(skills).toHaveLength(2);
-    expect(skills.map((s) => s.meta.name).sort()).toEqual(['alpha', 'beta']);
-  });
-
-  it('skips invalid files and includes valid ones', () => {
-    writeSkill(tempDir, 'good.md', { name: 'good', description: 'Good one' });
-    writeFileSync(join(tempDir, 'bad.md'), '# No frontmatter\n', 'utf-8');
-    const skills = scanDirectory(tempDir, 'builtin');
-    expect(skills).toHaveLength(1);
-    expect(skills[0].meta.name).toBe('good');
-  });
-
-  it('skips README.md', () => {
-    writeFileSync(
-      join(tempDir, 'README.md'),
-      '---\nname: readme\ndescription: Should be skipped\n---\n'
+  it('returns null for array with only non-string entries', () => {
+    const path = writeSkillFile(
+      tempDir,
+      'test.md',
+      '---\nname: test\ndescription: Test\nroles:\n  - 1\n  - 2\n---\n\nContent\n'
     );
-    writeSkill(tempDir, 'real.md', { name: 'real', description: 'Real skill' });
-    const skills = scanDirectory(tempDir, 'builtin');
-    expect(skills).toHaveLength(1);
-    expect(skills[0].meta.name).toBe('real');
+    expect(extractRoles(path)).toBeNull();
+  });
+
+  it('filters out empty-string entries from mixed array', () => {
+    const path = writeSkillFile(
+      tempDir,
+      'test.md',
+      '---\nname: test\ndescription: Test\nroles:\n  - "guide"\n  - "   "\n---\n\nContent\n'
+    );
+    expect(extractRoles(path)).toEqual(['guide']);
+  });
+
+  it('silently drops non-string entries from mixed array', () => {
+    const path = writeSkillFile(
+      tempDir,
+      'test.md',
+      '---\nname: test\ndescription: Test\nroles:\n  - guide\n  - 123\n---\n\nContent\n'
+    );
+    expect(extractRoles(path)).toEqual(['guide']);
+  });
+
+  it('returns empty array for non-existent file', () => {
+    expect(extractRoles(join(tempDir, 'nope.md'))).toEqual([]);
+  });
+
+  it('returns empty array for file with no frontmatter', () => {
+    const path = writeSkillFile(tempDir, 'plain.md', '# Just markdown\n\nNo frontmatter.\n');
+    expect(extractRoles(path)).toEqual([]);
   });
 });
 
-describe('loadSkills', () => {
-  let builtinDir: string;
-  let userDir: string;
+describe('filterByRole', () => {
+  function skillAt(filePath: string): Skill {
+    return makeSdkSkill({ filePath });
+  }
 
-  beforeEach(() => {
-    builtinDir = join(tempDir, 'builtin');
-    userDir = join(tempDir, 'user');
-    mkdirSync(builtinDir);
-    mkdirSync(userDir);
-  });
-
-  it('merges skills from both directories', () => {
-    writeSkill(builtinDir, 'a.md', { name: 'alpha', description: 'Built-in alpha' });
-    writeSkill(userDir, 'b.md', { name: 'beta', description: 'User beta' });
-    const skills = loadSkills(builtinDir, userDir);
-    expect(skills).toHaveLength(2);
-  });
-
-  it('user skill overrides built-in with same name', () => {
-    writeSkill(builtinDir, 'deploy.md', { name: 'deploy', description: 'Built-in deploy' });
-    writeSkill(userDir, 'deploy.md', { name: 'deploy', description: 'User deploy' });
-    const skills = loadSkills(builtinDir, userDir);
-    expect(skills).toHaveLength(1);
-    expect(skills[0].meta.description).toBe('User deploy');
-    expect(skills[0].source).toBe('user');
-  });
-
-  it('user skill overrides built-in regardless of name casing', () => {
-    writeSkill(builtinDir, 'deploy.md', { name: 'deploy', description: 'Built-in' });
-    writeSkill(userDir, 'deploy.md', { name: 'Deploy', description: 'User' });
-    const skills = loadSkills(builtinDir, userDir);
-    expect(skills).toHaveLength(1);
-    expect(skills[0].meta.description).toBe('User');
-  });
-
-  it('handles empty directories', () => {
-    expect(loadSkills(builtinDir, userDir)).toEqual([]);
-  });
-
-  it('handles non-existent directories', () => {
-    expect(loadSkills(join(tempDir, 'nope1'), join(tempDir, 'nope2'))).toEqual([]);
-  });
-});
-
-describe('filterSkillsByRole', () => {
-  const allRolesSkill: Skill = {
-    meta: { name: 'shared', description: 'For all', roles: [] },
-    path: '/fake/shared.md',
-    source: 'builtin',
-  };
-  const conductorSkill: Skill = {
-    meta: { name: 'deploy', description: 'Deploy', roles: ['conductor'] },
-    path: '/fake/deploy.md',
-    source: 'user',
-  };
-  const guideReviewerSkill: Skill = {
-    meta: { name: 'review', description: 'Review', roles: ['guide', 'reviewer'] },
-    path: '/fake/review.md',
-    source: 'builtin',
-  };
-
-  it('includes all-role skills for any role', () => {
-    const result = filterSkillsByRole([allRolesSkill], 'narrator');
+  it('includes skills with no roles restriction (all roles)', () => {
+    const path = writeSkillFile(
+      tempDir,
+      'all.md',
+      '---\nname: all\ndescription: For all\n---\n\nContent\n'
+    );
+    const result = filterByRole([skillAt(path)], 'narrator');
     expect(result).toHaveLength(1);
   });
 
-  it('includes role-specific skill for matching role', () => {
-    const result = filterSkillsByRole([conductorSkill], 'conductor');
+  it('includes skills matching the agent role', () => {
+    const path = writeSkillFile(
+      tempDir,
+      'deploy.md',
+      '---\nname: deploy\ndescription: Deploy\nroles: [conductor]\n---\n\nContent\n'
+    );
+    const result = filterByRole([skillAt(path)], 'conductor');
     expect(result).toHaveLength(1);
   });
 
-  it('excludes role-specific skill for non-matching role', () => {
-    const result = filterSkillsByRole([conductorSkill], 'guide');
+  it('excludes skills not matching the agent role', () => {
+    const path = writeSkillFile(
+      tempDir,
+      'deploy.md',
+      '---\nname: deploy\ndescription: Deploy\nroles: [conductor]\n---\n\nContent\n'
+    );
+    const result = filterByRole([skillAt(path)], 'guide');
     expect(result).toHaveLength(0);
   });
 
-  it('handles mixed skills correctly', () => {
-    const all = [allRolesSkill, conductorSkill, guideReviewerSkill];
-    expect(filterSkillsByRole(all, 'conductor')).toHaveLength(2); // shared + deploy
-    expect(filterSkillsByRole(all, 'guide')).toHaveLength(2); // shared + review
-    expect(filterSkillsByRole(all, 'reviewer')).toHaveLength(2); // shared + review
-    expect(filterSkillsByRole(all, 'narrator')).toHaveLength(1); // shared only
+  it('excludes skills with invalid roles metadata', () => {
+    const path = writeSkillFile(
+      tempDir,
+      'bad.md',
+      '---\nname: bad\ndescription: Bad\nroles: 42\n---\n\nContent\n'
+    );
+    const result = filterByRole([skillAt(path)], 'conductor');
+    expect(result).toHaveLength(0);
   });
 
   it('normalizes role comparison to lowercase', () => {
-    const result = filterSkillsByRole([conductorSkill], 'Conductor');
+    const path = writeSkillFile(
+      tempDir,
+      'deploy.md',
+      '---\nname: deploy\ndescription: Deploy\nroles: [conductor]\n---\n\nContent\n'
+    );
+    const result = filterByRole([skillAt(path)], 'Conductor');
     expect(result).toHaveLength(1);
   });
-});
 
-describe('compileSkillsXml', () => {
-  it('returns empty string for no skills', () => {
-    expect(compileSkillsXml([])).toBe('');
+  it('handles mixed skills correctly', () => {
+    const allPath = writeSkillFile(
+      tempDir,
+      'all.md',
+      '---\nname: all\ndescription: For all\n---\n\nContent\n'
+    );
+    const conductorPath = writeSkillFile(
+      tempDir,
+      'deploy.md',
+      '---\nname: deploy\ndescription: Deploy\nroles: [conductor]\n---\n\nContent\n'
+    );
+    const guidePath = writeSkillFile(
+      tempDir,
+      'review.md',
+      '---\nname: review\ndescription: Review\nroles: [guide, reviewer]\n---\n\nContent\n'
+    );
+    const all = [skillAt(allPath), skillAt(conductorPath), skillAt(guidePath)];
+    expect(filterByRole(all, 'conductor')).toHaveLength(2); // all + deploy
+    expect(filterByRole(all, 'guide')).toHaveLength(2); // all + review
+    expect(filterByRole(all, 'narrator')).toHaveLength(1); // all only
   });
 
-  it('produces valid XML structure', () => {
-    const skills: Skill[] = [
-      {
-        meta: { name: 'deploy', description: 'Deploy to prod', roles: [] },
-        path: '/home/user/skills/deploy.md',
-        source: 'user',
-      },
-    ];
-    const xml = compileSkillsXml(skills);
-    expect(xml).toContain('<available_skills>');
-    expect(xml).toContain('</available_skills>');
-    expect(xml).toContain('name="deploy"');
-    expect(xml).toContain('description="Deploy to prod"');
-  });
-
-  it('sorts skills alphabetically by name', () => {
-    const skills: Skill[] = [
-      {
-        meta: { name: 'zeta', description: 'Z', roles: [] },
-        path: '/tmp/zeta.md',
-        source: 'builtin',
-      },
-      {
-        meta: { name: 'alpha', description: 'A', roles: [] },
-        path: '/tmp/alpha.md',
-        source: 'builtin',
-      },
-    ];
-    const xml = compileSkillsXml(skills);
-    const alphaIdx = xml.indexOf('name="alpha"');
-    const zetaIdx = xml.indexOf('name="zeta"');
-    expect(alphaIdx).toBeLessThan(zetaIdx);
-  });
-
-  it('escapes XML special characters', () => {
-    const skills: Skill[] = [
-      {
-        meta: { name: 'test', description: 'Uses <bash> & "quotes"', roles: [] },
-        path: '/tmp/test.md',
-        source: 'builtin',
-      },
-    ];
-    const xml = compileSkillsXml(skills);
-    expect(xml).toContain('&lt;bash&gt;');
-    expect(xml).toContain('&amp;');
-    expect(xml).toContain('&quot;quotes&quot;');
-  });
-
-  it('replaces home directory with ~ in paths', () => {
-    const home = homedir();
-    const skills: Skill[] = [
-      {
-        meta: { name: 'test', description: 'Test', roles: [] },
-        path: join(home, '.system2', 'skills', 'test.md'),
-        source: 'user',
-      },
-    ];
-    const xml = compileSkillsXml(skills);
-    expect(xml).toContain('~/.system2/skills/test.md');
-  });
-
-  it('does not replace home directory when it appears mid-path', () => {
-    const home = homedir();
-    const skills: Skill[] = [
-      {
-        meta: { name: 'test', description: 'Test', roles: [] },
-        path: `/other${home}/skills/test.md`,
-        source: 'builtin',
-      },
-    ];
-    const xml = compileSkillsXml(skills);
-    expect(xml).not.toContain('path="~');
-    expect(xml).toContain(`/other${home}/skills/test.md`);
+  it('returns all skills when role is empty', () => {
+    const path = writeSkillFile(
+      tempDir,
+      'deploy.md',
+      '---\nname: deploy\ndescription: Deploy\nroles: [conductor]\n---\n\nContent\n'
+    );
+    const result = filterByRole([skillAt(path)], '');
+    expect(result).toHaveLength(1);
   });
 });

--- a/packages/server/src/skills/loader.test.ts
+++ b/packages/server/src/skills/loader.test.ts
@@ -109,6 +109,30 @@ describe('parseSkillFile', () => {
     const skill = parseSkillFile(path, 'user');
     expect(skill?.meta.roles).toEqual([]);
   });
+
+  it('normalizes name to lowercase and trims whitespace', () => {
+    const path = writeSkill(tempDir, 'cased.md', {
+      name: '  Deploy-Pipeline ',
+      description: 'Cased name',
+    });
+    const skill = parseSkillFile(path, 'user');
+    expect(skill?.meta.name).toBe('deploy-pipeline');
+  });
+
+  it('returns null for invalid roles type (number)', () => {
+    const path = join(tempDir, 'bad-roles.md');
+    writeFileSync(path, '---\nname: bad\ndescription: Bad roles\nroles: 42\n---\n\nContent\n');
+    expect(parseSkillFile(path, 'user')).toBeNull();
+  });
+
+  it('returns null for roles array with only non-string entries', () => {
+    const path = join(tempDir, 'bad-array.md');
+    writeFileSync(
+      path,
+      '---\nname: bad\ndescription: Bad array\nroles:\n  - 1\n  - 2\n---\n\nContent\n'
+    );
+    expect(parseSkillFile(path, 'user')).toBeNull();
+  });
 });
 
 describe('scanDirectory', () => {
@@ -175,6 +199,14 @@ describe('loadSkills', () => {
     expect(skills).toHaveLength(1);
     expect(skills[0].meta.description).toBe('User deploy');
     expect(skills[0].source).toBe('user');
+  });
+
+  it('user skill overrides built-in regardless of name casing', () => {
+    writeSkill(builtinDir, 'deploy.md', { name: 'deploy', description: 'Built-in' });
+    writeSkill(userDir, 'deploy.md', { name: 'Deploy', description: 'User' });
+    const skills = loadSkills(builtinDir, userDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].meta.description).toBe('User');
   });
 
   it('handles empty directories', () => {
@@ -295,5 +327,19 @@ describe('compileSkillsXml', () => {
     ];
     const xml = compileSkillsXml(skills);
     expect(xml).toContain('~/.system2/skills/test.md');
+  });
+
+  it('does not replace home directory when it appears mid-path', () => {
+    const home = process.env.HOME ?? '/home/user';
+    const skills: Skill[] = [
+      {
+        meta: { name: 'test', description: 'Test', roles: [] },
+        path: `/other${home}/skills/test.md`,
+        source: 'builtin',
+      },
+    ];
+    const xml = compileSkillsXml(skills);
+    expect(xml).not.toContain('path="~');
+    expect(xml).toContain(`/other${home}/skills/test.md`);
   });
 });

--- a/packages/server/src/skills/loader.test.ts
+++ b/packages/server/src/skills/loader.test.ts
@@ -145,6 +145,22 @@ describe('parseSkillFile', () => {
     expect(skill?.meta.roles).toEqual(['guide', 'reviewer']);
   });
 
+  it('returns null for whitespace-only roles string', () => {
+    const path = join(tempDir, 'ws-role.md');
+    writeFileSync(path, '---\nname: ws\ndescription: WS role\nroles: "   "\n---\n\nContent\n');
+    expect(parseSkillFile(path, 'user')).toBeNull();
+  });
+
+  it('filters out empty-string roles from array after trimming', () => {
+    const path = join(tempDir, 'empty-entry.md');
+    writeFileSync(
+      path,
+      '---\nname: mixed\ndescription: Mixed\nroles:\n  - "guide"\n  - "   "\n---\n\nContent\n'
+    );
+    const skill = parseSkillFile(path, 'user');
+    expect(skill?.meta.roles).toEqual(['guide']);
+  });
+
   it('returns null for invalid roles type (number)', () => {
     const path = join(tempDir, 'bad-roles.md');
     writeFileSync(path, '---\nname: bad\ndescription: Bad roles\nroles: 42\n---\n\nContent\n');

--- a/packages/server/src/skills/loader.test.ts
+++ b/packages/server/src/skills/loader.test.ts
@@ -1,0 +1,299 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  compileSkillsXml,
+  filterSkillsByRole,
+  loadSkills,
+  parseSkillFile,
+  type Skill,
+  scanDirectory,
+} from './loader.js';
+
+let tempDir: string;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), 'skills-test-'));
+});
+
+afterEach(() => {
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+function writeSkill(dir: string, filename: string, frontmatter: Record<string, unknown>): string {
+  const fm = Object.entries(frontmatter)
+    .map(([k, v]) => {
+      if (Array.isArray(v)) return `${k}: [${v.map((i) => `"${i}"`).join(', ')}]`;
+      return `${k}: "${v}"`;
+    })
+    .join('\n');
+  const content = `---\n${fm}\n---\n\n# ${frontmatter.name ?? 'Test'}\n\nInstructions here.\n`;
+  const filePath = join(dir, filename);
+  writeFileSync(filePath, content, 'utf-8');
+  return filePath;
+}
+
+describe('parseSkillFile', () => {
+  it('parses a valid skill file', () => {
+    const path = writeSkill(tempDir, 'deploy.md', {
+      name: 'deploy',
+      description: 'Deploy to production',
+      roles: ['conductor'],
+    });
+    const skill = parseSkillFile(path, 'user');
+    expect(skill).not.toBeNull();
+    expect(skill?.meta.name).toBe('deploy');
+    expect(skill?.meta.description).toBe('Deploy to production');
+    expect(skill?.meta.roles).toEqual(['conductor']);
+    expect(skill?.source).toBe('user');
+    expect(skill?.path).toBe(path);
+  });
+
+  it('returns null for missing name', () => {
+    const path = writeSkill(tempDir, 'bad.md', {
+      description: 'No name here',
+    });
+    expect(parseSkillFile(path, 'builtin')).toBeNull();
+  });
+
+  it('returns null for missing description', () => {
+    const path = writeSkill(tempDir, 'bad.md', {
+      name: 'no-desc',
+    });
+    expect(parseSkillFile(path, 'builtin')).toBeNull();
+  });
+
+  it('returns null for non-existent file', () => {
+    expect(parseSkillFile(join(tempDir, 'nope.md'), 'user')).toBeNull();
+  });
+
+  it('returns null for file with no frontmatter', () => {
+    const path = join(tempDir, 'plain.md');
+    writeFileSync(path, '# Just markdown\n\nNo frontmatter here.\n', 'utf-8');
+    expect(parseSkillFile(path, 'user')).toBeNull();
+  });
+
+  it('normalizes roles string to array', () => {
+    const path = writeSkill(tempDir, 'single-role.md', {
+      name: 'single',
+      description: 'Single role',
+      roles: 'Guide',
+    });
+    const skill = parseSkillFile(path, 'user');
+    expect(skill?.meta.roles).toEqual(['guide']);
+  });
+
+  it('normalizes roles array to lowercase', () => {
+    const path = writeSkill(tempDir, 'mixed.md', {
+      name: 'mixed',
+      description: 'Mixed case roles',
+      roles: ['Conductor', 'REVIEWER'],
+    });
+    const skill = parseSkillFile(path, 'builtin');
+    expect(skill?.meta.roles).toEqual(['conductor', 'reviewer']);
+  });
+
+  it('treats omitted roles as empty array (all roles)', () => {
+    const path = writeSkill(tempDir, 'all.md', {
+      name: 'all-roles',
+      description: 'For everyone',
+    });
+    const skill = parseSkillFile(path, 'user');
+    expect(skill?.meta.roles).toEqual([]);
+  });
+
+  it('treats empty roles array as all roles', () => {
+    const path = join(tempDir, 'empty-roles.md');
+    writeFileSync(path, '---\nname: empty\ndescription: Empty roles\nroles: []\n---\n\nContent\n');
+    const skill = parseSkillFile(path, 'user');
+    expect(skill?.meta.roles).toEqual([]);
+  });
+});
+
+describe('scanDirectory', () => {
+  it('returns empty array for non-existent directory', () => {
+    expect(scanDirectory(join(tempDir, 'nope'), 'user')).toEqual([]);
+  });
+
+  it('returns empty array for empty directory', () => {
+    const dir = join(tempDir, 'empty');
+    mkdirSync(dir);
+    expect(scanDirectory(dir, 'builtin')).toEqual([]);
+  });
+
+  it('scans valid skill files', () => {
+    writeSkill(tempDir, 'a.md', { name: 'alpha', description: 'Alpha skill' });
+    writeSkill(tempDir, 'b.md', { name: 'beta', description: 'Beta skill' });
+    const skills = scanDirectory(tempDir, 'user');
+    expect(skills).toHaveLength(2);
+    expect(skills.map((s) => s.meta.name).sort()).toEqual(['alpha', 'beta']);
+  });
+
+  it('skips invalid files and includes valid ones', () => {
+    writeSkill(tempDir, 'good.md', { name: 'good', description: 'Good one' });
+    writeFileSync(join(tempDir, 'bad.md'), '# No frontmatter\n', 'utf-8');
+    const skills = scanDirectory(tempDir, 'builtin');
+    expect(skills).toHaveLength(1);
+    expect(skills[0].meta.name).toBe('good');
+  });
+
+  it('skips README.md', () => {
+    writeFileSync(
+      join(tempDir, 'README.md'),
+      '---\nname: readme\ndescription: Should be skipped\n---\n'
+    );
+    writeSkill(tempDir, 'real.md', { name: 'real', description: 'Real skill' });
+    const skills = scanDirectory(tempDir, 'builtin');
+    expect(skills).toHaveLength(1);
+    expect(skills[0].meta.name).toBe('real');
+  });
+});
+
+describe('loadSkills', () => {
+  let builtinDir: string;
+  let userDir: string;
+
+  beforeEach(() => {
+    builtinDir = join(tempDir, 'builtin');
+    userDir = join(tempDir, 'user');
+    mkdirSync(builtinDir);
+    mkdirSync(userDir);
+  });
+
+  it('merges skills from both directories', () => {
+    writeSkill(builtinDir, 'a.md', { name: 'alpha', description: 'Built-in alpha' });
+    writeSkill(userDir, 'b.md', { name: 'beta', description: 'User beta' });
+    const skills = loadSkills(builtinDir, userDir);
+    expect(skills).toHaveLength(2);
+  });
+
+  it('user skill overrides built-in with same name', () => {
+    writeSkill(builtinDir, 'deploy.md', { name: 'deploy', description: 'Built-in deploy' });
+    writeSkill(userDir, 'deploy.md', { name: 'deploy', description: 'User deploy' });
+    const skills = loadSkills(builtinDir, userDir);
+    expect(skills).toHaveLength(1);
+    expect(skills[0].meta.description).toBe('User deploy');
+    expect(skills[0].source).toBe('user');
+  });
+
+  it('handles empty directories', () => {
+    expect(loadSkills(builtinDir, userDir)).toEqual([]);
+  });
+
+  it('handles non-existent directories', () => {
+    expect(loadSkills(join(tempDir, 'nope1'), join(tempDir, 'nope2'))).toEqual([]);
+  });
+});
+
+describe('filterSkillsByRole', () => {
+  const allRolesSkill: Skill = {
+    meta: { name: 'shared', description: 'For all', roles: [] },
+    path: '/fake/shared.md',
+    source: 'builtin',
+  };
+  const conductorSkill: Skill = {
+    meta: { name: 'deploy', description: 'Deploy', roles: ['conductor'] },
+    path: '/fake/deploy.md',
+    source: 'user',
+  };
+  const guideReviewerSkill: Skill = {
+    meta: { name: 'review', description: 'Review', roles: ['guide', 'reviewer'] },
+    path: '/fake/review.md',
+    source: 'builtin',
+  };
+
+  it('includes all-role skills for any role', () => {
+    const result = filterSkillsByRole([allRolesSkill], 'narrator');
+    expect(result).toHaveLength(1);
+  });
+
+  it('includes role-specific skill for matching role', () => {
+    const result = filterSkillsByRole([conductorSkill], 'conductor');
+    expect(result).toHaveLength(1);
+  });
+
+  it('excludes role-specific skill for non-matching role', () => {
+    const result = filterSkillsByRole([conductorSkill], 'guide');
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles mixed skills correctly', () => {
+    const all = [allRolesSkill, conductorSkill, guideReviewerSkill];
+    expect(filterSkillsByRole(all, 'conductor')).toHaveLength(2); // shared + deploy
+    expect(filterSkillsByRole(all, 'guide')).toHaveLength(2); // shared + review
+    expect(filterSkillsByRole(all, 'reviewer')).toHaveLength(2); // shared + review
+    expect(filterSkillsByRole(all, 'narrator')).toHaveLength(1); // shared only
+  });
+
+  it('normalizes role comparison to lowercase', () => {
+    const result = filterSkillsByRole([conductorSkill], 'Conductor');
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe('compileSkillsXml', () => {
+  it('returns empty string for no skills', () => {
+    expect(compileSkillsXml([])).toBe('');
+  });
+
+  it('produces valid XML structure', () => {
+    const skills: Skill[] = [
+      {
+        meta: { name: 'deploy', description: 'Deploy to prod', roles: [] },
+        path: '/home/user/skills/deploy.md',
+        source: 'user',
+      },
+    ];
+    const xml = compileSkillsXml(skills);
+    expect(xml).toContain('<available_skills>');
+    expect(xml).toContain('</available_skills>');
+    expect(xml).toContain('name="deploy"');
+    expect(xml).toContain('description="Deploy to prod"');
+  });
+
+  it('sorts skills alphabetically by name', () => {
+    const skills: Skill[] = [
+      {
+        meta: { name: 'zeta', description: 'Z', roles: [] },
+        path: '/tmp/zeta.md',
+        source: 'builtin',
+      },
+      {
+        meta: { name: 'alpha', description: 'A', roles: [] },
+        path: '/tmp/alpha.md',
+        source: 'builtin',
+      },
+    ];
+    const xml = compileSkillsXml(skills);
+    const alphaIdx = xml.indexOf('name="alpha"');
+    const zetaIdx = xml.indexOf('name="zeta"');
+    expect(alphaIdx).toBeLessThan(zetaIdx);
+  });
+
+  it('escapes XML special characters', () => {
+    const skills: Skill[] = [
+      {
+        meta: { name: 'test', description: 'Uses <bash> & "quotes"', roles: [] },
+        path: '/tmp/test.md',
+        source: 'builtin',
+      },
+    ];
+    const xml = compileSkillsXml(skills);
+    expect(xml).toContain('&lt;bash&gt;');
+    expect(xml).toContain('&amp;');
+    expect(xml).toContain('&quot;quotes&quot;');
+  });
+
+  it('replaces home directory with ~ in paths', () => {
+    const skills: Skill[] = [
+      {
+        meta: { name: 'test', description: 'Test', roles: [] },
+        path: join(process.env.HOME ?? '/home/user', '.system2', 'skills', 'test.md'),
+        source: 'user',
+      },
+    ];
+    const xml = compileSkillsXml(skills);
+    expect(xml).toContain('~/.system2/skills/test.md');
+  });
+});

--- a/packages/server/src/skills/loader.ts
+++ b/packages/server/src/skills/loader.ts
@@ -57,6 +57,10 @@ export function parseSkillFile(filePath: string, source: 'builtin' | 'user'): Sk
 
   // Normalize name: lowercase and trim for consistent merge key matching.
   const name = data.name.trim().toLowerCase();
+  if (!name) {
+    console.warn(`[Skills] Empty 'name' after normalization in ${filePath}, skipping`);
+    return null;
+  }
 
   // Normalize roles: omitted/undefined/empty = all roles (empty array).
   // String value is coerced to single-element array.

--- a/packages/server/src/skills/loader.ts
+++ b/packages/server/src/skills/loader.ts
@@ -1,0 +1,148 @@
+/**
+ * Skill Loader
+ *
+ * Discovers, parses, and merges SKILL.md files from built-in and user directories.
+ * Compiles a compact XML index filtered by agent role for system prompt injection.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import matter from 'gray-matter';
+
+export interface SkillMeta {
+  name: string;
+  description: string;
+  /** Agent roles that can use this skill. Empty array = all roles. */
+  roles: string[];
+}
+
+export interface Skill {
+  meta: SkillMeta;
+  /** Absolute path to the SKILL.md file (agents read on demand). */
+  path: string;
+  source: 'builtin' | 'user';
+}
+
+/**
+ * Parse a single SKILL.md file. Returns null if the file is invalid or unreadable.
+ */
+export function parseSkillFile(filePath: string, source: 'builtin' | 'user'): Skill | null {
+  let raw: string;
+  try {
+    raw = readFileSync(filePath, 'utf-8');
+  } catch {
+    console.warn(`[Skills] Could not read ${filePath}, skipping`);
+    return null;
+  }
+
+  let parsed: matter.GrayMatterFile<string>;
+  try {
+    parsed = matter(raw);
+  } catch {
+    console.warn(`[Skills] Invalid frontmatter in ${filePath}, skipping`);
+    return null;
+  }
+
+  const { data } = parsed;
+
+  if (!data.name || typeof data.name !== 'string') {
+    console.warn(`[Skills] Missing or invalid 'name' in ${filePath}, skipping`);
+    return null;
+  }
+  if (!data.description || typeof data.description !== 'string') {
+    console.warn(`[Skills] Missing or invalid 'description' in ${filePath}, skipping`);
+    return null;
+  }
+
+  // Normalize roles: omitted/undefined/empty = all roles (empty array).
+  // String value is coerced to single-element array.
+  let roles: string[] = [];
+  if (data.roles != null) {
+    if (typeof data.roles === 'string') {
+      roles = [data.roles.toLowerCase()];
+    } else if (Array.isArray(data.roles)) {
+      roles = data.roles
+        .filter((r): r is string => typeof r === 'string')
+        .map((r) => r.toLowerCase());
+    }
+  }
+
+  return {
+    meta: { name: data.name, description: data.description, roles },
+    path: filePath,
+    source,
+  };
+}
+
+/**
+ * Scan a directory for .md skill files (flat, non-recursive).
+ * Returns an empty array if the directory does not exist.
+ */
+export function scanDirectory(dirPath: string, source: 'builtin' | 'user'): Skill[] {
+  if (!existsSync(dirPath)) return [];
+
+  const files = readdirSync(dirPath).filter((f) => f.endsWith('.md') && f !== 'README.md');
+  const skills: Skill[] = [];
+
+  for (const file of files) {
+    const skill = parseSkillFile(join(dirPath, file), source);
+    if (skill) skills.push(skill);
+  }
+
+  return skills;
+}
+
+/**
+ * Load skills from both directories, with user skills overriding built-in by name.
+ */
+export function loadSkills(builtinDir: string, userDir: string): Skill[] {
+  const builtinSkills = scanDirectory(builtinDir, 'builtin');
+  const userSkills = scanDirectory(userDir, 'user');
+
+  // Built-in first, then user overwrites on name collision
+  const merged = new Map<string, Skill>();
+  for (const skill of builtinSkills) {
+    merged.set(skill.meta.name, skill);
+  }
+  for (const skill of userSkills) {
+    merged.set(skill.meta.name, skill);
+  }
+
+  return Array.from(merged.values());
+}
+
+/**
+ * Filter skills to those eligible for a given agent role.
+ * Skills with an empty roles array are available to all roles.
+ */
+export function filterSkillsByRole(skills: Skill[], role: string): Skill[] {
+  const normalizedRole = role.toLowerCase();
+  return skills.filter((s) => s.meta.roles.length === 0 || s.meta.roles.includes(normalizedRole));
+}
+
+/**
+ * Compile a compact XML index of skills for system prompt injection.
+ * Returns an empty string if there are no skills.
+ */
+export function compileSkillsXml(skills: Skill[]): string {
+  if (skills.length === 0) return '';
+
+  const home = homedir();
+  const sorted = [...skills].sort((a, b) => a.meta.name.localeCompare(b.meta.name));
+
+  const entries = sorted.map((s) => {
+    const displayPath = s.path.replace(home, '~').replace(/\\/g, '/');
+    return `<skill name="${escapeXml(s.meta.name)}" path="${escapeXml(displayPath)}" description="${escapeXml(s.meta.description)}" />`;
+  });
+
+  return `<available_skills>\n${entries.join('\n')}\n</available_skills>`;
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}

--- a/packages/server/src/skills/loader.ts
+++ b/packages/server/src/skills/loader.ts
@@ -7,7 +7,7 @@
 
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 import matter from 'gray-matter';
 
 export interface SkillMeta {
@@ -55,21 +55,33 @@ export function parseSkillFile(filePath: string, source: 'builtin' | 'user'): Sk
     return null;
   }
 
+  // Normalize name: lowercase and trim for consistent merge key matching.
+  const name = data.name.trim().toLowerCase();
+
   // Normalize roles: omitted/undefined/empty = all roles (empty array).
   // String value is coerced to single-element array.
+  // Invalid types or arrays with no valid string entries reject the file.
   let roles: string[] = [];
   if (data.roles != null) {
     if (typeof data.roles === 'string') {
       roles = [data.roles.toLowerCase()];
     } else if (Array.isArray(data.roles)) {
-      roles = data.roles
+      const stringRoles = data.roles
         .filter((r): r is string => typeof r === 'string')
         .map((r) => r.toLowerCase());
+      if (stringRoles.length === 0 && data.roles.length > 0) {
+        console.warn(`[Skills] Invalid 'roles' entries in ${filePath}, skipping`);
+        return null;
+      }
+      roles = stringRoles;
+    } else {
+      console.warn(`[Skills] Invalid 'roles' type in ${filePath}, skipping`);
+      return null;
     }
   }
 
   return {
-    meta: { name: data.name, description: data.description, roles },
+    meta: { name, description: data.description, roles },
     path: filePath,
     source,
   };
@@ -82,7 +94,13 @@ export function parseSkillFile(filePath: string, source: 'builtin' | 'user'): Sk
 export function scanDirectory(dirPath: string, source: 'builtin' | 'user'): Skill[] {
   if (!existsSync(dirPath)) return [];
 
-  const files = readdirSync(dirPath).filter((f) => f.endsWith('.md') && f !== 'README.md');
+  let files: string[];
+  try {
+    files = readdirSync(dirPath).filter((f) => f.endsWith('.md') && f !== 'README.md');
+  } catch {
+    console.warn(`[Skills] Could not read directory ${dirPath}, skipping`);
+    return [];
+  }
   const skills: Skill[] = [];
 
   for (const file of files) {
@@ -132,7 +150,9 @@ export function compileSkillsXml(skills: Skill[]): string {
   const sorted = [...skills].sort((a, b) => a.meta.name.localeCompare(b.meta.name));
 
   const entries = sorted.map((s) => {
-    const displayPath = s.path.replace(home, '~').replace(/\\/g, '/');
+    const displayPath = (
+      s.path.startsWith(home + sep) ? `~${s.path.slice(home.length)}` : s.path
+    ).replace(/\\/g, '/');
     return `<skill name="${escapeXml(s.meta.name)}" path="${escapeXml(displayPath)}" description="${escapeXml(s.meta.description)}" />`;
   });
 

--- a/packages/server/src/skills/loader.ts
+++ b/packages/server/src/skills/loader.ts
@@ -1,179 +1,73 @@
 /**
- * Skill Loader
+ * Skill Role Filter
  *
- * Discovers, parses, and merges SKILL.md files from built-in and user directories.
- * Compiles a compact XML index filtered by agent role for system prompt injection.
+ * Extracts the `roles` frontmatter field from skill files and filters
+ * SDK-discovered skills by agent role. Discovery, parsing, XML compilation,
+ * and prompt injection are handled by the pi-coding-agent SDK.
  */
 
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { join, sep } from 'node:path';
+import { readFileSync } from 'node:fs';
+import type { Skill } from '@mariozechner/pi-coding-agent';
 import matter from 'gray-matter';
 
-export interface SkillMeta {
-  name: string;
-  description: string;
-  /** Agent roles that can use this skill. Empty array = all roles. */
-  roles: string[];
-}
-
-export interface Skill {
-  meta: SkillMeta;
-  /** Absolute path to the SKILL.md file (agents read on demand). */
-  path: string;
-  source: 'builtin' | 'user';
-}
-
 /**
- * Parse a single SKILL.md file. Returns null if the file is invalid or unreadable.
+ * Extract the normalized `roles` array from a skill file's YAML frontmatter.
+ * Returns an empty array (meaning "all roles") if:
+ * - The file is unreadable or has no/invalid frontmatter
+ * - The `roles` field is omitted or an empty array
+ *
+ * Returns null if `roles` is present but entirely invalid (e.g. a number,
+ * or an array with no valid string entries), signalling the skill should
+ * be excluded.
  */
-export function parseSkillFile(filePath: string, source: 'builtin' | 'user'): Skill | null {
+export function extractRoles(filePath: string): string[] | null {
   let raw: string;
   try {
     raw = readFileSync(filePath, 'utf-8');
   } catch {
-    console.warn(`[Skills] Could not read ${filePath}, skipping`);
-    return null;
+    return [];
   }
 
   let parsed: matter.GrayMatterFile<string>;
   try {
     parsed = matter(raw);
   } catch {
-    console.warn(`[Skills] Invalid frontmatter in ${filePath}, skipping`);
-    return null;
-  }
-
-  const { data } = parsed;
-
-  if (!data.name || typeof data.name !== 'string') {
-    console.warn(`[Skills] Missing or invalid 'name' in ${filePath}, skipping`);
-    return null;
-  }
-  if (!data.description || typeof data.description !== 'string') {
-    console.warn(`[Skills] Missing or invalid 'description' in ${filePath}, skipping`);
-    return null;
-  }
-
-  // Normalize name: lowercase and trim for consistent merge key matching.
-  const name = data.name.trim().toLowerCase();
-  if (!name) {
-    console.warn(`[Skills] Empty 'name' after normalization in ${filePath}, skipping`);
-    return null;
-  }
-
-  // Normalize roles: omitted/undefined/empty = all roles (empty array).
-  // String value is coerced to single-element array.
-  // Mixed arrays (e.g. ["guide", 123]) silently drop non-string entries.
-  // Arrays with no valid string entries reject the file.
-  let roles: string[] = [];
-  if (data.roles != null) {
-    if (typeof data.roles === 'string') {
-      const trimmed = data.roles.trim().toLowerCase();
-      if (!trimmed) {
-        console.warn(`[Skills] Empty 'roles' string in ${filePath}, skipping`);
-        return null;
-      }
-      roles = [trimmed];
-    } else if (Array.isArray(data.roles)) {
-      const stringRoles = data.roles
-        .filter((r): r is string => typeof r === 'string')
-        .map((r) => r.trim().toLowerCase())
-        .filter((r) => r !== '');
-      if (stringRoles.length === 0 && data.roles.length > 0) {
-        console.warn(`[Skills] Invalid 'roles' entries in ${filePath}, skipping`);
-        return null;
-      }
-      roles = stringRoles;
-    } else {
-      console.warn(`[Skills] Invalid 'roles' type in ${filePath}, skipping`);
-      return null;
-    }
-  }
-
-  return {
-    meta: { name, description: data.description, roles },
-    path: filePath,
-    source,
-  };
-}
-
-/**
- * Scan a directory for .md skill files (flat, non-recursive).
- * Returns an empty array if the directory does not exist.
- */
-export function scanDirectory(dirPath: string, source: 'builtin' | 'user'): Skill[] {
-  if (!existsSync(dirPath)) return [];
-
-  let files: string[];
-  try {
-    files = readdirSync(dirPath).filter((f) => f.endsWith('.md') && f !== 'README.md');
-  } catch {
-    console.warn(`[Skills] Could not read directory ${dirPath}, skipping`);
     return [];
   }
-  const skills: Skill[] = [];
 
-  for (const file of files) {
-    const skill = parseSkillFile(join(dirPath, file), source);
-    if (skill) skills.push(skill);
+  const { roles } = parsed.data;
+
+  if (roles == null) return [];
+
+  if (typeof roles === 'string') {
+    const trimmed = roles.trim().toLowerCase();
+    return trimmed ? [trimmed] : null;
   }
 
-  return skills;
+  if (Array.isArray(roles)) {
+    const valid = roles
+      .filter((r): r is string => typeof r === 'string')
+      .map((r) => r.trim().toLowerCase())
+      .filter((r) => r !== '');
+    if (valid.length === 0 && roles.length > 0) return null;
+    return valid;
+  }
+
+  // Invalid type (number, boolean, object, etc.)
+  return null;
 }
 
 /**
- * Load skills from both directories, with user skills overriding built-in by name.
+ * Filter SDK Skill objects to those eligible for a given agent role.
+ * Skills whose frontmatter has no `roles` (or empty roles) are available to all roles.
+ * Skills with invalid `roles` metadata are excluded.
  */
-export function loadSkills(builtinDir: string, userDir: string): Skill[] {
-  const builtinSkills = scanDirectory(builtinDir, 'builtin');
-  const userSkills = scanDirectory(userDir, 'user');
-
-  // Built-in first, then user overwrites on name collision
-  const merged = new Map<string, Skill>();
-  for (const skill of builtinSkills) {
-    merged.set(skill.meta.name, skill);
-  }
-  for (const skill of userSkills) {
-    merged.set(skill.meta.name, skill);
-  }
-
-  return Array.from(merged.values());
-}
-
-/**
- * Filter skills to those eligible for a given agent role.
- * Skills with an empty roles array are available to all roles.
- */
-export function filterSkillsByRole(skills: Skill[], role: string): Skill[] {
+export function filterByRole(skills: Skill[], role: string): Skill[] {
+  if (!role) return skills;
   const normalizedRole = role.toLowerCase();
-  return skills.filter((s) => s.meta.roles.length === 0 || s.meta.roles.includes(normalizedRole));
-}
-
-/**
- * Compile a compact XML index of skills for system prompt injection.
- * Returns an empty string if there are no skills.
- */
-export function compileSkillsXml(skills: Skill[]): string {
-  if (skills.length === 0) return '';
-
-  const home = homedir();
-  const sorted = [...skills].sort((a, b) => a.meta.name.localeCompare(b.meta.name));
-
-  const entries = sorted.map((s) => {
-    const displayPath = (
-      s.path.startsWith(home + sep) ? `~${s.path.slice(home.length)}` : s.path
-    ).replace(/\\/g, '/');
-    return `<skill name="${escapeXml(s.meta.name)}" path="${escapeXml(displayPath)}" description="${escapeXml(s.meta.description)}" />`;
+  return skills.filter((skill) => {
+    const roles = extractRoles(skill.filePath);
+    if (roles === null) return false;
+    return roles.length === 0 || roles.includes(normalizedRole);
   });
-
-  return `<available_skills>\n${entries.join('\n')}\n</available_skills>`;
-}
-
-function escapeXml(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
 }

--- a/packages/server/src/skills/loader.ts
+++ b/packages/server/src/skills/loader.ts
@@ -69,11 +69,17 @@ export function parseSkillFile(filePath: string, source: 'builtin' | 'user'): Sk
   let roles: string[] = [];
   if (data.roles != null) {
     if (typeof data.roles === 'string') {
-      roles = [data.roles.trim().toLowerCase()];
+      const trimmed = data.roles.trim().toLowerCase();
+      if (!trimmed) {
+        console.warn(`[Skills] Empty 'roles' string in ${filePath}, skipping`);
+        return null;
+      }
+      roles = [trimmed];
     } else if (Array.isArray(data.roles)) {
       const stringRoles = data.roles
         .filter((r): r is string => typeof r === 'string')
-        .map((r) => r.trim().toLowerCase());
+        .map((r) => r.trim().toLowerCase())
+        .filter((r) => r !== '');
       if (stringRoles.length === 0 && data.roles.length > 0) {
         console.warn(`[Skills] Invalid 'roles' entries in ${filePath}, skipping`);
         return null;

--- a/packages/server/src/skills/loader.ts
+++ b/packages/server/src/skills/loader.ts
@@ -64,15 +64,16 @@ export function parseSkillFile(filePath: string, source: 'builtin' | 'user'): Sk
 
   // Normalize roles: omitted/undefined/empty = all roles (empty array).
   // String value is coerced to single-element array.
-  // Invalid types or arrays with no valid string entries reject the file.
+  // Mixed arrays (e.g. ["guide", 123]) silently drop non-string entries.
+  // Arrays with no valid string entries reject the file.
   let roles: string[] = [];
   if (data.roles != null) {
     if (typeof data.roles === 'string') {
-      roles = [data.roles.toLowerCase()];
+      roles = [data.roles.trim().toLowerCase()];
     } else if (Array.isArray(data.roles)) {
       const stringRoles = data.roles
         .filter((r): r is string => typeof r === 'string')
-        .map((r) => r.toLowerCase());
+        .map((r) => r.trim().toLowerCase());
       if (stringRoles.length === 0 && data.roles.length > 0) {
         console.warn(`[Skills] Invalid 'roles' entries in ${filePath}, skipping`);
         return null;

--- a/packages/server/tsup.config.ts
+++ b/packages/server/tsup.config.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'tsup';
@@ -45,11 +45,15 @@ export default defineConfig({
     const srcSkills = join(srcAgents, 'skills');
     const destSkills = join(destAgents, 'skills');
     mkdirSync(destSkills, { recursive: true });
-    const skillFiles = readdirSync(srcSkills).filter((f) => f.endsWith('.md'));
-    for (const file of skillFiles) {
-      copyFileSync(join(srcSkills, file), join(destSkills, file));
+    if (existsSync(srcSkills)) {
+      const skillFiles = readdirSync(srcSkills).filter((f) => f.endsWith('.md'));
+      for (const file of skillFiles) {
+        copyFileSync(join(srcSkills, file), join(destSkills, file));
+      }
+      console.log(`✓ Copied ${skillFiles.length} skill files to dist/`);
+    } else {
+      console.log('✓ No built-in skills directory found, skipping');
     }
-    console.log(`✓ Copied ${skillFiles.length} skill files to dist/`);
 
     // Copy schema.sql to dist/db/
     const srcDb = join(__dirname, 'src', 'db');

--- a/packages/server/tsup.config.ts
+++ b/packages/server/tsup.config.ts
@@ -50,7 +50,7 @@ export default defineConfig({
       for (const file of skillFiles) {
         copyFileSync(join(srcSkills, file), join(destSkills, file));
       }
-      console.log(`✓ Copied ${skillFiles.length} skill files to dist/`);
+      console.log(`✓ Copied ${skillFiles.length} skill files to dist/agents/skills/`);
     } else {
       console.log('✓ No built-in skills directory found, skipping');
     }

--- a/packages/server/tsup.config.ts
+++ b/packages/server/tsup.config.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, mkdirSync } from 'node:fs';
+import { copyFileSync, mkdirSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'tsup';
@@ -40,6 +40,16 @@ export default defineConfig({
     }
 
     console.log('✓ Copied agent library files to dist/');
+
+    // Copy built-in skill files to dist/agents/skills/
+    const srcSkills = join(srcAgents, 'skills');
+    const destSkills = join(destAgents, 'skills');
+    mkdirSync(destSkills, { recursive: true });
+    const skillFiles = readdirSync(srcSkills).filter((f) => f.endsWith('.md'));
+    for (const file of skillFiles) {
+      copyFileSync(join(srcSkills, file), join(destSkills, file));
+    }
+    console.log(`✓ Copied ${skillFiles.length} skill files to dist/`);
 
     // Copy schema.sql to dist/db/
     const srcDb = join(__dirname, 'src', 'db');


### PR DESCRIPTION
## Summary

Adds a skills system that gives agents reusable workflow instructions via SKILL.md files, filling the gap between tools (single actions) and knowledge (accumulated facts).

- **SKILL.md format**: YAML frontmatter (`name`, `description`, `roles`) + markdown body with multi-step instructions
- **Two sources**: built-in skills (`packages/server/src/agents/skills/`) and user-created (`~/.system2/skills/`), with user skills overriding built-in by name
- **Dynamic injection**: A compact XML index filtered by agent role is compiled and injected into each agent's system prompt on every LLM call via `loadSkillsContext()`
- **Lazy loading**: Agents read full skill content on demand via the `read` tool
- **Skill creation**: Guide and Conductor agents are instructed to proactively create skills when they recognize reusable patterns

### Changes

- `packages/server/src/skills/loader.ts`: Core module with pure functions for discovery, parsing, merging, role filtering, and XML compilation
- `packages/server/src/skills/loader.test.ts`: 28 tests covering all exported functions
- `packages/server/src/agents/host.ts`: New `loadSkillsContext()` method wired into `systemPromptOverride`
- `packages/server/src/agents/agents.md`: New Skills section teaching agents how to use and create skills
- `packages/server/src/knowledge/init.ts`: Creates `~/.system2/skills/` directory on startup
- `packages/server/tsup.config.ts`: Copies built-in skill files to dist at build time
- Documentation updates: `docs/skills.md` (new), `docs/agents.md`, `docs/knowledge-system.md`, `docs/README.md`, `CLAUDE.md`

## Test plan

- [x] All 495 tests pass (28 new + 467 existing)
- [x] `pnpm build` succeeds (copies 0 skill files to dist, expected since no built-in skills yet)
- [x] `pnpm check` passes (only pre-existing warning on host.ts:462)
- [x] `pnpm typecheck` passes
- [ ] Manual: start server, verify `~/.system2/skills/` is created
- [ ] Manual: place a test SKILL.md in `~/.system2/skills/`, verify it appears in agent prompt

Closes #85