### PR TITLE
docs: introduce scratchpad as working area for exploration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ The [`docs/`](docs/) directory contains in-depth documentation. Start with [`doc
 | [`tools.md`](docs/tools.md) | Custom agent tools: typed parameters, factory pattern, execution |
 | [`database.md`](docs/database.md) | SQLite schema, WAL mode, better-sqlite3 usage |
 | [`artifacts.md`](docs/artifacts.md) | Published analytical outputs, storage, DB registration, UI rendering, postMessage bridge |
+| [`scratchpad.md`](docs/scratchpad.md) | Working area for exploration and prototyping, intermediate data and notebook recommendations, promotion to artifacts |
 | [`websocket-protocol.md`](docs/websocket-protocol.md) | Real-time UI–server communication protocol |
 | [`knowledge-system.md`](docs/knowledge-system.md) | Persistent knowledge files, git-tracked, dynamic prompt injection |
 | [`skills.md`](docs/skills.md) | Reusable agent workflow instructions, SKILL.md format, discovery and injection |

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ For installation and usage, see the [project README](../README.md).
 - [Tools](tools.md): The tools available to agents, including what each one does, how they are registered, and how permissions are enforced.
 - [Database](database.md): The SQLite schema that stores projects, tasks, agents, and comments, with table definitions, indices, and common query patterns.
 - [Artifacts](artifacts.md): What artifacts are (published analytical outputs), where they live on disk, database registration, UI rendering (iframes, markdown, live reload), and the postMessage bridge for interactive dashboards.
+- [Scratchpad](scratchpad.md): The working area for exploration, prototyping, and debugging, including project-scoped and project-free locations, recommendations for intermediate data formats and notebook workflows, and the promotion path to artifacts.
 - [WebSocket Protocol](websocket-protocol.md): The message format between the UI and server, covering how chat messages, tool calls, and agent events are exchanged in real time.
 - [Knowledge System](knowledge-system.md): How agents persist and share memory, including knowledge files, daily summaries, project logs, project stories, and git tracking of `~/.system2/`.
 - [Skills](skills.md): Reusable workflow instructions for agents, including the SKILL.md format, discovery from built-in and user directories, role filtering, and XML index injection.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,7 @@ All runtime state lives in `~/.system2/`:
 │   └── daily_summaries/             Daily activity logs
 │       └── YYYY-MM-DD.md
 ├── artifacts/                       Project-free reports, dashboards, exports
+├── scratchpad/                      Project-free working files (exploration, debugging)
 ├── skills/                          Reusable workflow instructions
 │   └── {skill-name}/
 │       └── SKILL.md                 Frontmatter (name, description, roles) + steps
@@ -81,7 +82,8 @@ All runtime state lives in `~/.system2/`:
 │   └── {id}_{name}/
 │       ├── log.md                   Continuous project log (Narrator)
 │       ├── project_story.md         Final narrative (Narrator)
-│       └── artifacts/               Project-scoped artifacts
+│       ├── artifacts/               Project-scoped artifacts
+│       └── scratchpad/              Project-scoped working files (exploration, debugging)
 ├── sessions/                        Conversation history as JSONL (gitignored)
 │   └── {role}_{id}/
 └── logs/                            Server logs (gitignored)

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -2,7 +2,7 @@
 
 Artifacts are files produced as published results of analytical work: EDA notebooks, dashboards, plots, PDFs, markdown reports, and similar deliverables meant for the user to read and see. They are the tangible outputs of projects.
 
-Pipeline code, utility scripts, intermediate data files, and other working materials are **not** artifacts. The distinction is intent: artifacts are created for the user to consume, not for agents to execute.
+Pipeline code, utility scripts, intermediate data files, and other working materials are **not** artifacts. The distinction is intent: artifacts are created for the user to consume, not for agents to execute. Working files used during exploration, prototyping, and debugging belong in the [Scratchpad](scratchpad.md), which is the companion working area where source notebooks, intermediate data dumps, and prototype scripts live before anything is published as an artifact.
 
 **Key source files:**
 - `packages/server/src/agents/tools/show-artifact.ts`: Guide-only tool to display artifacts in the UI
@@ -26,7 +26,7 @@ Examples of artifacts:
 
 Not artifacts:
 - Python scripts, pipeline code, SQL files (these are working tools, not deliverables)
-- Intermediate data files (staging CSVs, temp parquet files)
+- Intermediate data files (staging CSVs, temp parquet files): these belong in the [Scratchpad](scratchpad.md)
 - Configuration files, logs, knowledge files
 
 ## File Storage
@@ -139,6 +139,7 @@ The same message type is sent on live reload (with a cache-busting `&t=<timestam
 
 ## See Also
 
+- [Scratchpad](scratchpad.md): the working area for exploration, prototyping, and intermediate data; source files and drafts that may eventually be promoted to artifacts
 - [Database](database.md#artifact): full column definitions and indices
 - [Tools](tools.md#show_artifact): `show_artifact` tool parameters and behavior
 - [WebSocket Protocol](websocket-protocol.md): artifact message type and live reload events

--- a/docs/knowledge-system.md
+++ b/docs/knowledge-system.md
@@ -54,7 +54,8 @@ Project-scoped files live outside `knowledge/`:
 └── {id}_{name}/           # e.g. 1_linkedin-campaign (Conductor creates)
     ├── log.md             # Continuous project log (Narrator, append-only)
     ├── project_story.md   # Final narrative (Narrator, on completion)
-    └── artifacts/         # Reports, dashboards, data exports
+    ├── artifacts/         # Reports, dashboards, data exports
+    └── scratchpad/        # Working files for exploration and prototyping
 ```
 
 ## File Ownership

--- a/docs/scratchpad.md
+++ b/docs/scratchpad.md
@@ -1,0 +1,81 @@
+# Scratchpad
+
+The scratchpad is a working area for exploration, testing, and debugging. It holds prototype scripts, intermediate data dumps, draft notebooks, experimental queries, and any other transient files agents produce while figuring something out. Scratchpad files are working materials, not deliverables: they are not registered in the database and do not appear in the artifact catalog. `show_artifact` can technically display any file, so an agent may show a scratchpad file if the user explicitly asks to see one, but the normal flow is to promote a file to an artifact first when it becomes worth showing.
+
+The scratchpad is the companion working area to [Artifacts](artifacts.md): exploration happens in the scratchpad, finished deliverables are promoted to artifacts.
+
+**Key source files:**
+- `packages/server/src/agents/agents.md`: agent-facing instructions on what belongs in the scratchpad and how it relates to artifacts and pipeline code
+
+## What Goes in the Scratchpad
+
+Examples of scratchpad files:
+- Prototype Python scripts being iterated on
+- Source Jupyter notebooks (`.ipynb`) under active editing
+- Intermediate DataFrames snapshotted as parquet for reuse across runs
+- Pickled Python objects (models, fitted estimators, dicts of arrays) used as caches
+- Small JSON data caches (config-like dicts, sample API responses)
+- Draft SQL queries and ad-hoc analysis snippets
+- Throwaway plots produced during exploratory analysis
+
+Not in the scratchpad:
+- **Deliverables**: anything meant for the user to read or see belongs in [Artifacts](artifacts.md), with a database record.
+- **Data pipeline code**: ingestion, transformation, loading, and scheduling code belongs in the data pipeline code repository documented in `infrastructure.md`. The scratchpad is for exploration, not production code. If a prototype script in the scratchpad matures into reusable pipeline code, graduate it to the pipelines repository as an explicit step.
+
+## File Storage
+
+Scratchpad files live under `~/.system2/`:
+
+| Location | When to use |
+|----------|-------------|
+| `~/.system2/projects/{id}_{name}/scratchpad/` | Working files tied to a specific project. Default for any work happening inside a project. |
+| `~/.system2/scratchpad/` | Working files not associated with any project (one-off explorations, system-wide experiments, generic prototypes). |
+
+There are no subdirectory conventions: agents organize the contents of these directories as they see fit for the work at hand. There is no automatic cleanup; files persist indefinitely.
+
+## Recommendations for Intermediate Data
+
+When an exploration produces a Python object, DataFrame, or query result that may be reloaded later (in another step, another script, or another session) without recomputing from scratch, snapshot it to disk in the scratchpad. Recommended formats:
+
+- **`df.to_parquet()`** for pandas/polars DataFrames: compact, typed, fast to read back, language-portable. The default choice for tabular data.
+- **`pickle`** for arbitrary Python objects (models, dicts of arrays, custom classes) when parquet does not fit. Pickle is Python-only and version-sensitive: prefer parquet whenever the data is tabular.
+- **JSON** for small structured data (config-like dicts, small lists of records) where human-readability matters more than performance.
+
+These snapshots avoid re-running expensive queries or recomputing transforms across separate tool calls and let later work resume from a known state.
+
+## Recommendations for Notebooks
+
+Jupyter notebooks (`.ipynb`) are a natural fit for exploratory analysis with mixed code, prose, and inline plots. The recommended workflow:
+
+1. Author the source `.ipynb` in the scratchpad (project-scoped or project-free as appropriate).
+2. Run cells iteratively, or execute the whole notebook with `jupyter nbconvert --execute notebook.ipynb` (or similar) to populate outputs.
+3. When the notebook is ready to be shown to the user, render it to HTML with `jupyter nbconvert --to html notebook.ipynb`.
+4. Copy the HTML into the project's `artifacts/` directory.
+5. Register it as an artifact in the database (`createArtifact` via the `write_system2_db` tool).
+6. Display it with `show_artifact` for the user.
+
+The source `.ipynb` stays in the scratchpad as the editable working copy; the HTML in `artifacts/` is the published deliverable. This separation lets the agent keep iterating on the source without disturbing the published version, and lets the user see the rendered output without needing a Jupyter server.
+
+## Promotion to Artifacts
+
+Promotion is an explicit step, not an automatic one. When something in the scratchpad becomes a deliverable the user should see (a finished plot, a polished report, a rendered notebook, a usable export):
+
+1. Copy the file from the scratchpad to the appropriate `artifacts/` directory (project-scoped or project-free).
+2. Register the artifact in the database with `createArtifact`, providing `file_path`, `title`, optional `description`, and optional `tags`.
+3. Optionally call `show_artifact` to display it to the user immediately.
+
+The scratchpad copy stays as the working version. If the artifact needs further iteration, the agent edits the scratchpad source, re-renders or re-exports, and overwrites the artifact file. The database record tracks the title and metadata; the file at `file_path` is the live published version.
+
+If the same exploration also produced reusable pipeline code, graduate that code to the data pipelines repository as a separate step (see `infrastructure.md` for the repository location).
+
+## Lifecycle and Cleanup
+
+Scratchpad files persist indefinitely. There is no automatic cleanup, retention policy, or expiry. The intent is that working files remain available for as long as they might be useful: a parquet snapshot taken last week may still be the right starting point this week.
+
+Agents may delete their own scratchpad files when they are confident the files are no longer needed (e.g., a prototype that has been graduated to a pipeline, or a cache for a query that has since been re-run from a different source). When in doubt, leave the file in place.
+
+## See Also
+
+- [Artifacts](artifacts.md): the published-deliverable counterpart, with database registration and UI rendering
+- [Agents](agents.md): the agent-facing scratchpad instructions in the shared system prompt
+- [Knowledge System](knowledge-system.md): how the broader `~/.system2/` directory is structured and git-tracked

--- a/docs/scratchpad.md
+++ b/docs/scratchpad.md
@@ -31,7 +31,7 @@ Scratchpad files live under `~/.system2/`:
 | `~/.system2/projects/{id}_{name}/scratchpad/` | Working files tied to a specific project. Default for any work happening inside a project. |
 | `~/.system2/scratchpad/` | Working files not associated with any project (one-off explorations, system-wide experiments, generic prototypes). |
 
-There are no subdirectory conventions: agents organize the contents of these directories as they see fit for the work at hand. There is no automatic cleanup; files persist indefinitely.
+There are no subdirectory conventions: agents organize the contents of these directories as they see fit for the work at hand. There is no automatic cleanup; files persist indefinitely. Both directories are gitignored by the default `.gitignore` template installed in `~/.system2/` (see `packages/server/src/knowledge/git.ts`), so scratchpad files do not appear in `git -C ~/.system2 status` and never get committed to the knowledge repo.
 
 ## Recommendations for Intermediate Data
 
@@ -50,11 +50,11 @@ Jupyter notebooks (`.ipynb`) are a natural fit for exploratory analysis with mix
 1. Author the source `.ipynb` in the scratchpad (project-scoped or project-free as appropriate).
 2. Run cells iteratively, or execute the whole notebook with `jupyter nbconvert --execute notebook.ipynb` (or similar) to populate outputs.
 3. When the notebook is ready to be shown to the user, render it to HTML with `jupyter nbconvert --to html notebook.ipynb`.
-4. Copy the HTML into the project's `artifacts/` directory.
-5. Register it as an artifact in the database (`createArtifact` via the `write_system2_db` tool).
+4. Copy the HTML into the appropriate `artifacts/` directory (project-scoped or project-free).
+5. Register it as an artifact in the database (`createArtifact` via the `write_system2_db` tool), using an absolute `file_path`.
 6. Display it with `show_artifact` for the user.
 
-The source `.ipynb` stays in the scratchpad as the editable working copy; the HTML in `artifacts/` is the published deliverable. This separation lets the agent keep iterating on the source without disturbing the published version, and lets the user see the rendered output without needing a Jupyter server.
+The source `.ipynb` stays in the scratchpad as the editable working copy; the HTML in the appropriate `artifacts/` directory is the published deliverable. This separation lets the agent keep iterating on the source without disturbing the published version, and lets the user see the rendered output without needing a Jupyter server.
 
 ## Promotion to Artifacts
 

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -1,4 +1,4 @@
-# AGENTS
+# General System Prompt
 
 This document is the shared reference for all agents and is part of your context. It provides you with an understanding of the purpose and architecture of the environment you operate within. It also provides you with general important behavioral rules that you must adopt to succeed at your job. Your full context consists of a system prompt (this document, role-specific instructions, your identity, and a knowledge base loaded from disk), your tool schemas, a list of skills and your conversation history. See [Context Assembly](#context-assembly) for the full breakdown.
 
@@ -13,6 +13,7 @@ You are one of the AI agents of System2, which is a single-user, self-hosted mul
   - [Communication](#communication)
   - [Where Things Live](#where-things-live)
   - [Artifacts](#artifacts)
+  - [Scratchpad](#scratchpad)
   - [Background Processes](#background-processes)
 - [Knowledge and Memory](#knowledge-and-memory)
   - [Sessions](#sessions)
@@ -136,6 +137,7 @@ Your chat text output is visible only to the user, not to other agents. Always u
 │   └── daily_summaries/             Daily activity logs
 │       └── YYYY-MM-DD.md
 ├── artifacts/                       Project-free reports, dashboards, exports
+├── scratchpad/                      Project-free working files (exploration, debugging)
 ├── skills/                          Reusable workflow instructions
 │   └── {skill-name}/
 │       └── SKILL.md                 Frontmatter (name, description, roles) + steps
@@ -143,7 +145,8 @@ Your chat text output is visible only to the user, not to other agents. Always u
 │   └── {id}_{name}/
 │       ├── log.md                   Continuous project log (Narrator)
 │       ├── project_story.md         Final narrative (Narrator)
-│       └── artifacts/               Project-scoped artifacts
+│       ├── artifacts/               Project-scoped artifacts
+│       └── scratchpad/              Project-scoped working files (exploration, debugging)
 ├── sessions/                        Conversation history as JSONL
 │   └── {role}_{id}/
 └── logs/                            Server logs
@@ -201,9 +204,9 @@ All timestamps are UTC ISO 8601. See the [Schema Reference](#schema-reference) a
 
 ### Artifacts
 
-Artifacts are files produced as published results of analytical work: EDA notebooks, dashboards, plots, PDFs, markdown reports, and similar deliverables meant for the user to read and see. The distinction is intent: a Python script that performs data analysis and produces a report is an artifact (register it, store it in the project directory); a data pipeline script that transforms and loads data belongs in its code repository as part of the infrastructure. Pipeline code, utility scripts, and intermediate data files are not artifacts.
+Artifacts are files produced as published results of analytical work: EDA notebooks, dashboards, plots, PDFs, markdown reports, and similar deliverables meant for the user to read and see. The distinction is intent: a Python script that performs data analysis and produces a report is an artifact (register it, store it in the project directory); a data pipeline script that transforms and loads data belongs in its code repository as part of the infrastructure. Pipeline code, utility scripts, and intermediate data files are not artifacts; working files used during exploration and prototyping belong in the [Scratchpad](#scratchpad).
 
-The `show_artifact` tool displays a file in the artifact viewer with live reload. It can show any file on the filesystem, not only registered artifacts. Best results with HTML (sandboxed iframe), markdown (styled), and images/PDFs (native). Notebooks (`.ipynb`) must be converted to HTML so the UI can render them in its artifact viewer. Plain text renders unstyled.
+The `show_artifact` tool displays a file in the artifact viewer with live reload. It can show any file on the filesystem, not only registered artifacts. Best results with HTML (sandboxed iframe), markdown (styled), and images/PDFs (native). Notebooks (`.ipynb`) must be converted to HTML (e.g., `jupyter nbconvert --to html notebook.ipynb`) so the UI can render them in its artifact viewer; see [Scratchpad](#scratchpad) for the typical work-then-publish workflow. Plain text renders unstyled.
 
 **Where artifacts live:**
 
@@ -212,6 +215,29 @@ The `show_artifact` tool displays a file in the artifact viewer with live reload
 - **Elsewhere on the filesystem**: when a more natural location exists (e.g., an analysis directory the user has designated). Document such locations in `infrastructure.md` and `user.md` so other agents can find them.
 
 Regardless of where the file lives, **every artifact must have a database record** with its absolute file path, title, description, tags, and project ID (NULL if project-free). The UI artifact catalog is driven entirely by database records: an artifact without a record is invisible. Always create a record when producing an artifact and update it when the artifact changes.
+
+### Scratchpad
+
+The scratchpad is a working area for exploration, testing, and debugging: prototype scripts, intermediate data dumps, draft notebooks, experimental queries, and any other transient files produced while figuring something out. It is **not** where data pipelines live. Pipeline code (scripts that ingest, transform, load, or schedule data) belongs in the data pipeline code repository documented in `infrastructure.md`.
+
+Scratchpad files are working materials, not deliverables. They are **not** registered in the database and do not appear in the artifact catalog. `show_artifact` can technically display any file, so use it on a scratchpad file if the user explicitly asks to see one; otherwise, promote the file to an artifact first when it becomes something worth showing. They persist indefinitely (no automatic cleanup).
+
+**Where scratchpad files live:**
+
+- **Project-scoped**: `~/.system2/projects/{id}_{name}/scratchpad/` for working files tied to a specific project. This is the default for any work happening inside a project.
+- **Project-free**: `~/.system2/scratchpad/` for working files not associated with any project (one-off explorations, generic utilities being prototyped, system-wide experiments).
+
+**Working with intermediate data:** when an exploration produces a Python object, DataFrame, or query result that you may want to reload later (in another step, another script, or another session) without recomputing from scratch, snapshot it to disk in the scratchpad. Recommended formats:
+
+- **`df.to_parquet()`** for pandas/polars DataFrames: compact, typed, fast to read back, language-portable.
+- **`pickle`** for arbitrary Python objects (models, dicts of arrays, custom classes) when parquet does not fit. Pickle is Python-only and version-sensitive: prefer parquet whenever the data is tabular.
+- **JSON** for small structured data (config-like dicts, small lists of records) where human-readability matters more than performance.
+
+This avoids re-running expensive queries or recomputing transforms across separate tool calls and lets later work resume from a known state.
+
+**Working with notebooks:** Jupyter notebooks (`.ipynb`) are a natural fit for exploratory analysis with mixed code, prose, and inline plots. Author the source notebook in the scratchpad, run cells (or execute the whole notebook with `jupyter nbconvert --execute` or similar) to populate outputs, and keep iterating there. When the notebook is ready to be shown to the user, render it to HTML with `jupyter nbconvert --to html notebook.ipynb`, copy the HTML into the project's `artifacts/` directory, register it as an artifact in the database, and call `show_artifact` to display it. The source `.ipynb` stays in the scratchpad as the editable working copy; the HTML in `artifacts/` is the published deliverable.
+
+**Promotion to artifacts:** when something in the scratchpad becomes a deliverable the user should see (a finished plot, a polished report, a rendered notebook, a usable export), copy it to the appropriate `artifacts/` directory and register it in the database. Promotion is an explicit step, not an automatic one: the scratchpad stays as the working copy, the artifact is the published version. If the work also produces reusable pipeline code, graduate that code to the data pipelines repository as a separate step.
 
 ### Background Processes
 
@@ -222,7 +248,7 @@ An in-process scheduler (Croner) runs two recurring jobs. Both work the same way
    - `knowledge/daily_summaries/YYYY-MM-DD.md`: cross-project summary appended with the day's activity.
    - Skipped if no activity since last run.
 2. **`memory-update`** (daily at 11 AM): the server collects all daily summaries since the last memory update and delivers them inline to the Narrator, who consolidates them into:
-   - `knowledge/memory.md`: rewrites the file, incorporating new patterns and learnings from the summaries and consolidating the `## Latest Learnings` scratchpad.
+   - `knowledge/memory.md`: rewrites the file, incorporating new patterns and learnings from the summaries and consolidating the `## Latest Learnings` buffer.
    - Skipped if no new summaries to incorporate.
 
 On startup, the server checks for missed jobs and runs catch-up if needed. Jobs silently skip when the network is unreachable (prevents session bloat during laptop sleep).
@@ -270,7 +296,7 @@ Three knowledge files are injected into every agent's context:
 
 - **`infrastructure.md`**: the user's technical environment (databases, servers, pipeline orchestrators, repositories, deployed services). Curated by the Guide during onboarding and updated as infrastructure evolves.
 - **`user.md`**: the user profile (background, technical expertise, domain knowledge, goals, communication preferences, working patterns). Curated by the Guide.
-- **`memory.md`**: general-purpose long-term memory for important knowledge that all agents benefit from but does not belong in `infrastructure.md`, `user.md`, a role-specific file, or a skill. This is the last place to consider, not the first. The Narrator maintains the bulk of the file, consolidating observations from daily summaries during the scheduled memory-update job (daily at 11 AM). Non-Narrator agents must limit their edits to appending entries under the `## Latest Learnings` section, which acts as a scratchpad. The Narrator is the sole curator of the file as a whole: during memory-update jobs it incorporates scratchpad entries into the main body, clears `## Latest Learnings`, and restructures the file for clarity. Uses YAML frontmatter to track `last_narrator_update_ts`.
+- **`memory.md`**: general-purpose long-term memory for important knowledge that all agents benefit from but does not belong in `infrastructure.md`, `user.md`, a role-specific file, or a skill. This is the last place to consider, not the first. The Narrator maintains the bulk of the file, consolidating observations from daily summaries during the scheduled memory-update job (daily at 11 AM). Non-Narrator agents must limit their edits to appending entries under the `## Latest Learnings` section, which acts as a buffer. The Narrator is the sole curator of the file as a whole: during memory-update jobs it incorporates buffered entries into the main body, clears `## Latest Learnings`, and restructures the file for clarity. Uses YAML frontmatter to track `last_narrator_update_ts`.
 
 ### What Goes Where
 
@@ -357,7 +383,7 @@ The primary model for task asignement is **push**: the Conductor assigns tasks b
 
 ### Execution
 
-15. If you are not the Guide: execute, don't narrate. Do the work. Do not describe what you would do in your responses, unless the user asked you directly to do so or your a messaging another agent. The Guide's role is conversational (mediating between the user and other agents), not executive. No scratchpad tool calls: never run `bash echo` or similar no-ops to think out loud.
+15. If you are not the Guide: execute, don't narrate. Do the work. Do not describe what you would do in your responses, unless the user asked you directly to do so or your a messaging another agent. The Guide's role is conversational (mediating between the user and other agents), not executive. No no-op tool calls: never run `bash echo` or similar no-ops to think out loud.
 16. When working on a code repository, look for and read `AGENTS.md`, `CLAUDE.md`, and `README.md` at the repository root (if present) before making changes. These files contain project-specific conventions, build commands, and contribution guidelines that must be closely considered. Also check `~/.claude/claude.md` for the user's general coding instructions and apply them alongside project-specific ones.
 17. Your tools are available to you with full descriptions. Do not ask what tools you have; use them.
 18. When rewriting or restructuring a file, read it in full first. Restructure for clarity; do not just append, unless explicitly instructed otherwise.

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -220,7 +220,7 @@ Regardless of where the file lives, **every artifact must have a database record
 
 The scratchpad is a working area for exploration, testing, and debugging: prototype scripts, intermediate data dumps, draft notebooks, experimental queries, and any other transient files produced while figuring something out. It is **not** where data pipelines live. Pipeline code (scripts that ingest, transform, load, or schedule data) belongs in the data pipeline code repository documented in `infrastructure.md`.
 
-Scratchpad files are working materials, not deliverables. They are **not** registered in the database and do not appear in the artifact catalog. `show_artifact` can technically display any file, so use it on a scratchpad file if the user explicitly asks to see one; otherwise, promote the file to an artifact first when it becomes something worth showing. They persist indefinitely (no automatic cleanup).
+Scratchpad files are working materials, not deliverables. They are **not** registered in the database and do not appear in the artifact catalog. `show_artifact` can technically display any file, so use it on a scratchpad file if the user explicitly asks to see one; otherwise, promote the file to an artifact first when it becomes something worth showing. They persist indefinitely (no automatic cleanup) and are gitignored, so they do not appear in the rule 24 cleanliness check.
 
 **Where scratchpad files live:**
 
@@ -235,7 +235,7 @@ Scratchpad files are working materials, not deliverables. They are **not** regis
 
 This avoids re-running expensive queries or recomputing transforms across separate tool calls and lets later work resume from a known state.
 
-**Working with notebooks:** Jupyter notebooks (`.ipynb`) are a natural fit for exploratory analysis with mixed code, prose, and inline plots. Author the source notebook in the scratchpad, run cells (or execute the whole notebook with `jupyter nbconvert --execute` or similar) to populate outputs, and keep iterating there. When the notebook is ready to be shown to the user, render it to HTML with `jupyter nbconvert --to html notebook.ipynb`, copy the HTML into the project's `artifacts/` directory, register it as an artifact in the database, and call `show_artifact` to display it. The source `.ipynb` stays in the scratchpad as the editable working copy; the HTML in `artifacts/` is the published deliverable.
+**Working with notebooks:** Jupyter notebooks (`.ipynb`) are a natural fit for exploratory analysis with mixed code, prose, and inline plots. Author the source notebook in the scratchpad, run cells (or execute the whole notebook with `jupyter nbconvert --execute` or similar) to populate outputs, and keep iterating there. When the notebook is ready to be shown to the user, render it to HTML with `jupyter nbconvert --to html notebook.ipynb`, copy the HTML into the appropriate `artifacts/` directory (project-scoped or project-free), register it as an artifact in the database, and call `show_artifact` to display it. The source `.ipynb` stays in the scratchpad as the editable working copy; the HTML in the appropriate `artifacts/` directory is the published deliverable.
 
 **Promotion to artifacts:** when something in the scratchpad becomes a deliverable the user should see (a finished plot, a polished report, a rendered notebook, a usable export), copy it to the appropriate `artifacts/` directory and register it in the database. Promotion is an explicit step, not an automatic one: the scratchpad stays as the working copy, the artifact is the published version. If the work also produces reusable pipeline code, graduate that code to the data pipelines repository as a separate step.
 
@@ -383,7 +383,7 @@ The primary model for task asignement is **push**: the Conductor assigns tasks b
 
 ### Execution
 
-15. If you are not the Guide: execute, don't narrate. Do the work. Do not describe what you would do in your responses, unless the user asked you directly to do so or your a messaging another agent. The Guide's role is conversational (mediating between the user and other agents), not executive. No no-op tool calls: never run `bash echo` or similar no-ops to think out loud.
+15. If you are not the Guide: execute, don't narrate. Do the work. Do not describe what you would do in your responses unless the user asked you directly to do so or you're messaging another agent. The Guide's role is conversational (mediating between the user and other agents), not executive. No no-op tool calls: never run `bash echo` or similar no-ops to think out loud.
 16. When working on a code repository, look for and read `AGENTS.md`, `CLAUDE.md`, and `README.md` at the repository root (if present) before making changes. These files contain project-specific conventions, build commands, and contribution guidelines that must be closely considered. Also check `~/.claude/claude.md` for the user's general coding instructions and apply them alongside project-specific ones.
 17. Your tools are available to you with full descriptions. Do not ask what tools you have; use them.
 18. When rewriting or restructuring a file, read it in full first. Restructure for clarity; do not just append, unless explicitly instructed otherwise.

--- a/packages/server/src/agents/library/conductor.md
+++ b/packages/server/src/agents/library/conductor.md
@@ -51,7 +51,7 @@ You are spawned by the Guide to execute a specific project. Your job is to:
 On receiving your initial message from Guide:
 
 - Read your project record from app.db (`read_system2_db`)
-- Create your project workspace directory at `~/.system2/projects/{id}_{name}/` (lowercase, slugified name, e.g. `1_linkedin-campaign`) and an `artifacts/` subdirectory inside it
+- Create your project workspace directory at `~/.system2/projects/{id}_{name}/` (lowercase, slugified name, e.g. `1_linkedin-campaign`) with `artifacts/` and `scratchpad/` subdirectories inside it
 - **Consult infrastructure.md** in your Knowledge Base to understand the available data stack (databases, orchestrator, pipeline repo, installed tools, deployment workflow). This file is already in your system prompt; you do not need to read it with a tool.
 - Inspect the data pipeline code repository (path in infrastructure.md; defaults to `~/repos/data_pipelines`) to understand existing DAG patterns, file structure, naming conventions, and code style
 - Research the problem domain independently: explore data sources, check APIs and documentation, assess file formats and data volumes, examine schemas

--- a/packages/server/src/knowledge/git.ts
+++ b/packages/server/src/knowledge/git.ts
@@ -24,6 +24,9 @@ logs/
 
 # Session files (JSONL + per-agent chat caches)
 sessions/
+
+# Scratchpad (transient working files: parquet, pickle, draft notebooks, prototype scripts)
+scratchpad/
 `;
 
 /**


### PR DESCRIPTION
## Summary

Introduces the **scratchpad** concept as a documentation/instruction-only feature: a working area where agents put exploration, prototyping, and debugging files, complementary to the existing `artifacts/` directory which is reserved for published deliverables.

This is a deliberate departure from the original proposal in #90, which envisioned a `jupyter_client`-backed persistent kernel with `exec`/`view`/`install`/`reset` operations and AST-based graduation to the pipelines repo. After collaborative discussion, the chosen scope is prompt-only: the agents already have the tools they need (`bash`, `read`, `write`, `edit`), so the gap was conceptual rather than technical. What was missing was a clear convention telling agents *where* to put intermediate work and *how* it relates to artifacts and pipeline code.

### What ships

- **Two locations**: `~/.system2/scratchpad/` (project-free) and `~/.system2/projects/{id}_{name}/scratchpad/` (project-scoped). Files are not database-tracked, do not appear in the artifact catalog, and persist indefinitely.
- **Boundary against pipeline code**: scratchpad is for exploration; production pipeline code still goes in the data pipelines repository documented in `infrastructure.md`.
- **Recommendations** (not hard rules) for intermediate data formats (parquet for DataFrames, pickle for arbitrary objects, JSON for small structured data) and for the Jupyter notebook workflow (source `.ipynb` in scratchpad, render to HTML via `jupyter nbconvert --to html`, copy HTML to `artifacts/`, register and `show_artifact`).
- **Promotion path**: explicit copy from scratchpad to `artifacts/` when something becomes a deliverable; agents register the artifact in the database.

### Files touched

- `packages/server/src/agents/agents.md`: new `Scratchpad` subsection (sibling of `Artifacts`); `Where Things Live` filesystem tree updated; rule 15 reworded to "no no-op tool calls" to free the term `scratchpad` from its previous metaphorical use; metaphorical "scratchpad" usages in the `memory.md` description renamed to "buffer"; TOC updated.
- `docs/scratchpad.md` (new): canonical scratchpad documentation, mirrors the structure of `docs/artifacts.md`.
- `docs/artifacts.md`: cross-references to `scratchpad.md` in intro, the "Not artifacts" list, and See Also.
- `docs/architecture.md`, `docs/knowledge-system.md`: filesystem trees updated with `scratchpad/` entries.
- `docs/README.md`, `CLAUDE.md`: `scratchpad.md` indexed in docs tables.
- `packages/server/src/agents/library/conductor.md`: project workspace creation now includes a `scratchpad/` subdirectory alongside `artifacts/`.

## Dependency

This PR is based on `agents-md-refine` (PR #89) because the new `Scratchpad` subsection in `agents.md` slots into the rewritten document structure that #89 introduces. Once #89 merges, this PR's base should be retargeted to `main`.

## Test plan

- [x] `pnpm check` (biome) clean
- [x] `pnpm build` succeeds across all packages
- [x] `pnpm test` 504 tests passing (no test changes; documentation-only PR)
- [ ] Manual review of the new `Scratchpad` subsection in context with the surrounding `Artifacts` and `Background Processes` sections
- [ ] Manual review of `docs/scratchpad.md` for accuracy and tone consistency with `docs/artifacts.md`

Closes #90