### PR TITLE
fix: narrator delivery resolution, frontmatter cursor, and chat cache

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -159,7 +159,7 @@ When `AgentHost` detects an API error in a `message_end` event:
 1. Categorize the error (see [retry.ts](#retry-logic))
 2. Set `lastTurnErrored = true` synchronously (prevents `agent_end` from clearing pending state). On successful turns, `agent_end` resolves `min(deliverySendCount, pendingDeliveries.length)` promises from the queue and resets the counter. `deliverySendCount` is incremented each time `sendCustomMessage` succeeds in `deliverMessage`, so it tracks how many deliveries were sent in the current turn regardless of whether they entered as the initial prompt or as follow-ups
 3. Capture `pendingPrompt` and `pendingDeliveries` synchronously (before any `await`)
-4. If retriable: wait with exponential backoff, retry with same provider (re-sends the failed prompt or delivery)
+4. If retriable: wait with exponential backoff, retry with same provider (re-sends the failed prompt and/or all pending deliveries)
 5. If retries exhausted or immediate failover: mark key in cooldown, failover to next provider
 6. Reinitialize the session with the new provider (`reinitializeWithProvider()`)
 7. Retry the pending prompt and/or replay pending deliveries on the new session

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -157,7 +157,7 @@ Cooldowns are set once: if a key is already in cooldown, subsequent failures ski
 When `AgentHost` detects an API error in a `message_end` event:
 
 1. Categorize the error (see [retry.ts](#retry-logic))
-2. Set `lastTurnErrored = true` synchronously (prevents `agent_end` from clearing pending state). On successful turns, `agent_end` inspects `event.messages` to count completed delivery messages (`role: 'custom'`, `customType: 'agent_message'`) and only shifts that many from `pendingDeliveries`, avoiding desync when prompt and delivery turns are batched into a single event
+2. Set `lastTurnErrored = true` synchronously (prevents `agent_end` from clearing pending state). On successful turns, `agent_end` resolves `min(deliverySendCount, pendingDeliveries.length)` promises from the queue and resets the counter. `deliverySendCount` is incremented each time `sendCustomMessage` succeeds in `deliverMessage`, so it tracks how many deliveries were sent in the current turn regardless of whether they entered as the initial prompt or as follow-ups
 3. Capture `pendingPrompt` and `pendingDeliveries` synchronously (before any `await`)
 4. If retriable: wait with exponential backoff, retry with same provider (re-sends the failed prompt or delivery)
 5. If retries exhausted or immediate failover: mark key in cooldown, failover to next provider

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -64,6 +64,7 @@ Each project log is a single continuous file per project lifetime (unlike daily 
    - **Project Activity:** included only for projects that have agent JSONL entries or DB changes in the window; inactive projects are omitted entirely. The entire section is omitted when no project has changes.
    - **Non-Project Activity:** Guide JSONL (via `dailySummarySystemAgents`, which excludes Narrator to prevent recursive embedding of its own `custom_message` injections) and DB changes not tied to any active project. Omitted when there is no non-project activity.
 6. **Deliver:** send to Narrator via `deliverMessage()` with `sender: 0` (system sentinel)
+7. **Advance cursors:** after all deliveries complete (or on skip), the server writes `newRunTs` to `last_narrator_update_ts` in the daily summary file and each project's `log.md` frontmatter. This runs after `agent_end`, so the Narrator has already finished editing the files. On skip (no activity), the cursor still advances to prevent re-scanning the same empty window.
 
 The Narrator synthesizes each section into narrative summaries, avoiding repetition of project-specific content already covered in project-log entries (which are processed first).
 
@@ -76,6 +77,7 @@ The Narrator synthesizes each section into narrative summaries, avoiding repetit
 3. Read each file and embed its content inline in the message
 4. Deliver to Narrator via `deliverMessage()` with all summary content included
 5. Narrator incorporates summaries into `memory.md`, clears processed Notes
+6. Server advances `last_narrator_update_ts` in `memory.md` frontmatter after delivery completes
 
 ## Catch-Up on Startup
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -87,7 +87,7 @@ Croner does **not** catch up missed jobs after laptop sleep or server shutdown. 
 
 This runs once at server start, after agent sessions are initialized. Catch-up executions are tracked in the `job_execution` table with `trigger_type: 'catch-up'`.
 
-Both checks use `last_narrator_update_ts` as a cursor. This timestamp only advances when the Narrator successfully processes the delivered message and writes it back to the file's frontmatter. If a job is skipped (network down) or fails, the cursor stays stale and the next restart will re-trigger catch-up.
+Both checks use `last_narrator_update_ts` as a cursor. The server advances the cursor in the file's frontmatter after successful delivery (or on skip when no activity is found), so it does not depend on the Narrator LLM to update it. If a job fails, the cursor stays stale and the next restart will re-trigger catch-up.
 
 **Within a single server lifecycle:** if the server starts without network, catch-up is skipped entirely. The `daily-summary` job self-recovers within one cron interval (default 30 min) once the network is back, because its staleness check runs on every cron tick. The `memory-update` catch-up is lost until its next scheduled run (daily at 11 AM), since the cron handler only fires once per day. A server restart recovers both.
 
@@ -107,7 +107,7 @@ The `trigger_type` column distinguishes how the execution was initiated:
 
 **Skip reasons** are stored in the `error` column when status is `skipped`. Common reasons: `no network connectivity`, `no activity since last run`, `no daily summaries to incorporate`.
 
-**Missing timestamps:** if daily summary files exist but none contain `last_narrator_update_ts` (and memory.md also lacks it), the job fails rather than silently falling back. This catches cases where the Narrator failed to advance the cursor.
+**Missing timestamps:** if daily summary files exist but none contain `last_narrator_update_ts` (and memory.md also lacks it), the job fails rather than silently falling back. This catches initialization errors where no cursor has been set yet.
 
 ## See Also
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -140,7 +140,7 @@ User messages are broadcast to other tabs: when tab A sends a message, the handl
 
 ## History Capture
 
-Each `AgentHost` owns its own `MessageHistory` (chat cache) stored at `~/.system2/sessions/{role}_{id}/chat-cache.json`. Assistant message history is captured by a **single subscriber** registered in `Server` per agent (not per-handler), preventing duplicate entries when multiple tabs are open. User messages are captured by the handler that receives them (one per user action).
+Each `AgentHost` owns its own `MessageHistory` (chat cache) stored at `~/.system2/sessions/{role}_{id}/chat-cache.json`. Assistant message history is captured by a **single subscriber** registered in `Server` per agent (not per-handler), preventing duplicate entries when multiple tabs are open. User messages are captured by the handler that receives them (one per user action). Tool-only turns (thinking + tool calls with no text output) are also persisted, and compaction events (`compaction_start`/`compaction_end`) are recorded as system messages in the cache.
 
 ## WebSocketHandler (`handler.ts`)
 

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -201,7 +201,7 @@ describe('AgentHost', () => {
       expect(hostInternal.pendingPrompt).toBeNull();
     });
 
-    it('tracks pendingDeliveries and shifts on agent_end only for delivery turns', () => {
+    it('tracks pendingDeliveries and resolves on agent_end using deliverySendCount', () => {
       const host = new AgentHost({
         db: makeDbStub(),
         agentId: 1,
@@ -217,6 +217,7 @@ describe('AgentHost', () => {
           resolve: () => void;
           reject: (reason: Error) => void;
         }>;
+        deliverySendCount: number;
         handleSessionEvent: (event: Record<string, unknown>) => void;
         handlePotentialError: ReturnType<typeof vi.fn>;
         handleCompactionTracking: ReturnType<typeof vi.fn>;
@@ -246,36 +247,30 @@ describe('AgentHost', () => {
       hostInternal.pendingDeliveries[0].resolve = resolve1;
       hostInternal.pendingDeliveries[1].resolve = resolve2;
 
-      // Prompt-only agent_end does NOT shift deliveries
-      hostInternal.handleSessionEvent({
-        type: 'agent_end',
-        messages: [{ role: 'user', content: 'hello' }],
-      });
+      // agent_end with deliverySendCount=0 does NOT shift deliveries
+      hostInternal.deliverySendCount = 0;
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
       expect(hostInternal.pendingDeliveries).toHaveLength(2);
 
-      // Delivery agent_end shifts the matching delivery
-      hostInternal.handleSessionEvent({
-        type: 'agent_end',
-        messages: [{ role: 'custom', customType: 'agent_message', content: 'msg1' }],
-      });
+      // agent_end with deliverySendCount=1 shifts one delivery
+      hostInternal.deliverySendCount = 1;
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
       expect(hostInternal.pendingDeliveries).toHaveLength(1);
       expect(hostInternal.pendingDeliveries[0].content).toBe('msg2');
       expect(resolve1).toHaveBeenCalledOnce();
+      expect(hostInternal.deliverySendCount).toBe(0); // reset after agent_end
 
-      // Second delivery agent_end clears the queue
-      hostInternal.handleSessionEvent({
-        type: 'agent_end',
-        messages: [{ role: 'custom', customType: 'agent_message', content: 'msg2' }],
-      });
+      // agent_end with deliverySendCount=1 clears the remaining delivery
+      hostInternal.deliverySendCount = 1;
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
       expect(hostInternal.pendingDeliveries).toHaveLength(0);
       expect(resolve2).toHaveBeenCalledOnce();
 
-      // Extra agent_end on empty queue is a no-op
-      hostInternal.handleSessionEvent({
-        type: 'agent_end',
-        messages: [{ role: 'custom', customType: 'agent_message', content: 'x' }],
-      });
+      // Extra agent_end on empty queue is a no-op (counter clamped to queue length)
+      hostInternal.deliverySendCount = 5;
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
       expect(hostInternal.pendingDeliveries).toHaveLength(0);
+      expect(hostInternal.deliverySendCount).toBe(0);
     });
 
     it('lastTurnErrored prevents cleanup on error turns', () => {
@@ -295,6 +290,7 @@ describe('AgentHost', () => {
           resolve: () => void;
           reject: (reason: Error) => void;
         }>;
+        deliverySendCount: number;
         lastTurnErrored: boolean;
         handleSessionEvent: (event: Record<string, unknown>) => void;
         handlePotentialError: ReturnType<typeof vi.fn>;
@@ -319,10 +315,8 @@ describe('AgentHost', () => {
 
       // Simulate error turn: handlePotentialError sets the flag before agent_end fires
       hostInternal.lastTurnErrored = true;
-      hostInternal.handleSessionEvent({
-        type: 'agent_end',
-        messages: [{ role: 'custom', customType: 'agent_message', content: 'delivery1' }],
-      });
+      hostInternal.deliverySendCount = 1;
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
 
       // Neither pendingPrompt nor pendingDeliveries should be cleaned up
       expect(hostInternal.pendingPrompt).toBe('user message');
@@ -333,17 +327,12 @@ describe('AgentHost', () => {
       expect(resolveDelivery).not.toHaveBeenCalled();
       expect(rejectDelivery).not.toHaveBeenCalled();
 
-      // Flag is reset after agent_end
+      // Flag is reset after agent_end, but deliverySendCount preserved for retry
       expect(hostInternal.lastTurnErrored).toBe(false);
 
-      // Next successful agent_end with user + delivery messages cleans up normally
-      hostInternal.handleSessionEvent({
-        type: 'agent_end',
-        messages: [
-          { role: 'user', content: 'user message' },
-          { role: 'custom', customType: 'agent_message', content: 'delivery1' },
-        ],
-      });
+      // Next successful agent_end with deliverySendCount=1 cleans up normally
+      hostInternal.deliverySendCount = 1;
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
       expect(hostInternal.pendingPrompt).toBeNull();
       expect(hostInternal.pendingDeliveries).toHaveLength(0);
       expect(resolveDelivery).toHaveBeenCalledOnce();
@@ -361,6 +350,7 @@ describe('AgentHost', () => {
         session: { sendCustomMessage: ReturnType<typeof vi.fn> };
         _chatCache: null;
         _sessionDir: string | null;
+        deliverySendCount: number;
         handleSessionEvent: (event: Record<string, unknown>) => void;
         handlePotentialError: ReturnType<typeof vi.fn>;
         handleCompactionTracking: ReturnType<typeof vi.fn>;
@@ -378,16 +368,16 @@ describe('AgentHost', () => {
         timestamp: Date.now(),
       });
 
-      // Fire agent_end with a delivery message to resolve the promise
-      hostInternal.handleSessionEvent({
-        type: 'agent_end',
-        messages: [{ role: 'custom', customType: 'agent_message', content: 'msg1' }],
-      });
+      // Simulate the send counter being incremented (normally done by .then() on sendCustomMessage)
+      hostInternal.deliverySendCount = 1;
+
+      // Fire agent_end to resolve the promise using the send counter
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
 
       await expect(promise).resolves.toBeUndefined();
     });
 
-    it('agent_end resolves delivery promises in order', () => {
+    it('agent_end resolves delivery promises in order using send counter', () => {
       const host = new AgentHost({
         db: makeDbStub(),
         agentId: 1,
@@ -403,6 +393,7 @@ describe('AgentHost', () => {
           resolve: () => void;
           reject: (reason: Error) => void;
         }>;
+        deliverySendCount: number;
         handleSessionEvent: (event: Record<string, unknown>) => void;
         handlePotentialError: ReturnType<typeof vi.fn>;
         handleCompactionTracking: ReturnType<typeof vi.fn>;
@@ -420,18 +411,14 @@ describe('AgentHost', () => {
         { content: 'second', details, resolve: resolve2, reject: vi.fn() },
       ];
 
-      // agent_end with 2 delivery messages resolves both in order
-      hostInternal.handleSessionEvent({
-        type: 'agent_end',
-        messages: [
-          { role: 'custom', customType: 'agent_message', content: 'first' },
-          { role: 'custom', customType: 'agent_message', content: 'second' },
-        ],
-      });
+      // agent_end with deliverySendCount=2 resolves both in order
+      hostInternal.deliverySendCount = 2;
+      hostInternal.handleSessionEvent({ type: 'agent_end' });
 
       expect(resolve1).toHaveBeenCalledOnce();
       expect(resolve2).toHaveBeenCalledOnce();
       expect(hostInternal.pendingDeliveries).toHaveLength(0);
+      expect(hostInternal.deliverySendCount).toBe(0);
     });
 
     it('captures deliveriesToRetry and replays them on failover', async () => {

--- a/packages/server/src/agents/host.test.ts
+++ b/packages/server/src/agents/host.test.ts
@@ -746,6 +746,150 @@ describe('AgentHost', () => {
       expect(hostInternal.pendingDeliveries).toHaveLength(0);
     });
 
+    it('same-provider retry resends ALL pending deliveries, not just the first', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        pendingPrompt: string | null;
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
+        }>;
+        lastTurnErrored: boolean;
+        session: {
+          prompt: ReturnType<typeof vi.fn>;
+          sendCustomMessage: ReturnType<typeof vi.fn>;
+        };
+        handlePotentialError: (event: unknown) => Promise<void>;
+        authResolver: {
+          markKeyFailed: ReturnType<typeof vi.fn>;
+          getNextProvider: ReturnType<typeof vi.fn>;
+          isKeyInCooldown: ReturnType<typeof vi.fn>;
+        };
+        retryAttempts: Map<string, number>;
+        currentProvider: string;
+        currentKeyIndex: number;
+      };
+
+      hostInternal.session = {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        sendCustomMessage: vi.fn().mockResolvedValue(undefined),
+      };
+      hostInternal.currentProvider = 'cerebras';
+      hostInternal.currentKeyIndex = 0;
+      hostInternal.pendingPrompt = null;
+
+      const details = { sender: 0, receiver: 2, timestamp: Date.now() };
+      hostInternal.pendingDeliveries = [
+        { content: 'project-log-A', details, urgent: false, resolve: vi.fn(), reject: vi.fn() },
+        { content: 'project-log-B', details, urgent: false, resolve: vi.fn(), reject: vi.fn() },
+        { content: 'daily-summary', details, urgent: false, resolve: vi.fn(), reject: vi.fn() },
+      ];
+
+      hostInternal.retryAttempts = new Map();
+      hostInternal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
+      hostInternal.authResolver.markKeyFailed = vi.fn().mockReturnValue(false);
+      hostInternal.authResolver.getNextProvider = vi.fn().mockReturnValue(null);
+
+      await hostInternal.handlePotentialError({
+        type: 'message_end',
+        message: { stopReason: 'error', errorMessage: 'Error 429: rate limit exceeded' },
+      });
+
+      // All 3 deliveries should have been resent
+      expect(hostInternal.session.sendCustomMessage).toHaveBeenCalledTimes(3);
+      expect(hostInternal.session.sendCustomMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ content: 'project-log-A' }),
+        expect.objectContaining({ deliverAs: 'followUp', triggerTurn: true })
+      );
+      expect(hostInternal.session.sendCustomMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ content: 'project-log-B' }),
+        expect.objectContaining({ deliverAs: 'followUp', triggerTurn: true })
+      );
+      expect(hostInternal.session.sendCustomMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ content: 'daily-summary' }),
+        expect.objectContaining({ deliverAs: 'followUp', triggerTurn: true })
+      );
+    });
+
+    it('same-provider retry resends deliveries even when prompt is also retried', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        pendingPrompt: string | null;
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
+        }>;
+        lastTurnErrored: boolean;
+        session: {
+          prompt: ReturnType<typeof vi.fn>;
+          sendCustomMessage: ReturnType<typeof vi.fn>;
+        };
+        handlePotentialError: (event: unknown) => Promise<void>;
+        authResolver: {
+          markKeyFailed: ReturnType<typeof vi.fn>;
+          getNextProvider: ReturnType<typeof vi.fn>;
+          isKeyInCooldown: ReturnType<typeof vi.fn>;
+        };
+        retryAttempts: Map<string, number>;
+        currentProvider: string;
+        currentKeyIndex: number;
+        resourceLoader: { reload: ReturnType<typeof vi.fn> } | null;
+      };
+
+      hostInternal.session = {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        sendCustomMessage: vi.fn().mockResolvedValue(undefined),
+      };
+      hostInternal.resourceLoader = { reload: vi.fn().mockResolvedValue(undefined) };
+      hostInternal.currentProvider = 'cerebras';
+      hostInternal.currentKeyIndex = 0;
+      hostInternal.pendingPrompt = 'user question';
+
+      const details = { sender: 0, receiver: 2, timestamp: Date.now() };
+      hostInternal.pendingDeliveries = [
+        { content: 'project-log', details, urgent: false, resolve: vi.fn(), reject: vi.fn() },
+      ];
+
+      hostInternal.retryAttempts = new Map();
+      hostInternal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
+      hostInternal.authResolver.markKeyFailed = vi.fn().mockReturnValue(false);
+      hostInternal.authResolver.getNextProvider = vi.fn().mockReturnValue(null);
+
+      await hostInternal.handlePotentialError({
+        type: 'message_end',
+        message: { stopReason: 'error', errorMessage: 'Error 503: service unavailable' },
+      });
+
+      // Prompt should have been retried
+      expect(hostInternal.session.prompt).toHaveBeenCalledWith('user question', {
+        streamingBehavior: 'followUp',
+      });
+
+      // Delivery should ALSO have been resent (not dropped by the old else-if)
+      expect(hostInternal.session.sendCustomMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ content: 'project-log' }),
+        expect.objectContaining({ deliverAs: 'followUp', triggerTurn: true })
+      );
+    });
+
     it('pendingPrompt persists if session.prompt() throws', async () => {
       const host = new AgentHost({
         db: makeDbStub(),

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -570,40 +570,51 @@ export class AgentHost {
           );
         }
         await this.session.prompt(promptToRetry, { streamingBehavior: 'followUp' });
-      } else if (deliveriesToRetry.length > 0 && this.session) {
-        // Retry the failed delivery (no prompt took priority)
-        console.log('[AgentHost] Retrying failed delivery...');
-        try {
-          await this.resourceLoader?.reload();
-        } catch (reloadErr) {
-          console.warn(
-            '[AgentHost] Resource reload failed before delivery retry, using cached:',
-            reloadErr
-          );
+      }
+
+      // Resend ALL pending deliveries (not just the first). The prompt retry
+      // above (if any) queued a turn; deliveries queue as follow-ups behind it.
+      // Without this, deliveries beyond [0] stay in pendingDeliveries forever
+      // and their promises never resolve, blocking trackJobExecution.
+      if (deliveriesToRetry.length > 0 && this.session) {
+        console.log(
+          `[AgentHost] Resending ${deliveriesToRetry.length} pending delivery(ies) after retry...`
+        );
+        if (!promptToRetry) {
+          try {
+            await this.resourceLoader?.reload();
+          } catch (reloadErr) {
+            console.warn(
+              '[AgentHost] Resource reload failed before delivery retry, using cached:',
+              reloadErr
+            );
+          }
         }
-        const failed = deliveriesToRetry[0];
-        this.session
-          .sendCustomMessage(
-            {
-              customType: 'agent_message',
-              content: failed.content,
-              display: false,
-              details: failed.details,
-            },
-            {
-              deliverAs: failed.urgent ? 'steer' : 'followUp',
-              triggerTurn: true,
-            }
-          )
-          .then(() => {
-            this.deliverySendCount++;
-          })
-          .catch((error) => {
-            console.error('[AgentHost] Failed to resend delivery after retry:', error);
-            const idx = this.pendingDeliveries.indexOf(failed);
-            if (idx !== -1) this.pendingDeliveries.splice(idx, 1);
-            failed.reject(error instanceof Error ? error : new Error(String(error)));
-          });
+        const session = this.session;
+        for (const d of deliveriesToRetry) {
+          session
+            .sendCustomMessage(
+              {
+                customType: 'agent_message',
+                content: d.content,
+                display: false,
+                details: d.details,
+              },
+              {
+                deliverAs: d.urgent ? 'steer' : 'followUp',
+                triggerTurn: true,
+              }
+            )
+            .then(() => {
+              this.deliverySendCount++;
+            })
+            .catch((error) => {
+              console.error('[AgentHost] Failed to resend delivery after retry:', error);
+              const idx = this.pendingDeliveries.indexOf(d);
+              if (idx !== -1) this.pendingDeliveries.splice(idx, 1);
+              d.reject(error instanceof Error ? error : new Error(String(error)));
+            });
+        }
       }
       return;
     }

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -165,6 +165,7 @@ export class AgentHost {
   private resourceLoader: DefaultResourceLoader | null = null;
   private busy = false;
   private lastTurnErrored = false;
+  private deliverySendCount = 0;
   private compactionCount = 0;
   private compactionDepth = 0;
   private isPruning = false;
@@ -442,25 +443,20 @@ export class AgentHost {
       // handlePotentialError before agent_end fires). Skip cleanup so the
       // failed prompt/delivery stays tracked for retry or failover.
       if (!this.lastTurnErrored) {
-        const messages =
-          'messages' in event ? (event.messages as Array<Record<string, unknown>>) : null;
-        // Only clear pendingPrompt when a prompt turn (user message) completed.
-        // A delivery-only agent_end (only custom messages) should not clear it,
-        // since a queued prompt may still be waiting to process.
-        if (!messages || messages.some((m) => m.role === 'user')) {
-          this.pendingPrompt = null;
+        // Clear pendingPrompt: one agent_end fires after ALL turns (prompt +
+        // follow-ups) are processed, so it's always safe to clear here.
+        this.pendingPrompt = null;
+        // Resolve delivery promises using the send counter. The SDK's
+        // agent_end.messages excludes the initial prompt (which is how
+        // sendCustomMessage delivers to an idle agent), so counting messages
+        // there always under-counts by 1. The send counter tracks how many
+        // sendCustomMessage calls completed since the last agent_end.
+        const toResolve = Math.min(this.deliverySendCount, this.pendingDeliveries.length);
+        for (let i = 0; i < toResolve; i++) {
+          const completed = this.pendingDeliveries.shift();
+          if (completed) completed.resolve();
         }
-        // Count delivery messages that completed in this agent loop. The SDK
-        // batches follow-up turns into a single agent_end, so a prompt turn
-        // followed by queued deliveries produces one event with mixed messages.
-        // Only shift for actual deliveries to avoid desync.
-        const deliveriesCompleted = messages
-          ? messages.filter((m) => m.role === 'custom' && m.customType === 'agent_message').length
-          : 0;
-        for (let i = 0; i < deliveriesCompleted && this.pendingDeliveries.length > 0; i++) {
-          const completed = this.pendingDeliveries.shift()!;
-          completed.resolve();
-        }
+        this.deliverySendCount = 0;
       }
       this.lastTurnErrored = false;
     }
@@ -514,6 +510,10 @@ export class AgentHost {
     // reinitializeWithProvider needs the values passed as arguments.
     const promptToRetry = this.pendingPrompt;
     const deliveriesToRetry = [...this.pendingDeliveries];
+    // Reset the send counter: any .then() callbacks from the failed turn's
+    // sendCustomMessage calls have already run, and their increments are stale.
+    // The retry/failover path will re-send and re-increment as needed.
+    this.deliverySendCount = 0;
 
     // If another agent already put our key in cooldown, skip retries and reinitialize.
     // Uses the tracked key index so we check our actual key, not whatever index
@@ -595,6 +595,9 @@ export class AgentHost {
               triggerTurn: true,
             }
           )
+          .then(() => {
+            this.deliverySendCount++;
+          })
           .catch((error) => {
             console.error('[AgentHost] Failed to resend delivery after retry:', error);
             const idx = this.pendingDeliveries.indexOf(failed);
@@ -676,6 +679,7 @@ export class AgentHost {
       if (recovered) {
         // Clear the overflow-causing prompt so a future failover doesn't retry it
         this.pendingPrompt = null;
+        this.deliverySendCount = 0;
         // Replay pending deliveries on the recovered session. Don't clear
         // pendingDeliveries: agent_end will shift each one as turns succeed.
         if (this.pendingDeliveries.length > 0 && this.session) {
@@ -693,6 +697,9 @@ export class AgentHost {
                   triggerTurn: true,
                 }
               )
+              .then(() => {
+                this.deliverySendCount++;
+              })
               .catch((error) => {
                 console.error(
                   '[AgentHost] Failed to replay delivery after context overflow:',
@@ -815,6 +822,8 @@ export class AgentHost {
       // Re-arm error handling before retrying the prompt. Errors from the new
       // provider need normal failover, not the isReinitializing early-return.
       this.isReinitializing = false;
+      // Reset the send counter: old session's sends are gone, new session starts fresh
+      this.deliverySendCount = 0;
 
       // Retry the pending prompt with the new provider
       if (promptToRetry && this.session) {
@@ -854,6 +863,9 @@ export class AgentHost {
                 triggerTurn: true,
               }
             )
+            .then(() => {
+              this.deliverySendCount++;
+            })
             .catch((error) => {
               console.error('[AgentHost] Failed to replay delivery after failover:', error);
               const idx = this.pendingDeliveries.indexOf(d);
@@ -1133,6 +1145,14 @@ export class AgentHost {
           }
         )
       )
+      .then(() => {
+        // Track successful send for agent_end resolution. Incremented here
+        // (after sendCustomMessage resolves) so only actually-sent messages
+        // are counted. The SDK processes all queued messages (prompt +
+        // follow-ups) in one turn and fires a single agent_end, so the
+        // counter accumulates correctly across the batch.
+        this.deliverySendCount++;
+      })
       .catch((err) => {
         console.error('[AgentHost] deliverMessage error:', err);
         // Send itself failed (session destroyed, etc.). The message never
@@ -1160,6 +1180,7 @@ export class AgentHost {
         this.busy = false;
       }
       this.pendingPrompt = null;
+      this.deliverySendCount = 0;
       for (const delivery of this.pendingDeliveries) {
         delivery.reject(new Error('Agent session aborted'));
       }

--- a/packages/server/src/chat/history-capture.test.ts
+++ b/packages/server/src/chat/history-capture.test.ts
@@ -48,7 +48,7 @@ function toolEnd(toolName: string, result?: string, isError = false): AgentSessi
 describe('createHistoryCaptureSubscriber', () => {
   it('captures text-only assistant turn', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(cache as unknown as MessageHistory);
+    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
     sub(textDelta('Hello '));
     sub(textDelta('world'));
@@ -63,7 +63,7 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('captures tool-only turn (no text)', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(cache as unknown as MessageHistory);
+    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
     sub(thinkingDelta('Let me think...'));
     sub(toolStart('read_file', { path: '/tmp/foo' }));
@@ -85,7 +85,7 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('does not push when message_end fires with no content or events', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(cache as unknown as MessageHistory);
+    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
     sub(messageEnd());
 
@@ -94,7 +94,7 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('captures compaction_start as system message', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(cache as unknown as MessageHistory);
+    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
     sub({ type: 'compaction_start' } as unknown as AgentSessionEvent);
 
@@ -106,7 +106,7 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('captures compaction_end as system message', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(cache as unknown as MessageHistory);
+    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
     sub({ type: 'compaction_end' } as unknown as AgentSessionEvent);
 
@@ -118,7 +118,7 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('captures text + tool calls in the same turn', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(cache as unknown as MessageHistory);
+    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
     sub(thinkingDelta('Thinking...'));
     sub(toolStart('bash', 'ls'));
@@ -142,7 +142,7 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('marks tool error results with Error prefix', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(cache as unknown as MessageHistory);
+    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
     sub(toolStart('bash', 'bad-cmd'));
     sub(toolEnd('bash', 'command not found', true));

--- a/packages/server/src/chat/history-capture.test.ts
+++ b/packages/server/src/chat/history-capture.test.ts
@@ -1,0 +1,156 @@
+import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
+import { describe, expect, it, vi } from 'vitest';
+import type { MessageHistory } from './history.js';
+import { createHistoryCaptureSubscriber } from './history-capture.js';
+
+interface MockCache {
+  messages: unknown[];
+  push: ReturnType<typeof vi.fn>;
+}
+
+function mockCache(): MockCache {
+  const messages: unknown[] = [];
+  const push = vi.fn((msg: unknown) => messages.push(msg));
+  return { messages, push };
+}
+
+function textDelta(delta: string): AgentSessionEvent {
+  return {
+    type: 'message_update',
+    assistantMessageEvent: { type: 'text_delta', delta },
+  } as unknown as AgentSessionEvent;
+}
+
+function thinkingDelta(delta: string): AgentSessionEvent {
+  return {
+    type: 'message_update',
+    assistantMessageEvent: { type: 'thinking_delta', delta },
+  } as unknown as AgentSessionEvent;
+}
+
+function messageEnd(): AgentSessionEvent {
+  return { type: 'message_end' } as unknown as AgentSessionEvent;
+}
+
+function toolStart(toolName: string, args?: unknown): AgentSessionEvent {
+  return { type: 'tool_execution_start', toolName, args } as unknown as AgentSessionEvent;
+}
+
+function toolEnd(toolName: string, result?: string, isError = false): AgentSessionEvent {
+  return {
+    type: 'tool_execution_end',
+    toolName,
+    isError,
+    result: result ? { content: [{ type: 'text', text: result }] } : undefined,
+  } as unknown as AgentSessionEvent;
+}
+
+describe('createHistoryCaptureSubscriber', () => {
+  it('captures text-only assistant turn', () => {
+    const cache = mockCache();
+    const sub = createHistoryCaptureSubscriber(cache as unknown as MessageHistory);
+
+    sub(textDelta('Hello '));
+    sub(textDelta('world'));
+    sub(messageEnd());
+
+    expect(cache.push).toHaveBeenCalledOnce();
+    const msg = cache.messages[0] as { role: string; content: string; turnEvents?: unknown };
+    expect(msg.role).toBe('assistant');
+    expect(msg.content).toBe('Hello world');
+    expect(msg.turnEvents).toBeUndefined();
+  });
+
+  it('captures tool-only turn (no text)', () => {
+    const cache = mockCache();
+    const sub = createHistoryCaptureSubscriber(cache as unknown as MessageHistory);
+
+    sub(thinkingDelta('Let me think...'));
+    sub(toolStart('read_file', { path: '/tmp/foo' }));
+    sub(toolEnd('read_file', 'file contents'));
+    sub(messageEnd());
+
+    expect(cache.push).toHaveBeenCalledOnce();
+    const msg = cache.messages[0] as {
+      role: string;
+      content: string;
+      turnEvents: Array<{ type: string }>;
+    };
+    expect(msg.role).toBe('assistant');
+    expect(msg.content).toBe('');
+    expect(msg.turnEvents).toHaveLength(2);
+    expect(msg.turnEvents[0].type).toBe('thinking');
+    expect(msg.turnEvents[1].type).toBe('tool_call');
+  });
+
+  it('does not push when message_end fires with no content or events', () => {
+    const cache = mockCache();
+    const sub = createHistoryCaptureSubscriber(cache as unknown as MessageHistory);
+
+    sub(messageEnd());
+
+    expect(cache.push).not.toHaveBeenCalled();
+  });
+
+  it('captures compaction_start as system message', () => {
+    const cache = mockCache();
+    const sub = createHistoryCaptureSubscriber(cache as unknown as MessageHistory);
+
+    sub({ type: 'compaction_start' } as unknown as AgentSessionEvent);
+
+    expect(cache.push).toHaveBeenCalledOnce();
+    const msg = cache.messages[0] as { role: string; content: string };
+    expect(msg.role).toBe('system');
+    expect(msg.content).toBe('Context compaction started');
+  });
+
+  it('captures compaction_end as system message', () => {
+    const cache = mockCache();
+    const sub = createHistoryCaptureSubscriber(cache as unknown as MessageHistory);
+
+    sub({ type: 'compaction_end' } as unknown as AgentSessionEvent);
+
+    expect(cache.push).toHaveBeenCalledOnce();
+    const msg = cache.messages[0] as { role: string; content: string };
+    expect(msg.role).toBe('system');
+    expect(msg.content).toBe('Context compacted');
+  });
+
+  it('captures text + tool calls in the same turn', () => {
+    const cache = mockCache();
+    const sub = createHistoryCaptureSubscriber(cache as unknown as MessageHistory);
+
+    sub(thinkingDelta('Thinking...'));
+    sub(toolStart('bash', 'ls'));
+    sub(toolEnd('bash', 'file.txt'));
+    sub(textDelta('Here are the files.'));
+    sub(messageEnd());
+
+    expect(cache.push).toHaveBeenCalledOnce();
+    const msg = cache.messages[0] as {
+      role: string;
+      content: string;
+      turnEvents: Array<{ type: string; data: { status?: string; result?: string } }>;
+    };
+    expect(msg.content).toBe('Here are the files.');
+    expect(msg.turnEvents).toHaveLength(2);
+    expect(msg.turnEvents[0].type).toBe('thinking');
+    expect(msg.turnEvents[1].type).toBe('tool_call');
+    expect(msg.turnEvents[1].data.status).toBe('completed');
+    expect(msg.turnEvents[1].data.result).toBe('file.txt');
+  });
+
+  it('marks tool error results with Error prefix', () => {
+    const cache = mockCache();
+    const sub = createHistoryCaptureSubscriber(cache as unknown as MessageHistory);
+
+    sub(toolStart('bash', 'bad-cmd'));
+    sub(toolEnd('bash', 'command not found', true));
+    sub(messageEnd());
+
+    const msg = cache.messages[0] as {
+      turnEvents: Array<{ data: { result: string } }>;
+    };
+    expect(msg.turnEvents[0].data.result).toBe('Error: command not found');
+  });
+});

--- a/packages/server/src/chat/history-capture.ts
+++ b/packages/server/src/chat/history-capture.ts
@@ -13,13 +13,18 @@ import type { MessageHistory } from './history.js';
 /**
  * Create a subscriber function that captures agent events into the chat cache.
  *
+ * Accepts a getter so the cache is resolved lazily on the first event, not at
+ * subscription time. This is important because subscriptions are set up before
+ * AgentHost.initialize() (to avoid missing events), but chatCache is only
+ * available after initialize() creates the MessageHistory instance.
+ *
  * Accumulates thinking blocks and tool calls as turn events, then persists
  * the complete assistant message on message_end. Tool-only turns (thinking +
  * tool calls without text) are also persisted. Compaction events are recorded
  * as system messages.
  */
 export function createHistoryCaptureSubscriber(
-  chatCache: MessageHistory
+  getChatCache: () => MessageHistory
 ): (event: AgentSessionEvent) => void {
   let currentAssistantText = '';
   let activeThinkingContent = '';
@@ -60,7 +65,7 @@ export function createHistoryCaptureSubscriber(
             timestamp: Date.now(),
             turnEvents: currentTurnEvents.length > 0 ? [...currentTurnEvents] : undefined,
           };
-          chatCache.push(assistantMsg);
+          getChatCache().push(assistantMsg);
           currentAssistantText = '';
           currentTurnEvents = [];
         }
@@ -138,7 +143,7 @@ export function createHistoryCaptureSubscriber(
 
       case 'compaction_start':
       case 'compaction_end':
-        chatCache.push({
+        getChatCache().push({
           id: `msg-${Date.now()}`,
           role: 'system',
           content:

--- a/packages/server/src/chat/history-capture.ts
+++ b/packages/server/src/chat/history-capture.ts
@@ -1,0 +1,151 @@
+/**
+ * History Capture
+ *
+ * Creates an event subscriber that captures agent session events into a
+ * MessageHistory (chat cache). Extracted from Server so the logic is testable
+ * independently.
+ */
+
+import type { ChatMessage, ChatTurnEvent } from '@dscarabelli/shared';
+import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
+import type { MessageHistory } from './history.js';
+
+/**
+ * Create a subscriber function that captures agent events into the chat cache.
+ *
+ * Accumulates thinking blocks and tool calls as turn events, then persists
+ * the complete assistant message on message_end. Tool-only turns (thinking +
+ * tool calls without text) are also persisted. Compaction events are recorded
+ * as system messages.
+ */
+export function createHistoryCaptureSubscriber(
+  chatCache: MessageHistory
+): (event: AgentSessionEvent) => void {
+  let currentAssistantText = '';
+  let activeThinkingContent = '';
+  let currentTurnEvents: ChatTurnEvent[] = [];
+
+  return (event: AgentSessionEvent) => {
+    switch (event.type) {
+      case 'message_update':
+        if (event.assistantMessageEvent.type === 'text_delta') {
+          currentAssistantText += event.assistantMessageEvent.delta;
+        } else if (event.assistantMessageEvent.type === 'thinking_delta') {
+          activeThinkingContent += event.assistantMessageEvent.delta;
+        }
+        break;
+
+      case 'message_end': {
+        // Finalize thinking if active
+        if (activeThinkingContent) {
+          currentTurnEvents.push({
+            type: 'thinking',
+            data: {
+              id: `thinking-${Date.now()}`,
+              content: activeThinkingContent,
+              isStreaming: false,
+              timestamp: Date.now(),
+            },
+          });
+          activeThinkingContent = '';
+        }
+
+        // Capture completed assistant message in history.
+        // Push when there's text OR tool-only turns (thinking + tool calls without text).
+        if (currentAssistantText || currentTurnEvents.length > 0) {
+          const assistantMsg: ChatMessage = {
+            id: `msg-${Date.now()}`,
+            role: 'assistant',
+            content: currentAssistantText,
+            timestamp: Date.now(),
+            turnEvents: currentTurnEvents.length > 0 ? [...currentTurnEvents] : undefined,
+          };
+          chatCache.push(assistantMsg);
+          currentAssistantText = '';
+          currentTurnEvents = [];
+        }
+        break;
+      }
+
+      case 'tool_execution_start': {
+        // Finalize thinking before tool call
+        if (activeThinkingContent) {
+          currentTurnEvents.push({
+            type: 'thinking',
+            data: {
+              id: `thinking-${Date.now()}`,
+              content: activeThinkingContent,
+              isStreaming: false,
+              timestamp: Date.now(),
+            },
+          });
+          activeThinkingContent = '';
+        }
+
+        // Format tool input for display
+        let inputText = '';
+        const rawInput = event.args;
+        if (rawInput) {
+          try {
+            inputText = typeof rawInput === 'string' ? rawInput : JSON.stringify(rawInput, null, 2);
+          } catch {
+            inputText = String(rawInput);
+          }
+        }
+
+        currentTurnEvents.push({
+          type: 'tool_call',
+          data: {
+            id: `tool-${Date.now()}`,
+            name: event.toolName,
+            status: 'running',
+            input: inputText,
+            timestamp: Date.now(),
+          },
+        });
+        break;
+      }
+
+      case 'tool_execution_end': {
+        // Format result as string for display
+        let resultText = '';
+        if (event.result?.content) {
+          resultText = event.result.content
+            .map((c: { type: string; text?: string }) => (c.type === 'text' ? c.text : ''))
+            .join('');
+        }
+        const finalResult = event.isError ? `Error: ${resultText}` : resultText;
+
+        // Update the tool call in turn events (immutable)
+        let matched = false;
+        currentTurnEvents = currentTurnEvents.map((e) => {
+          if (
+            !matched &&
+            e.type === 'tool_call' &&
+            e.data.name === event.toolName &&
+            e.data.status === 'running'
+          ) {
+            matched = true;
+            return {
+              ...e,
+              data: { ...e.data, status: 'completed' as const, result: finalResult },
+            };
+          }
+          return e;
+        });
+        break;
+      }
+
+      case 'compaction_start':
+      case 'compaction_end':
+        chatCache.push({
+          id: `msg-${Date.now()}`,
+          role: 'system',
+          content:
+            event.type === 'compaction_start' ? 'Context compaction started' : 'Context compacted',
+          timestamp: Date.now(),
+        });
+        break;
+    }
+  };
+}

--- a/packages/server/src/scheduler/jobs.test.ts
+++ b/packages/server/src/scheduler/jobs.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -17,6 +17,7 @@ import {
   resolveDailySummaryTimestamp,
   stripSessionEntry,
   trackJobExecution,
+  writeFrontmatterField,
 } from './jobs.js';
 import type { Scheduler } from './scheduler.js';
 
@@ -84,6 +85,47 @@ describe('readFrontmatterField', () => {
     const file = join(dir, 'test.md');
     writeFileSync(file, '---\nlast_narrator_update_ts:\n---\n');
     expect(readFrontmatterField(file, 'last_narrator_update_ts')).toBeNull();
+  });
+});
+
+describe('writeFrontmatterField', () => {
+  it('replaces an existing field value', () => {
+    const dir = trackTmpDir(makeTmpDir());
+    const file = join(dir, 'test.md');
+    writeFileSync(file, '---\nlast_narrator_update_ts: old-value\n---\n# Body');
+    writeFrontmatterField(file, 'last_narrator_update_ts', '2026-03-30T00:00:00Z');
+    expect(readFrontmatterField(file, 'last_narrator_update_ts')).toBe('2026-03-30T00:00:00Z');
+    expect(readFileSync(file, 'utf-8')).toContain('# Body');
+  });
+
+  it('replaces an empty field value', () => {
+    const dir = trackTmpDir(makeTmpDir());
+    const file = join(dir, 'test.md');
+    writeFileSync(file, '---\nlast_narrator_update_ts:\n---\n');
+    writeFrontmatterField(file, 'last_narrator_update_ts', '2026-03-30T00:00:00Z');
+    expect(readFrontmatterField(file, 'last_narrator_update_ts')).toBe('2026-03-30T00:00:00Z');
+  });
+
+  it('inserts field if not found in frontmatter', () => {
+    const dir = trackTmpDir(makeTmpDir());
+    const file = join(dir, 'test.md');
+    writeFileSync(file, '---\ntitle: Test\n---\n# Body');
+    writeFrontmatterField(file, 'last_narrator_update_ts', '2026-03-30T00:00:00Z');
+    expect(readFrontmatterField(file, 'last_narrator_update_ts')).toBe('2026-03-30T00:00:00Z');
+    expect(readFileSync(file, 'utf-8')).toContain('title: Test');
+  });
+
+  it('no-ops on missing file', () => {
+    writeFrontmatterField('/nonexistent/file.md', 'field', 'value');
+    // No throw
+  });
+
+  it('no-ops on file without frontmatter', () => {
+    const dir = trackTmpDir(makeTmpDir());
+    const file = join(dir, 'test.md');
+    writeFileSync(file, '# No frontmatter');
+    writeFrontmatterField(file, 'field', 'value');
+    expect(readFileSync(file, 'utf-8')).toBe('# No frontmatter');
   });
 });
 
@@ -270,7 +312,6 @@ describe('buildAndDeliverMemoryUpdate', () => {
     expect(msg).not.toContain('Old narrative.');
     expect(msg).not.toContain('2026-03-09.md');
     expect(msg).toContain('IMPORTANT');
-    expect(msg).toContain('UTC ISO 8601');
   });
 
   it('includes all summaries when memory.md has no timestamp', async () => {
@@ -967,6 +1008,65 @@ describe('buildAndDeliverDailySummary', () => {
     expect(dailySummaryMsg).toBeDefined();
     expect(dailySummaryMsg).toContain('## Project Activity');
     expect(dailySummaryMsg).not.toContain('## Non-Project Activity');
+  });
+
+  it('advances frontmatter cursor on successful delivery', async () => {
+    const dir = trackTmpDir(makeTmpDir());
+    const summariesDir = join(dir, 'knowledge', 'daily_summaries');
+    const sessionDir = join(dir, 'sessions', 'guide_1');
+    mkdirSync(summariesDir, { recursive: true });
+    mkdirSync(sessionDir, { recursive: true });
+
+    // Seed with a recent timestamp for the time window
+    const lastRunTs = new Date(Date.now() - 10 * 60_000).toISOString();
+    const entryTs = new Date(Date.now() - 5 * 60_000).toISOString();
+
+    writeFileSync(
+      join(summariesDir, '2026-03-15.md'),
+      `---\nlast_narrator_update_ts: ${lastRunTs}\n---\n# Daily Summary\n`
+    );
+
+    // Create JSONL activity within the time window
+    const entry = JSON.stringify({
+      type: 'message',
+      timestamp: entryTs,
+      message: { role: 'user', content: [{ type: 'text', text: 'hello' }] },
+    });
+    writeFileSync(join(sessionDir, 'session.jsonl'), entry);
+
+    const host = mockHost();
+    const db = mockDb([{ id: 1, role: 'guide', project_name: null }]);
+    await buildAndDeliverDailySummary(db, host, 99, dir, 30);
+
+    // Server should have advanced the cursor in today's file (not relying on LLM)
+    const today = new Date().toISOString().slice(0, 10);
+    const todayFile = join(summariesDir, `${today}.md`);
+    const cursor = readFrontmatterField(todayFile, 'last_narrator_update_ts');
+    expect(cursor).not.toBeNull();
+    expect(cursor).not.toBe(lastRunTs);
+  });
+
+  it('advances frontmatter cursor even on skip (no activity)', async () => {
+    const dir = trackTmpDir(makeTmpDir());
+    const summariesDir = join(dir, 'knowledge', 'daily_summaries');
+    mkdirSync(summariesDir, { recursive: true });
+
+    const lastRunTs = new Date(Date.now() - 10 * 60_000).toISOString();
+    writeFileSync(
+      join(summariesDir, '2026-03-15.md'),
+      `---\nlast_narrator_update_ts: ${lastRunTs}\n---\n# Daily Summary\n`
+    );
+
+    const host = mockHost();
+    const db = mockDb([{ id: 1, role: 'guide', project_name: null }]);
+    await expect(buildAndDeliverDailySummary(db, host, 99, dir, 30)).rejects.toThrow(JobSkipped);
+
+    // Cursor should still advance in today's file to prevent re-scanning the same window
+    const today = new Date().toISOString().slice(0, 10);
+    const todayFile = join(summariesDir, `${today}.md`);
+    const cursor = readFrontmatterField(todayFile, 'last_narrator_update_ts');
+    expect(cursor).not.toBeNull();
+    expect(cursor).not.toBe(lastRunTs);
   });
 });
 

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -663,8 +663,6 @@ ${projectDbChanges}`;
   const hasNonProjectChanges = hasActivity(nonProjectAgentActivity, nonProjectDbChanges);
 
   if (!hasProjectChanges && !hasNonProjectChanges) {
-    // Await any project-log deliveries that were already queued
-    if (deliveries.length > 0) await Promise.all(deliveries);
     // Advance cursor even on skip to prevent re-scanning an empty window
     advanceFrontmatterCursors(filePath, projectDataList, newRunTs);
     throw new JobSkipped('no activity since last run');

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -521,9 +521,9 @@ export async function buildAndDeliverDailySummary(
     lastRunTs = readFrontmatterField(memoryPath, 'last_narrator_update_ts');
   }
   if (!lastRunTs) {
-    // If daily summary files already exist, the Narrator should have written
-    // last_narrator_update_ts to their frontmatter. Missing timestamps indicate
-    // a problem (e.g., Narrator failed to update the cursor).
+    // If daily summary files already exist, the server should have written
+    // last_narrator_update_ts to their frontmatter after delivery. Missing
+    // timestamps indicate a problem (e.g., server crashed before cursor update).
     const hasExistingSummaries =
       existsSync(summariesDir) &&
       readdirSync(summariesDir).some((f) => f.endsWith('.md') && f !== `${today}.md`);

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -37,6 +37,45 @@ export function readFrontmatterField(filePath: string, field: string): string | 
 }
 
 /**
+ * Write a YAML frontmatter field in a file.
+ * If the field exists, its value is replaced. If the frontmatter block exists
+ * but the field is missing, the field is inserted after the opening `---`.
+ */
+export function writeFrontmatterField(filePath: string, field: string, value: string): void {
+  if (!existsSync(filePath)) return;
+  const content = readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+
+  // Find frontmatter boundaries
+  if (lines[0]?.trim() !== '---') return;
+  let endIdx = -1;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === '---') {
+      endIdx = i;
+      break;
+    }
+  }
+  if (endIdx === -1) return;
+
+  // Try to replace existing field
+  let replaced = false;
+  for (let i = 1; i < endIdx; i++) {
+    if (lines[i].match(new RegExp(`^${field}:`))) {
+      lines[i] = `${field}: ${value}`;
+      replaced = true;
+      break;
+    }
+  }
+
+  // Insert if not found
+  if (!replaced) {
+    lines.splice(1, 0, `${field}: ${value}`);
+  }
+
+  writeFileSync(filePath, lines.join('\n'), 'utf-8');
+}
+
+/**
  * Read the last N characters of a file.
  */
 export function readTailChars(filePath: string, n: number): string {
@@ -297,6 +336,7 @@ export function formatMarkdownTable(rows: Record<string, unknown>[]): string {
 interface ProjectActivityData {
   projectId: number;
   projectName: string;
+  logFile: string;
   agentActivity: string;
   dbChanges: string;
   hasChanges: boolean;
@@ -412,6 +452,22 @@ function hasActivity(agentActivity: string, dbChanges: string): boolean {
     .split('\n')
     .every((line) => !line.trim() || line.startsWith('###') || line === '(no activity)');
   return hasAgentLines || dbChanges.includes('|');
+}
+
+/**
+ * Advance last_narrator_update_ts in the daily summary file and all project log files.
+ */
+function advanceFrontmatterCursors(
+  dailySummaryPath: string,
+  projectDataList: ProjectActivityData[],
+  newRunTs: string
+): void {
+  writeFrontmatterField(dailySummaryPath, 'last_narrator_update_ts', newRunTs);
+  for (const pd of projectDataList) {
+    if (pd.logFile) {
+      writeFrontmatterField(pd.logFile, 'last_narrator_update_ts', newRunTs);
+    }
+  }
 }
 
 /**
@@ -551,6 +607,7 @@ export async function buildAndDeliverDailySummary(
     projectDataList.push({
       projectId: project.id,
       projectName: project.name,
+      logFile,
       agentActivity: projectScopedActivity,
       dbChanges: projectDbChanges,
       hasChanges: hasActivity(projectScopedActivity, projectDbChanges),
@@ -567,7 +624,6 @@ file: ${logFile}
 last_run_ts: ${lastRunTs}
 new_run_ts: ${newRunTs}
 
-IMPORTANT: After writing the log entry, you MUST set last_narrator_update_ts to exactly "${newRunTs}" (UTC ISO 8601) in the frontmatter of ${logFile}. This advances the cursor for the next run.
 IMPORTANT: Do not message the Guide when you are done. This is a background task — no response is expected.
 
 ## Most recent log.md content
@@ -609,6 +665,8 @@ ${projectDbChanges}`;
   if (!hasProjectChanges && !hasNonProjectChanges) {
     // Await any project-log deliveries that were already queued
     if (deliveries.length > 0) await Promise.all(deliveries);
+    // Advance cursor even on skip to prevent re-scanning an empty window
+    advanceFrontmatterCursors(filePath, projectDataList, newRunTs);
     throw new JobSkipped('no activity since last run');
   }
 
@@ -620,7 +678,6 @@ file: ${filePath}
 last_run_ts: ${lastRunTs}
 new_run_ts: ${newRunTs}
 
-IMPORTANT: After writing the summary, you MUST set last_narrator_update_ts to exactly "${newRunTs}" (UTC ISO 8601) in the frontmatter of ${filePath}. This advances the cursor for the next run.
 IMPORTANT: Do not message the Guide when you are done. This is a background task — no response is expected.
 
 ## Current daily summary file content
@@ -656,6 +713,11 @@ ${dailySummaryContent}`,
 
   // Wait for the Narrator to finish processing all deliveries
   await Promise.all(deliveries);
+
+  // Server-side cursor advancement: update frontmatter so the next cron run
+  // starts from newRunTs. Previously delegated to the LLM, but compaction
+  // could wipe the instruction, causing stale cursors and repeated deliveries.
+  advanceFrontmatterCursors(filePath, projectDataList, newRunTs);
 }
 
 /**
@@ -773,7 +835,6 @@ memory_file: ${memoryFile}
 last_narrator_update_ts: ${lastTs ?? '(none)'}
 new_run_ts: ${newRunTs}
 
-IMPORTANT: After writing memory.md, you MUST set last_narrator_update_ts to exactly "${newRunTs}" (UTC ISO 8601) in the frontmatter of ${memoryFile}. This advances the cursor for the next run.
 IMPORTANT: Do not message the Guide when you are done. This is a background task — no response is expected.
 
 ## Daily summaries to incorporate
@@ -785,4 +846,7 @@ ${summaryEntries.join('\n\n')}`;
     receiver: narratorId,
     timestamp: Date.now(),
   });
+
+  // Server-side cursor advancement for memory.md
+  writeFrontmatterField(memoryFile, 'last_narrator_update_ts', newRunTs);
 }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -438,7 +438,7 @@ export class Server {
    * then persists the complete assistant message on message_end.
    */
   private subscribeForHistoryCapture(agentHost: AgentHost): void {
-    agentHost.subscribe(createHistoryCaptureSubscriber(agentHost.chatCache));
+    agentHost.subscribe(createHistoryCaptureSubscriber(() => agentHost.chatCache));
   }
 
   async start(): Promise<void> {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -468,8 +468,9 @@ export class Server {
             activeThinkingContent = '';
           }
 
-          // Capture completed assistant message in history
-          if (currentAssistantText) {
+          // Capture completed assistant message in history.
+          // Push when there's text OR tool-only turns (thinking + tool calls without text).
+          if (currentAssistantText || currentTurnEvents.length > 0) {
             const assistantMsg: ChatMessage = {
               id: `msg-${Date.now()}`,
               role: 'assistant',
@@ -553,6 +554,19 @@ export class Server {
           });
           break;
         }
+
+        case 'compaction_start':
+        case 'compaction_end':
+          agentHost.chatCache.push({
+            id: `msg-${Date.now()}`,
+            role: 'system',
+            content:
+              event.type === 'compaction_start'
+                ? 'Context compaction started'
+                : 'Context compacted',
+            timestamp: Date.now(),
+          });
+          break;
       }
     });
   }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -11,8 +11,6 @@ import { dirname, isAbsolute, join, normalize } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type {
   ChatConfig,
-  ChatMessage,
-  ChatTurnEvent,
   JobExecution,
   LlmConfig,
   SchedulerConfig,
@@ -29,6 +27,7 @@ import { AgentHost } from './agents/host.js';
 import { AgentRegistry } from './agents/registry.js';
 import type { AgentResurrector } from './agents/tools/resurrect-agent.js';
 import type { AgentSpawner } from './agents/tools/spawn-agent.js';
+import { createHistoryCaptureSubscriber } from './chat/history-capture.js';
 import { ConversationSummarizer } from './chat/summarizer.js';
 import { DatabaseClient } from './db/client.js';
 import { initializeGitRepo } from './knowledge/git.js';
@@ -439,136 +438,7 @@ export class Server {
    * then persists the complete assistant message on message_end.
    */
   private subscribeForHistoryCapture(agentHost: AgentHost): void {
-    let currentAssistantText = '';
-    let activeThinkingContent = '';
-    let currentTurnEvents: ChatTurnEvent[] = [];
-
-    agentHost.subscribe((event: AgentSessionEvent) => {
-      switch (event.type) {
-        case 'message_update':
-          if (event.assistantMessageEvent.type === 'text_delta') {
-            currentAssistantText += event.assistantMessageEvent.delta;
-          } else if (event.assistantMessageEvent.type === 'thinking_delta') {
-            activeThinkingContent += event.assistantMessageEvent.delta;
-          }
-          break;
-
-        case 'message_end': {
-          // Finalize thinking if active
-          if (activeThinkingContent) {
-            currentTurnEvents.push({
-              type: 'thinking',
-              data: {
-                id: `thinking-${Date.now()}`,
-                content: activeThinkingContent,
-                isStreaming: false,
-                timestamp: Date.now(),
-              },
-            });
-            activeThinkingContent = '';
-          }
-
-          // Capture completed assistant message in history.
-          // Push when there's text OR tool-only turns (thinking + tool calls without text).
-          if (currentAssistantText || currentTurnEvents.length > 0) {
-            const assistantMsg: ChatMessage = {
-              id: `msg-${Date.now()}`,
-              role: 'assistant',
-              content: currentAssistantText,
-              timestamp: Date.now(),
-              turnEvents: currentTurnEvents.length > 0 ? [...currentTurnEvents] : undefined,
-            };
-            agentHost.chatCache.push(assistantMsg);
-            currentAssistantText = '';
-            currentTurnEvents = [];
-          }
-          break;
-        }
-
-        case 'tool_execution_start': {
-          // Finalize thinking before tool call
-          if (activeThinkingContent) {
-            currentTurnEvents.push({
-              type: 'thinking',
-              data: {
-                id: `thinking-${Date.now()}`,
-                content: activeThinkingContent,
-                isStreaming: false,
-                timestamp: Date.now(),
-              },
-            });
-            activeThinkingContent = '';
-          }
-
-          // Format tool input for display
-          let inputText = '';
-          const rawInput = event.args;
-          if (rawInput) {
-            try {
-              inputText =
-                typeof rawInput === 'string' ? rawInput : JSON.stringify(rawInput, null, 2);
-            } catch {
-              inputText = String(rawInput);
-            }
-          }
-
-          currentTurnEvents.push({
-            type: 'tool_call',
-            data: {
-              id: `tool-${Date.now()}`,
-              name: event.toolName,
-              status: 'running',
-              input: inputText,
-              timestamp: Date.now(),
-            },
-          });
-          break;
-        }
-
-        case 'tool_execution_end': {
-          // Format result as string for display
-          let resultText = '';
-          if (event.result?.content) {
-            resultText = event.result.content
-              .map((c: { type: string; text?: string }) => (c.type === 'text' ? c.text : ''))
-              .join('');
-          }
-          const finalResult = event.isError ? `Error: ${resultText}` : resultText;
-
-          // Update the tool call in turn events (immutable)
-          let matched = false;
-          currentTurnEvents = currentTurnEvents.map((e) => {
-            if (
-              !matched &&
-              e.type === 'tool_call' &&
-              e.data.name === event.toolName &&
-              e.data.status === 'running'
-            ) {
-              matched = true;
-              return {
-                ...e,
-                data: { ...e.data, status: 'completed' as const, result: finalResult },
-              };
-            }
-            return e;
-          });
-          break;
-        }
-
-        case 'compaction_start':
-        case 'compaction_end':
-          agentHost.chatCache.push({
-            id: `msg-${Date.now()}`,
-            role: 'system',
-            content:
-              event.type === 'compaction_start'
-                ? 'Context compaction started'
-                : 'Context compacted',
-            timestamp: Date.now(),
-          });
-          break;
-      }
-    });
+    agentHost.subscribe(createHistoryCaptureSubscriber(agentHost.chatCache));
   }
 
   async start(): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes 5 interconnected bugs discovered during overnight narrator behavior investigation (2026-03-29 to 2026-03-30).

- **Bug 1 (root cause):** `deliverMessage` promises never resolved because `agent_end.messages` excludes the initial prompt sent via `sendCustomMessage`. Replaced `event.messages` counting with a `deliverySendCount` that tracks successful sends and resolves the correct number of pending deliveries on `agent_end`. Counter is reset on all error/retry/failover boundaries.
- **Bug 2:** `last_narrator_update_ts` was never advanced because the LLM instruction to update frontmatter was lost to compaction, causing ~30 duplicate deliveries overnight. The server now writes the cursor itself (via `writeFrontmatterField`) after successful delivery or on skip.
- **Bug 3:** Tool-only turns (thinking + tool calls, no text) were dropped from the chat cache. Fixed the `message_end` subscriber condition and added compaction event persistence.
- **Bug 4:** Chat UI gap from stuck delivery promises. Resolved by Bug 1 fix.
- **Bug 5:** Stale `running` job records on restart. Already fixed in #80; startup cleanup marks them as `failed`.

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] All 474 tests pass, including:
  - Updated delivery resolution tests using `deliverySendCount`
  - New `writeFrontmatterField` unit tests (replace, insert, edge cases)
  - New cursor advancement tests (on delivery success and on skip)
  - Updated memory-update prompt test (removed stale assertion)