### PR TITLE
feat: WebSocket push notifications, rawSql, bash guardrails

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@ System2 is a TypeScript monorepo built on [pi-coding-agent](https://github.com/b
 
 **Persistent, evolving context.** Every agent's context is assembled from three layers on each LLM call: static instructions (shared agent reference and role-specific prompt, loaded once at startup or spawn); a Knowledge Base of files re-read fresh from disk (knowledge files, plus daily summaries or a project log depending on scope), so any edit takes effect immediately; and the full conversation history replayed from a JSONL session file, with a compaction summary substituted when the context was compressed. Knowledge files are versioned in git; session JSONL files are gitignored (large, private). Session logs rotate at a configurable size threshold to prevent unbounded growth. See [Agents](agents.md#session-management) | [Knowledge System](knowledge-system.md).
 
-**Reliable infrastructure.** Chat history, database state, and agent sessions are managed server-side; the UI is stateless and receives full history on WebSocket connect. API errors trigger automatic retry with exponential backoff, then failover to the next configured key or provider. Scheduled jobs run in-process and are checked for staleness on startup so missed work is caught up automatically. See [Configuration](configuration.md#automatic-failover) | [Scheduler](scheduler.md).
+**Reliable infrastructure.** Chat history, database state, and agent sessions are managed server-side; the UI is stateless and receives full history on WebSocket connect. Database writes by agents trigger push notifications over WebSocket, so UI panels update in real time without polling. API errors trigger automatic retry with exponential backoff, then failover to the next configured key or provider. Scheduled jobs run in-process and are checked for staleness on startup so missed work is caught up automatically. See [Configuration](configuration.md#automatic-failover) | [Scheduler](scheduler.md) | [WebSocket Protocol](websocket-protocol.md).
 
 ## Runtime Architecture
 
@@ -48,6 +48,7 @@ System2 is a TypeScript monorepo built on [pi-coding-agent](https://github.com/b
 ┌──────────────────────────▼──────────────────────────────┐
 │  UI (React on port 3001 dev, served by server in prod)  │
 │  - Chat interface with streaming                        │
+│  - Push-driven panels (kanban, agents, artifacts, jobs) │
 │  - Artifact display (sandboxed iframe)                  │
 └─────────────────────────────────────────────────────────┘
 ```

--- a/docs/database.md
+++ b/docs/database.md
@@ -162,7 +162,7 @@ Agents query the database via the `read_system2_db` tool (SELECT only). Interact
 
 Agents write to the database via the `write_system2_db` tool, which exposes structured named operations (`createProject`, `updateProject`, `createTask`, `updateTask`, `createTaskLink`, `deleteTaskLink`, `createTaskComment`, `deleteTaskComment`, `createArtifact`, `updateArtifact`, `deleteArtifact`, `rawSql`). These delegate to `DatabaseClient` methods, ensuring `updated_at` is always maintained and `task_comment.author` is auto-filled from the calling agent's ID. The `rawSql` operation accepts DML and SELECT statements for cases not covered by named operations; DDL, PRAGMA, and maintenance statements are blocked. See [Tools](tools.md#write_system2_db).
 
-Each write triggers an `onWrite` callback that the server maps to a WebSocket push notification (`board_changed`, `agents_changed`, `artifacts_changed`, etc.), so UI panels update in real time. Direct `sqlite3` access to `app.db` via `bash` is blocked to ensure all writes flow through this notification path.
+Each write triggers an `onWrite` callback that the server maps to a WebSocket push notification (`board_changed`, `agents_changed`, `artifacts_changed`, etc.), so UI panels update in real time. Direct `sqlite3` access to `app.db` via `bash` is blocked to ensure all writes flow through this notification path. These restrictions apply exclusively to `app.db`; agents operate on data pipeline databases (TimescaleDB, DuckDB, etc.) directly via `bash` with no restrictions.
 
 ## See Also
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -160,9 +160,9 @@ Agents query the database via the `read_system2_db` tool (SELECT only). Interact
 
 ### Write access
 
-Agents write to the database via the `write_system2_db` tool, which exposes structured named operations (`createProject`, `updateProject`, `createTask`, `updateTask`, `createTaskLink`, `deleteTaskLink`, `createTaskComment`, `deleteTaskComment`, `createArtifact`, `updateArtifact`, `deleteArtifact`). These delegate to `DatabaseClient` methods, ensuring `updated_at` is always maintained and `task_comment.author` is auto-filled from the calling agent's ID. See [Tools](tools.md#write_system2_db).
+Agents write to the database via the `write_system2_db` tool, which exposes structured named operations (`createProject`, `updateProject`, `createTask`, `updateTask`, `createTaskLink`, `deleteTaskLink`, `createTaskComment`, `deleteTaskComment`, `createArtifact`, `updateArtifact`, `deleteArtifact`, `rawSql`). These delegate to `DatabaseClient` methods, ensuring `updated_at` is always maintained and `task_comment.author` is auto-filled from the calling agent's ID. The `rawSql` operation accepts DML and SELECT statements for cases not covered by named operations; DDL, PRAGMA, and maintenance statements are blocked. See [Tools](tools.md#write_system2_db).
 
-For ad-hoc SQL not covered by the tool (bulk updates, complex transactions), agents can use `bash` with `sqlite3 ~/.system2/app.db`.
+Each write triggers an `onWrite` callback that the server maps to a WebSocket push notification (`board_changed`, `agents_changed`, `artifacts_changed`, etc.), so UI panels update in real time. Direct `sqlite3` access to `app.db` via `bash` is blocked to ensure all writes flow through this notification path.
 
 ## See Also
 

--- a/docs/packages/server.md
+++ b/docs/packages/server.md
@@ -53,10 +53,11 @@ The `Server` class is the main entry point. It accepts a `ServerConfig` and orch
 4. Create Guide agent (singleton via `db.getOrCreateGuideAgent()`)
 5. Create Narrator agent (singleton via `db.getOrCreateNarratorAgent()`)
 6. Subscribe to each agent's events for assistant message history capture into per-agent chat caches (prevents duplicates with multiple tabs)
-7. Resolve Narrator model and create `ConversationSummarizer` (summarizes user-agent interactions for Guide notification)
-8. Create `Scheduler`
-9. Set up Express routes
-10. Create HTTP server and WebSocket server
+7. Wire push notification callbacks (`onDatabaseWrite`, `onBusyChange`, `onAgentTerminate`) into agent hosts
+8. Resolve Narrator model and create `ConversationSummarizer` (summarizes user-agent interactions for Guide notification)
+9. Create `Scheduler`
+10. Set up Express routes
+11. Create HTTP server and WebSocket server
 
 ### `start()` Method
 
@@ -81,9 +82,22 @@ The `Server` class is the main entry point. It accepts a `ServerConfig` and orch
 | `/api/query` | POST | SQL query endpoint for artifact dashboards (SELECT only) |
 | `/*` | GET | UI static files (if `uiDistPath` configured) |
 
+### Push Broadcasts
+
+The server broadcasts lightweight WebSocket notifications when state changes, so UI panels update in real time without polling. Five push message types exist: `board_changed` (projects, tasks, links, comments), `agents_changed` (spawn/terminate/resurrect), `artifacts_changed`, `job_executions_changed`, and `agent_busy_changed` (inline busy/context data).
+
+Push notifications flow through callbacks threaded into subsystems:
+
+- **`onDatabaseWrite(entity)`**: fired by `write_system2_db` after each mutation, mapped to the appropriate push type by entity name
+- **`onBusyChange(agentId, busy, contextPercent)`**: fired by `AgentHost` when message processing starts/ends
+- **`onAgentTerminate()`**: fired by `terminate_agent` after archiving, broadcasts `agents_changed`
+- **`onJobChange()`**: fired by `trackJobExecution` on job lifecycle transitions
+
+All broadcasts are debounced per message type (50ms) to coalesce rapid successive writes. Callback failures are caught with best-effort try/catch so they never break the caller.
+
 ### Graceful Shutdown
 
-`stop()` tears down in order: summarizer -> scheduler -> WebSocket clients -> WebSocket server -> HTTP server -> database.
+`stop()` cancels pending debounced broadcasts, then tears down in order: scheduler -> WebSocket clients -> WebSocket server -> HTTP server -> database.
 
 1. Stop all scheduled cron jobs
 2. Send `close(1001, "server shutting down")` to every connected WebSocket client (clean close handshake)

--- a/docs/packages/shared.md
+++ b/docs/packages/shared.md
@@ -52,8 +52,8 @@ Types for the WebSocket protocol between UI and server. See [WebSocket Protocol]
 
 | Type | Description |
 |------|-------------|
-| `ClientMessage` | Union: `user_message`, `steering_message`, `abort` |
-| `ServerMessage` | Union: streaming chunks, tool calls, artifacts, context usage, errors, ready signal, chat history |
+| `ClientMessage` | Union: `user_message`, `steering_message`, `abort`, `switch_agent` |
+| `ServerMessage` | Union: streaming chunks, tool calls, artifacts, context usage, errors, ready signal, chat history, push notifications (`board_changed`, `agents_changed`, `artifacts_changed`, `job_executions_changed`, `agent_busy_changed`) |
 
 ## See Also
 

--- a/docs/packages/ui.md
+++ b/docs/packages/ui.md
@@ -33,6 +33,7 @@ src/
 ├── stores/
 │   ├── chat.ts            # Chat state (Zustand)
 │   ├── artifact.ts        # Artifact tab state (Zustand)
+│   ├── push.ts            # Push notification state (Zustand)
 │   └── theme.ts           # Theme preference (Zustand)
 └── theme/
     └── colors.ts          # Color palette constants
@@ -102,13 +103,13 @@ Configuration: 120 particles in accent + teal colors, linked within 150px distan
 
 ### ArtifactCatalog
 
-Side panel showing all registered artifacts from the database. Polls `GET /api/artifacts` every 2 seconds. Groups artifacts by project (null project shown as "No Project"). Supports text search and project/tag filtering via `MultiSelectDropdown` components (same as KanbanBoard filters). Both project and tags dropdowns include a "None" option for artifacts without a project or tags respectively; inline tag badges use a static accent style (not affected by dropdown selection). Clicking an item opens it as a new tab in ArtifactViewer. Toggled via StackIcon in the activity bar.
+Side panel showing all registered artifacts from the database. Refetches `GET /api/artifacts` when `artifactsVersion` bumps (push-driven). Groups artifacts by project (null project shown as "No Project"). Supports text search and project/tag filtering via `MultiSelectDropdown` components (same as KanbanBoard filters). Both project and tags dropdowns include a "None" option for artifacts without a project or tags respectively; inline tag badges use a static accent style (not affected by dropdown selection). Clicking an item opens it as a new tab in ArtifactViewer. Toggled via StackIcon in the activity bar.
 
 ### KanbanBoard
 
 Live kanban dashboard showing all tasks grouped by project in a swimlane layout. Toggled via the TasklistIcon button in the activity bar: clicking opens a native tab named "Board" at position 0; clicking again closes it.
 
-Polls `GET /api/kanban` every 2 seconds. On initial load shows a full loading state; subsequent polls update silently without clearing the board.
+Refetches `GET /api/kanban` when `boardVersion` bumps (push-driven). On initial load shows a full loading state; subsequent fetches update silently without clearing the board.
 
 **Layout:** A shared horizontal scroll container keeps column headers and card grids aligned (minimum 180px per column). Five status columns (Todo, In Progress, Review, Done, Abandoned) with transparent headers (fixed above the vertical scroll area) showing status dot, task count badge, and vertical dividers between columns. Each project is a collapsible swimlane row with transparent header showing project name, info icon button, status badge, completed/total count (done + abandoned = completed), and a segmented progress bar. Done/abandoned projects auto-collapse on first load.
 
@@ -120,7 +121,7 @@ Clicking a card opens a `TaskDetailModal` overlay for that task. Clicking the in
 
 ### TaskDetailModal
 
-Overlay modal showing full task details. Polls `GET /api/tasks/:id` every 2 seconds while open, restarting the poll cycle on navigation to a different task. Uses `AbortController` to cancel in-flight requests when the task ID changes (e.g., clicking a linked task).
+Overlay modal showing full task details. Refetches `GET /api/tasks/:id` when `boardVersion` bumps (push-driven), restarting on navigation to a different task. Uses `AbortController` to cancel in-flight requests when the task ID changes (e.g., clicking a linked task).
 
 **Sections:**
 
@@ -144,13 +145,13 @@ Overlay modal showing full project details. Receives the project data directly f
 
 ### AgentPane
 
-Side panel showing all non-archived agents with busy/idle indicators. Polls `GET /api/agents` every 2 seconds for agent list, busy state, and context window percentages. Groups agents into "System" (Guide, Narrator) listed first, then by project name. Each agent row shows a teal (`#00aaba`) circle when busy or grey when idle. Toggled via PeopleIcon in the activity bar.
+Side panel showing all non-archived agents with busy/idle indicators. Refetches `GET /api/agents` when `agentsVersion` bumps (push-driven); busy state and context window percentages come from `agent_busy_changed` push messages (inline, no refetch). Groups agents into "System" (Guide, Narrator) listed first, then by project name. Each agent row shows a teal (`#00aaba`) circle when busy or grey when idle. Toggled via PeopleIcon in the activity bar.
 
 Clicking an agent row switches the chat panel to that agent. The active agent is highlighted with an accent-colored left border on its ID cell. Switching updates `activeAgentId` in the chat store, which triggers the WebSocket hook to send `switch_agent` to the server. The server responds with the agent's chat history and streaming state.
 
 ### CronJobsPane
 
-Side panel titled "Cron Jobs" showing scheduler job execution history as a flat sortable table. Polls `GET /api/job-executions` every 2 seconds. Toggled via ClockIcon in the activity bar.
+Side panel titled "Cron Jobs" showing scheduler job execution history as a flat sortable table. Refetches `GET /api/job-executions` when `jobsVersion` bumps (push-driven). Toggled via ClockIcon in the activity bar.
 
 **Filters:** Three `MultiSelectDropdown` filters at the top: jobs (e.g., daily-summary, memory-update), statuses (running, completed, failed), and triggers (cron, catch-up, manual).
 
@@ -158,7 +159,7 @@ Side panel titled "Cron Jobs" showing scheduler job execution history as a flat 
 
 ## State Management
 
-Three [Zustand](https://github.com/pmndrs/zustand) stores with no Redux or Context:
+Four [Zustand](https://github.com/pmndrs/zustand) stores with no Redux or Context:
 
 ### `useChatStore` (Primary)
 
@@ -212,6 +213,23 @@ Key behaviors:
 - `toggleKanbanTab`: close kanban tab if open, otherwise call `openKanbanTab` (used by activity bar button)
 - Tab dedup uses `filePath` with cache-bust query params stripped
 
+### `usePushStore`
+
+Tracks server push notification state. Version counters are incremented when the server broadcasts a change notification; components that depend on a counter refetch from the REST API when it bumps.
+
+| State | Type | Description |
+|-------|------|-------------|
+| `boardVersion` | `number` | Bumped on `board_changed` (projects, tasks, links, comments) |
+| `agentsVersion` | `number` | Bumped on `agents_changed` (spawn/terminate/resurrect) |
+| `artifactsVersion` | `number` | Bumped on `artifacts_changed` |
+| `jobsVersion` | `number` | Bumped on `job_executions_changed` |
+| `agentBusy` | `Map<number, { busy, contextPercent }>` | Per-agent busy state from `agent_busy_changed`, consumed inline (no refetch) |
+
+Key actions:
+
+- `bumpAll()`: increments all 4 version counters at once (used on WebSocket reconnect to force a full refetch)
+- `clearAgentBusy()`: resets the busy map (used on reconnect to clear stale state that may have drifted during the disconnect)
+
 ### `useThemeStore`
 
 Tracks `colorMode` (light/dark) and `particlesEnabled` (boolean) with localStorage persistence (`system2-theme` and `system2-particles` respectively). Color mode falls back to system preference; particles default to enabled.
@@ -225,7 +243,7 @@ Manages the WebSocket connection to the server with multi-agent routing:
 - Routes all incoming `ServerMessage` types to the correct agent's state via `message.agentId` (falls back to `guideAgentId`)
 - Exposes `sendMessage()`, `sendSteering()`, `abort()` (all include `activeAgentId`)
 - Watches `activeAgentId` changes and sends `switch_agent` to the server when the user switches agents
-- On reconnect: re-sends `switch_agent` if the user was viewing a non-Guide agent
+- On reconnect: clears stale `agentBusy` state, bumps all push version counters (forces full refetch), and re-sends `switch_agent` if the user was viewing a non-Guide agent
 - On `ready_for_input`: clears `isStreaming` and `isWaitingForResponse` for that agent
 - On `chat_history`: merges committed messages but preserves in-progress streaming state (tool calls, thinking, partial text) for busy agents
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -33,7 +33,7 @@ Execute shell commands with streaming output and optional background execution. 
 - **AbortSignal:** child process is killed (`SIGTERM`) when the agent session is aborted
 - **Background:** when `run_in_background` is true, the tool returns immediately and delivers the result as a `followUp` custom message when the command finishes
 - **Implementation:** Node.js `child_process.spawn`
-- **Command blocklist:** certain catastrophic commands are hard-blocked before execution and return an error: recursive `rm` targeting `/`, `~`, or `$HOME`; the `--no-preserve-root` flag; `mkfs` (filesystem formatting); `dd` writing to raw block devices (`of=/dev/...`). Patterns are defined in `BLOCKED_BASH_PATTERNS` and checked against the full command string.
+- **Command blocklist:** certain catastrophic commands are hard-blocked before execution and return an error: recursive `rm` targeting `/`, `~`, or `$HOME`; the `--no-preserve-root` flag; `mkfs` (filesystem formatting); `dd` writing to raw block devices (`of=/dev/...`); `sqlite3` targeting `~/.system2/app.db` (writes must go through `write_system2_db` for push notifications). Patterns are defined in `BLOCKED_BASH_PATTERNS` and checked against the full command string. Note: the `sqlite3` blocklist only applies to System2's management database (`app.db`). Agents are free to use `bash` with any database tool (`sqlite3`, `psql`, `duckdb`, etc.) to operate on data pipeline databases directly.
 
 ### `read`
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -33,6 +33,7 @@ Execute shell commands with streaming output and optional background execution. 
 - **AbortSignal:** child process is killed (`SIGTERM`) when the agent session is aborted
 - **Background:** when `run_in_background` is true, the tool returns immediately and delivers the result as a `followUp` custom message when the command finishes
 - **Implementation:** Node.js `child_process.spawn`
+- **Command blocklist:** certain catastrophic commands are hard-blocked before execution and return an error: recursive `rm` targeting `/`, `~`, or `$HOME`; the `--no-preserve-root` flag; `mkfs` (filesystem formatting); `dd` writing to raw block devices (`of=/dev/...`). Patterns are defined in `BLOCKED_BASH_PATTERNS` and checked against the full command string.
 
 ### `read`
 
@@ -103,7 +104,7 @@ Create or update records in the System2 app database.
 | `operation` | string | Named operation (see table below) |
 | _(varies)_ | _(varies)_ | Additional params depend on operation |
 
-Executes against `~/.system2/app.db` using structured named operations that delegate to `DatabaseClient` methods. `updated_at` is always maintained automatically. The `author` field on task comments is auto-filled from the calling agent's ID. **Only for System2's management database**: for data pipeline databases use `bash`. For ad-hoc SQL not covered by these operations, use `bash` with `sqlite3 ~/.system2/app.db`.
+Executes against `~/.system2/app.db` using structured named operations that delegate to `DatabaseClient` methods. `updated_at` is always maintained automatically. The `author` field on task comments is auto-filled from the calling agent's ID. **Only for System2's management database**: for data pipeline databases use `bash`. For ad-hoc SQL not covered by the named operations, use `rawSql` (see below). **Never use `bash` with `sqlite3` to modify `app.db`**: writes made outside `write_system2_db` bypass WebSocket push notifications and the UI will not reflect the changes.
 
 | Operation | Required | Optional | Notes |
 |-----------|----------|----------|-------|
@@ -119,6 +120,7 @@ Executes against `~/.system2/app.db` using structured named operations that dele
 | `createArtifact` | `file_path`, `title` | `project`, `description`, `tags` | Any agent. Project scope checked if `project` is set. |
 | `updateArtifact` | `id` | `file_path`, `title`, `project`, `description`, `tags` | Any agent. Project scope checked. |
 | `deleteArtifact` | `id` | — | Any agent. Project scope checked. DB row only (does not delete the file). |
+| `rawSql` | `sql` | — | Execute arbitrary DML (INSERT/UPDATE/DELETE) or SELECT. DDL (CREATE/ALTER/DROP), PRAGMA, and ATTACH/DETACH are blocked. |
 
 Valid `status` values: `"todo"`, `"in progress"`, `"review"`, `"done"`, `"abandoned"`
 Valid `priority` values: `"low"`, `"medium"`, `"high"`

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -120,7 +120,7 @@ Executes against `~/.system2/app.db` using structured named operations that dele
 | `createArtifact` | `file_path`, `title` | `project`, `description`, `tags` | Any agent. Project scope checked if `project` is set. |
 | `updateArtifact` | `id` | `file_path`, `title`, `project`, `description`, `tags` | Any agent. Project scope checked. |
 | `deleteArtifact` | `id` | — | Any agent. Project scope checked. DB row only (does not delete the file). |
-| `rawSql` | `sql` | — | Execute arbitrary DML (INSERT/UPDATE/DELETE) or SELECT. DDL (CREATE/ALTER/DROP), PRAGMA, and ATTACH/DETACH are blocked. |
+| `rawSql` | `sql` | — | Execute DML (INSERT/UPDATE/DELETE/REPLACE) or SELECT (including WITH/CTE). DDL (CREATE/ALTER/DROP), PRAGMA, ATTACH/DETACH, and maintenance statements (VACUUM, REINDEX, ANALYZE) are blocked. |
 
 Valid `status` values: `"todo"`, `"in progress"`, `"review"`, `"done"`, `"abandoned"`
 Valid `priority` values: `"low"`, `"medium"`, `"high"`

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -55,7 +55,13 @@ type ServerMessage =
   | { type: 'chat_history'; messages: ChatMessage[]; agentId: number }
   | { type: 'user_message_broadcast'; id: string; content: string; timestamp: number; agentId?: number }
   | { type: 'compaction_start'; agentId?: number }
-  | { type: 'compaction_end'; agentId?: number };
+  | { type: 'compaction_end'; agentId?: number }
+  // Push notifications for UI panels
+  | { type: 'board_changed' }
+  | { type: 'agents_changed' }
+  | { type: 'artifacts_changed' }
+  | { type: 'job_executions_changed' }
+  | { type: 'agent_busy_changed'; agentId: number; busy: boolean; contextPercent: number | null };
 ```
 
 | Message | Description |
@@ -72,8 +78,13 @@ type ServerMessage =
 | `chat_history` | Sent on connect (Guide) and on `switch_agent`: recent messages for the specified agent |
 | `user_message_broadcast` | User message from another tab, broadcast to all other connected clients |
 | `compaction_start` / `compaction_end` | Auto-compaction lifecycle (context window management). UI shows transient "Compacting..." / "Compacted" indicator |
+| `board_changed` | Broadcast when `write_system2_db` modifies a project, task, task_link, or task_comment. UI panels refetch `/api/kanban`. |
+| `agents_changed` | Broadcast when an agent is spawned, terminated, or resurrected. UI panels refetch `/api/agents`. |
+| `artifacts_changed` | Broadcast when `write_system2_db` modifies an artifact. UI panels refetch `/api/artifacts`. |
+| `job_executions_changed` | Broadcast when a scheduler job execution is created, completed, failed, or skipped. UI panels refetch `/api/job-executions`. |
+| `agent_busy_changed` | Broadcast when an agent's busy state changes (message processing start/end). Includes `agentId`, `busy`, and `contextPercent`. |
 
-Note: the Board, Catalog, and Agent Pane poll their REST endpoints every 2 seconds rather than relying on push notifications. This ensures the UI reflects database changes regardless of how they were made (tool callbacks, direct sqlite3 access, etc.).
+All database writes by agents go through `write_system2_db`, which fires an `onWrite` callback that the server maps to the appropriate push notification. Agents are instructed to never use `bash`/`sqlite3` to modify `app.db`, ensuring all changes are captured. REST endpoints are still used for the initial data load on page open or WebSocket reconnect.
 
 ## Message Flow
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -84,7 +84,7 @@ type ServerMessage =
 | `job_executions_changed` | Broadcast when a scheduler job execution is created, completed, failed, or skipped. UI panels refetch `/api/job-executions`. |
 | `agent_busy_changed` | Broadcast when an agent's busy state changes (message processing start/end). Includes `agentId`, `busy`, and `contextPercent`. |
 
-All database writes by agents go through `write_system2_db`, which fires an `onWrite` callback that the server maps to the appropriate push notification. Agents are instructed to never use `bash`/`sqlite3` to modify `app.db`, ensuring all changes are captured. REST endpoints are used for the initial data load on page open. On WebSocket reconnect, the UI bumps all push version counters so every panel refetches, recovering any changes missed during the disconnect.
+All database writes by agents go through `write_system2_db`, which fires an `onWrite` callback that the server maps to the appropriate push notification. Agents are instructed to never use `bash`/`sqlite3` to modify `app.db`, ensuring all changes are captured. REST endpoints are used for the initial data load on page open. On WebSocket reconnect, the UI clears stale `agentBusy` state (which may have drifted during the disconnect) and bumps all push version counters so every panel refetches from the server.
 
 ## Message Flow
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -84,7 +84,7 @@ type ServerMessage =
 | `job_executions_changed` | Broadcast when a scheduler job execution is created, completed, failed, or skipped. UI panels refetch `/api/job-executions`. |
 | `agent_busy_changed` | Broadcast when an agent's busy state changes (message processing start/end). Includes `agentId`, `busy`, and `contextPercent`. |
 
-All database writes by agents go through `write_system2_db`, which fires an `onWrite` callback that the server maps to the appropriate push notification. Agents are instructed to never use `bash`/`sqlite3` to modify `app.db`, ensuring all changes are captured. REST endpoints are still used for the initial data load on page open or WebSocket reconnect.
+All database writes by agents go through `write_system2_db`, which fires an `onWrite` callback that the server maps to the appropriate push notification. Agents are instructed to never use `bash`/`sqlite3` to modify `app.db`, ensuring all changes are captured. REST endpoints are used for the initial data load on page open. On WebSocket reconnect, the UI bumps all push version counters so every panel refetches, recovering any changes missed during the disconnect.
 
 ## Message Flow
 

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -195,7 +195,7 @@ Create or update records via named operations. `updated_at` is maintained automa
 
 For ad-hoc SQL not covered by the named operations above (bulk updates, complex transactions), use the `rawSql` operation. It accepts DML (INSERT/UPDATE/DELETE/REPLACE) and SELECT statements (including WITH/CTE prefixes). DDL (CREATE/ALTER/DROP), PRAGMA, ATTACH/DETACH, and maintenance statements (VACUUM, REINDEX, ANALYZE) are blocked.
 
-**Never use `bash` with `sqlite3` to modify `~/.system2/app.db`.** All database writes must go through `write_system2_db` so the server can push real-time updates to the UI. Writes made via `bash`/`sqlite3` bypass this mechanism and the UI will not reflect the changes until the next page reload.
+**Never use `bash` with `sqlite3` to modify `~/.system2/app.db`.** All database writes must go through `write_system2_db` so the server can push real-time updates to the UI. Writes made via `bash`/`sqlite3` bypass this mechanism and the UI will not reflect the changes until the next page reload. This restriction applies only to `app.db`. For data pipeline databases (TimescaleDB, DuckDB, etc.), use `bash` directly with the appropriate database CLI (`psql`, `duckdb`, `sqlite3`, etc.).
 
 ### Schema Reference
 

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -73,6 +73,10 @@ The **Guide** is the primary user-facing agent. However, the user may choose to 
 - **Every tracked file in `~/.system2/` must be committed.** `edit` and `write` handle git auto-commit when you pass `commit_message`. If you use `bash` to create or modify any file inside `~/.system2/` (that isn't covered by `.gitignore`), you must commit it manually: `cd ~/.system2 && git add <file> && git commit -m "<message>"`. Skipping this breaks the version history that other agents and the Narrator depend on. Before marking a task done, run `git -C ~/.system2 status` and verify no untracked or modified files belong to your work.
 - **All timestamps must be UTC ISO 8601** (e.g. `2026-03-13T16:00:00Z`). This applies to timestamps you write in files, database records, commit messages, and section headings. Time-only values (e.g. `16:00Z`) are acceptable when the date is unambiguous from context (e.g. daily summary files named by date). To get the current UTC time: `date -u +%Y-%m-%dT%H:%M:%SZ` (macOS/Linux) or `node -e "console.log(new Date().toISOString())"` (cross-platform). JSONL sessions and scheduled messages already use UTC.
 - `bash` streams output as the command runs. Set `run_in_background` to true for long-running commands — you will receive the result as a follow-up message when the command finishes.
+- **Bash safety:** Certain catastrophic commands are hard-blocked and will be rejected: recursive deletion of `/`, `~`, or `$HOME`; the `--no-preserve-root` flag; `mkfs`; and `dd` to raw block devices. Beyond the hard blocks, follow these guidelines:
+  - Before running any destructive command (`rm -r`, `kill`, `pkill`, `chmod -R`, `mv` that overwrites), ask the user for confirmation through the Guide (or directly if the user is messaging you). This applies especially to files or directories you did not create in the current project.
+  - Prefer reversible alternatives when possible: move files to a temp directory instead of deleting, copy before overwriting.
+  - Never run `rm -rf .` from a working directory you did not create. Verify your `cwd` before recursive deletions.
 - `spawn_agent`, `terminate_agent`, and `trigger_project_story` are available to Guide and Conductors only. Narrator and Reviewer cannot spawn, terminate, or trigger project stories.
 - `resurrect_agent` is available to Guide and Conductors. Guide may resurrect any archived non-singleton. Conductors may only resurrect agents within their own project. Narrator and Reviewer cannot resurrect agents.
 - `set_reminder`, `cancel_reminder`, and `list_reminders` are available to all agents. Reminders are in-memory only and do not survive server restarts. See [Reminders](#reminders) under Communication for usage guidance.
@@ -187,8 +191,11 @@ Create or update records via named operations. `updated_at` is maintained automa
 | `createArtifact` | `file_path`, `title` | `project`, `description`, `tags` | Any agent. Project scope checked if `project` is set. |
 | `updateArtifact` | `id` | `file_path`, `title`, `project`, `description`, `tags` | Any agent. Project scope checked. |
 | `deleteArtifact` | `id` | — | Any agent. Project scope checked. DB row only. |
+| `rawSql` | `sql` | — | Execute arbitrary DML/SELECT. DDL, PRAGMA, ATTACH blocked. |
 
-For ad-hoc SQL not covered by these operations (bulk updates, complex transactions), use `bash` with `sqlite3 ~/.system2/app.db`. Prefer the named operations above for standard work — they enforce permissions, auto-fill fields, and maintain audit trails. Only fall back to raw SQL when the named operations are insufficient for what you need to do.
+For ad-hoc SQL not covered by the named operations above (bulk updates, complex transactions), use the `rawSql` operation. It accepts any DML (INSERT/UPDATE/DELETE) or SELECT statement; DDL (CREATE/ALTER/DROP), PRAGMA, and ATTACH/DETACH are blocked for safety.
+
+**Never use `bash` with `sqlite3` to modify `~/.system2/app.db`.** All database writes must go through `write_system2_db` so the server can push real-time updates to the UI. Writes made via `bash`/`sqlite3` bypass this mechanism and the UI will not reflect the changes until the next page reload.
 
 ### Schema Reference
 

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -191,9 +191,9 @@ Create or update records via named operations. `updated_at` is maintained automa
 | `createArtifact` | `file_path`, `title` | `project`, `description`, `tags` | Any agent. Project scope checked if `project` is set. |
 | `updateArtifact` | `id` | `file_path`, `title`, `project`, `description`, `tags` | Any agent. Project scope checked. |
 | `deleteArtifact` | `id` | — | Any agent. Project scope checked. DB row only. |
-| `rawSql` | `sql` | — | Execute arbitrary DML/SELECT. DDL, PRAGMA, ATTACH blocked. |
+| `rawSql` | `sql` | — | Execute DML (INSERT/UPDATE/DELETE/REPLACE) or SELECT (including WITH/CTE). DDL, PRAGMA, ATTACH, and maintenance statements blocked. |
 
-For ad-hoc SQL not covered by the named operations above (bulk updates, complex transactions), use the `rawSql` operation. It accepts any DML (INSERT/UPDATE/DELETE) or SELECT statement; DDL (CREATE/ALTER/DROP), PRAGMA, and ATTACH/DETACH are blocked for safety.
+For ad-hoc SQL not covered by the named operations above (bulk updates, complex transactions), use the `rawSql` operation. It accepts DML (INSERT/UPDATE/DELETE/REPLACE) and SELECT statements (including WITH/CTE prefixes). DDL (CREATE/ALTER/DROP), PRAGMA, ATTACH/DETACH, and maintenance statements (VACUUM, REINDEX, ANALYZE) are blocked.
 
 **Never use `bash` with `sqlite3` to modify `~/.system2/app.db`.** All database writes must go through `write_system2_db` so the server can push real-time updates to the UI. Writes made via `bash`/`sqlite3` bypass this mechanism and the UI will not reflect the changes until the next page reload.
 

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -85,7 +85,7 @@ import { createTriggerProjectStoryTool } from './tools/trigger-project-story.js'
 import { createWebFetchTool } from './tools/web-fetch.js';
 import { createWebSearchTool } from './tools/web-search.js';
 import { createWriteTool } from './tools/write.js';
-import { createWriteSystem2DbTool } from './tools/write-system2-db.js';
+import { createWriteSystem2DbTool, type OnDatabaseWrite } from './tools/write-system2-db.js';
 import './types.js'; // Import custom message type declarations
 
 const __filename = fileURLToPath(import.meta.url);
@@ -130,6 +130,12 @@ export interface AgentHostConfig {
   /** Shared AuthResolver for cross-agent rate limit awareness. Falls back to creating a local instance. */
   authResolver?: AuthResolver;
   reminderManager?: ReminderManager;
+  /** Called after every successful write_system2_db operation. */
+  onDatabaseWrite?: OnDatabaseWrite;
+  /** Called when the agent's busy state changes. */
+  onBusyChange?: (agentId: number, busy: boolean, contextPercent: number | null) => void;
+  /** Called when an agent is terminated via terminate_agent tool. */
+  onAgentTerminate?: () => void;
 }
 
 export class AgentHost {
@@ -175,6 +181,9 @@ export class AgentHost {
   private agentModels: Record<string, string> = {};
   private reminderManager?: ReminderManager;
   private unsubscribeSession: (() => void) | null = null;
+  private onDatabaseWrite?: OnDatabaseWrite;
+  private onBusyChange?: (agentId: number, busy: boolean, contextPercent: number | null) => void;
+  private onAgentTerminate?: () => void;
 
   constructor(config: AgentHostConfig) {
     this.db = config.db;
@@ -186,6 +195,9 @@ export class AgentHost {
     this.resurrector = config.resurrector;
     this.chatMaxMessages = config.chatMaxMessages ?? 1000;
     this.reminderManager = config.reminderManager;
+    this.onDatabaseWrite = config.onDatabaseWrite;
+    this.onBusyChange = config.onBusyChange;
+    this.onAgentTerminate = config.onAgentTerminate;
 
     // Store LLM config for openai-compatible provider registration
     this.llmConfig = config.llmConfig;
@@ -440,10 +452,12 @@ export class AgentHost {
     if (event.type === 'message_update' || event.type === 'tool_execution_start') {
       if (!this.busy) {
         this.busy = true;
+        this.onBusyChange?.(this.agentId, true, this.getContextUsage()?.percent ?? null);
       }
     } else if (event.type === 'agent_end') {
       if (this.busy) {
         this.busy = false;
+        this.onBusyChange?.(this.agentId, false, this.getContextUsage()?.percent ?? null);
       }
       // On error turns, lastTurnErrored is true (set synchronously in
       // handlePotentialError before agent_end fires). Skip cleanup so the
@@ -760,6 +774,7 @@ export class AgentHost {
     // All recovery paths exhausted; ensure busy is cleared
     if (this.busy) {
       this.busy = false;
+      this.onBusyChange?.(this.agentId, false, this.getContextUsage()?.percent ?? null);
     }
 
     // Permanently failed: reject all pending delivery promises
@@ -800,6 +815,7 @@ export class AgentHost {
     // Old session is dead; clear busy so the agent doesn't appear stuck
     if (this.busy) {
       this.busy = false;
+      this.onBusyChange?.(this.agentId, false, this.getContextUsage()?.percent ?? null);
     }
 
     try {
@@ -975,7 +991,7 @@ export class AgentHost {
     // biome-ignore lint/suspicious/noExplicitAny: heterogeneous tool collection matches SDK's AgentTool<any>[]
     const tools: AgentTool<any>[] = [
       createReadSystem2DbTool(this.db),
-      createWriteSystem2DbTool(this.db, this.agentId),
+      createWriteSystem2DbTool(this.db, this.agentId, this.onDatabaseWrite),
       createMessageAgentTool(this.agentId, this.registry, this.db),
       createBashTool((content, details) => {
         this.session?.sendCustomMessage(
@@ -1011,7 +1027,9 @@ export class AgentHost {
 
     if (canOrchestrate && this.spawner) {
       tools.push(createSpawnAgentTool(this.db, this.agentId, this.spawner));
-      tools.push(createTerminateAgentTool(this.db, this.agentId, this.registry));
+      tools.push(
+        createTerminateAgentTool(this.db, this.agentId, this.registry, this.onAgentTerminate)
+      );
       tools.push(createTriggerProjectStoryTool(this.db, this.agentId, this.registry));
     }
 
@@ -1195,6 +1213,7 @@ export class AgentHost {
       // abort() may not trigger agent_end, so clear busy and pending state explicitly
       if (this.busy) {
         this.busy = false;
+        this.onBusyChange?.(this.agentId, false, this.getContextUsage()?.percent ?? null);
       }
       this.pendingPrompt = null;
       this.deliverySendCount = 0;

--- a/packages/server/src/agents/tools/bash.test.ts
+++ b/packages/server/src/agents/tools/bash.test.ts
@@ -160,6 +160,31 @@ describe('bash tool', () => {
       expect((result.content[0] as { text: string }).text).toContain('blocked');
     });
 
+    it('blocks dd to raw devices with quoted path', async () => {
+      const result = await exec('dd if=/dev/zero of="/dev/sda" bs=1M');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks dd to raw devices with spaces around =', async () => {
+      const result = await exec('dd if=/dev/zero of = /dev/sda bs=1M');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks sqlite3 ~/.system2/app.db', async () => {
+      const result = await exec('sqlite3 ~/.system2/app.db "INSERT INTO task VALUES (1)"');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks sqlite3 $HOME/.system2/app.db', async () => {
+      const result = await exec('sqlite3 $HOME/.system2/app.db "SELECT * FROM task"');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks sqlite3 with absolute path to .system2/app.db', async () => {
+      const result = await exec('sqlite3 /home/user/.system2/app.db ".tables"');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
     it('allows rm -rf on specific directories', async () => {
       const dir = trackDir(makeTmpDir());
       const result = await exec(`rm -rf ${dir}`);

--- a/packages/server/src/agents/tools/bash.test.ts
+++ b/packages/server/src/agents/tools/bash.test.ts
@@ -123,6 +123,18 @@ describe('bash tool', () => {
       expect((result.content[0] as { text: string }).text).toContain('blocked');
     });
 
+    it('blocks rm -rf "$HOME"', async () => {
+      const result = await exec('rm -rf "$HOME"');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks rm -rf with curly-brace HOME variable', async () => {
+      // eslint-disable-next-line -- literal ${HOME} is intentional, not a template placeholder
+      const cmd = 'rm -rf $' + '{HOME}';
+      const result = await exec(cmd);
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
     it('blocks rm --recursive /', async () => {
       const result = await exec('rm --recursive /');
       expect((result.content[0] as { text: string }).text).toContain('blocked');

--- a/packages/server/src/agents/tools/bash.test.ts
+++ b/packages/server/src/agents/tools/bash.test.ts
@@ -185,6 +185,11 @@ describe('bash tool', () => {
       expect((result.content[0] as { text: string }).text).toContain('blocked');
     });
 
+    it('blocks sqlite3 with backslash path separators', async () => {
+      const result = await exec('sqlite3 C:\\Users\\me\\.system2\\app.db ".tables"');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
     it('allows rm -rf on specific directories', async () => {
       const dir = trackDir(makeTmpDir());
       const result = await exec(`rm -rf ${dir}`);

--- a/packages/server/src/agents/tools/bash.test.ts
+++ b/packages/server/src/agents/tools/bash.test.ts
@@ -4,7 +4,7 @@ import { platform, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AgentToolUpdateCallback } from '@mariozechner/pi-agent-core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createBashTool } from './bash.js';
+import { BLOCKED_BASH_PATTERNS, createBashTool } from './bash.js';
 
 const isWindows = platform() === 'win32';
 
@@ -86,6 +86,91 @@ describe('bash tool', () => {
       expect(onUpdate).toHaveBeenCalled();
       const lastCall = onUpdate.mock.calls[onUpdate.mock.calls.length - 1][0];
       expect((lastCall.content[0] as { text: string }).text).toContain('streaming');
+    });
+  });
+
+  describe('blocked command patterns', () => {
+    const tool = createBashTool();
+    const exec = (command: string) => tool.execute('test-call', { command } as BashParams);
+
+    it('blocks rm -rf /', async () => {
+      const result = await exec('rm -rf /');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks rm -rf /*', async () => {
+      const result = await exec('rm -rf /*');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks sudo rm -rf /', async () => {
+      const result = await exec('sudo rm -rf /');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks rm -rf ~', async () => {
+      const result = await exec('rm -rf ~');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks rm -rf ~/', async () => {
+      const result = await exec('rm -rf ~/');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks rm -rf $HOME', async () => {
+      const result = await exec('rm -rf $HOME');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks rm --recursive /', async () => {
+      const result = await exec('rm --recursive /');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks rm -Rf /', async () => {
+      const result = await exec('rm -Rf /');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks --no-preserve-root', async () => {
+      const result = await exec('rm -rf --no-preserve-root /');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks mkfs', async () => {
+      const result = await exec('mkfs.ext4 /dev/sda1');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('blocks dd to raw devices', async () => {
+      const result = await exec('dd if=/dev/zero of=/dev/sda bs=1M');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('allows rm -rf on specific directories', async () => {
+      const dir = trackDir(makeTmpDir());
+      const result = await exec(`rm -rf ${dir}`);
+      expect((result.content[0] as { text: string }).text).not.toContain('blocked');
+    });
+
+    it('allows non-recursive rm', async () => {
+      const result = await exec('rm /tmp/some-file.txt');
+      // Should not be blocked (not recursive), will fail because file doesn't exist
+      expect((result.content[0] as { text: string }).text).not.toContain('blocked');
+    });
+
+    it('blocks dangerous command after semicolon', async () => {
+      const result = await exec('echo hello; rm -rf /');
+      expect((result.content[0] as { text: string }).text).toContain('blocked');
+    });
+
+    it('exports BLOCKED_BASH_PATTERNS for inspection', () => {
+      expect(BLOCKED_BASH_PATTERNS.length).toBeGreaterThan(0);
+      for (const { pattern, reason } of BLOCKED_BASH_PATTERNS) {
+        expect(pattern).toBeInstanceOf(RegExp);
+        expect(reason).toBeTruthy();
+      }
     });
   });
 

--- a/packages/server/src/agents/tools/bash.ts
+++ b/packages/server/src/agents/tools/bash.ts
@@ -43,7 +43,7 @@ export const BLOCKED_BASH_PATTERNS: { pattern: RegExp; reason: string }[] = [
     reason: 'Writing to raw block devices (dd of=/dev/) is blocked',
   },
   {
-    pattern: /\bsqlite3\b[^;|&]*\.system2\/app\.db/,
+    pattern: /\bsqlite3\b[^;|&]*\.system2[/\\]app\.db/,
     reason: 'Direct sqlite3 access to app.db is blocked — use write_system2_db instead',
   },
 ];

--- a/packages/server/src/agents/tools/bash.ts
+++ b/packages/server/src/agents/tools/bash.ts
@@ -26,7 +26,8 @@ export const BLOCKED_BASH_PATTERNS: { pattern: RegExp; reason: string }[] = [
     reason: 'Recursive deletion of home directory (~) is blocked',
   },
   {
-    pattern: /\brm\b[^;|&]*(--recursive|-[a-zA-Z]*[rR])[^;|&]*\s+\$HOME\/?(\s|$|\*)/,
+    pattern:
+      /\brm\b[^;|&]*(--recursive|-[a-zA-Z]*[rR])[^;|&]*\s+"?(?:\$HOME|\$\{HOME\})\/?"?(\s|$|\*)/,
     reason: 'Recursive deletion of home directory ($HOME) is blocked',
   },
   {

--- a/packages/server/src/agents/tools/bash.ts
+++ b/packages/server/src/agents/tools/bash.ts
@@ -39,8 +39,12 @@ export const BLOCKED_BASH_PATTERNS: { pattern: RegExp; reason: string }[] = [
     reason: 'Formatting filesystems (mkfs) is blocked',
   },
   {
-    pattern: /\bdd\b[^;|&]*\bof=\/dev\//,
+    pattern: /\bdd\b[^;|&]*\bof\s*=\s*["']?\/dev\//,
     reason: 'Writing to raw block devices (dd of=/dev/) is blocked',
+  },
+  {
+    pattern: /\bsqlite3\b[^;|&]*\.system2\/app\.db/,
+    reason: 'Direct sqlite3 access to app.db is blocked — use write_system2_db instead',
   },
 ];
 

--- a/packages/server/src/agents/tools/bash.ts
+++ b/packages/server/src/agents/tools/bash.ts
@@ -15,6 +15,34 @@ import { Type } from '@sinclair/typebox';
 const DEFAULT_TIMEOUT = 120_000; // 120 seconds
 const MAX_BUFFER = 10 * 1024 * 1024; // 10MB
 
+/** Patterns that are always blocked: catastrophic, essentially irreversible operations. */
+export const BLOCKED_BASH_PATTERNS: { pattern: RegExp; reason: string }[] = [
+  {
+    pattern: /\brm\b[^;|&]*(--recursive|-[a-zA-Z]*[rR])[^;|&]*\s+\/(\s|$|\*)/,
+    reason: 'Recursive deletion of root directory (/) is blocked',
+  },
+  {
+    pattern: /\brm\b[^;|&]*(--recursive|-[a-zA-Z]*[rR])[^;|&]*\s+~\/?(\s|$|\*)/,
+    reason: 'Recursive deletion of home directory (~) is blocked',
+  },
+  {
+    pattern: /\brm\b[^;|&]*(--recursive|-[a-zA-Z]*[rR])[^;|&]*\s+\$HOME\/?(\s|$|\*)/,
+    reason: 'Recursive deletion of home directory ($HOME) is blocked',
+  },
+  {
+    pattern: /--no-preserve-root/,
+    reason: 'The --no-preserve-root flag is blocked',
+  },
+  {
+    pattern: /\bmkfs\b/,
+    reason: 'Formatting filesystems (mkfs) is blocked',
+  },
+  {
+    pattern: /\bdd\b[^;|&]*\bof=\/dev\//,
+    reason: 'Writing to raw block devices (dd of=/dev/) is blocked',
+  },
+];
+
 // On Windows, use PowerShell instead of cmd.exe for better scripting support
 const isWindows = platform() === 'win32';
 const shellCmd = isWindows ? 'powershell.exe' : '/bin/bash';
@@ -159,6 +187,21 @@ export function createBashTool(notifyBackground?: NotifyBackground) {
       'Execute a shell command and return stdout/stderr. 120-second timeout by default. Uses PowerShell on Windows, bash on macOS/Linux. Set run_in_background to true for long-running commands — you will be notified when they complete. Output is streamed as the command runs.',
     parameters: params,
     execute: async (_toolCallId, params, signal, onUpdate) => {
+      // Block catastrophic commands before execution
+      for (const { pattern, reason } of BLOCKED_BASH_PATTERNS) {
+        if (pattern.test(params.command)) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: `Command blocked: ${reason}. Rephrase the command or use a safer alternative.`,
+              },
+            ],
+            details: { stdout: '', stderr: reason, exitCode: 1 },
+          };
+        }
+      }
+
       const cwd = params.cwd || homedir();
 
       // Background execution

--- a/packages/server/src/agents/tools/terminate-agent.test.ts
+++ b/packages/server/src/agents/tools/terminate-agent.test.ts
@@ -115,4 +115,31 @@ describe('terminate_agent tool', () => {
 
     expect((result.content[0] as { text: string }).text).toContain('not found');
   });
+
+  it('succeeds even when onTerminate callback throws', async () => {
+    const guide = makeAgent(1, 'guide', null);
+    const conductor = makeAgent(2, 'conductor', 10);
+    const abort = vi.fn();
+    const unregister = vi.fn();
+    const updateAgentStatus = vi.fn();
+    const db = {
+      getAgent: (id: number) => [guide, conductor].find((a) => a.id === id) ?? null,
+      updateAgentStatus,
+    } as unknown as DatabaseClient;
+    const registry = {
+      get: () => ({ abort }),
+      unregister,
+    } as unknown as AgentRegistry;
+    const onTerminate = vi.fn(() => {
+      throw new Error('broadcast failed');
+    });
+    const tool = createTerminateAgentTool(db, 1, registry, onTerminate);
+
+    const result = await tool.execute('test', { agent_id: 2 } as TerminateParams);
+
+    // Termination completed despite callback throwing
+    expect((result.content[0] as { text: string }).text).toContain('terminated and archived');
+    expect(updateAgentStatus).toHaveBeenCalledWith(2, 'archived');
+    expect(onTerminate).toHaveBeenCalled();
+  });
 });

--- a/packages/server/src/agents/tools/terminate-agent.ts
+++ b/packages/server/src/agents/tools/terminate-agent.ts
@@ -19,7 +19,8 @@ import type { AgentRegistry } from '../registry.js';
 export function createTerminateAgentTool(
   db: DatabaseClient,
   agentId: number,
-  registry: AgentRegistry
+  registry: AgentRegistry,
+  onTerminate?: () => void
 ) {
   const params = Type.Object({
     agent_id: Type.Number({
@@ -119,6 +120,8 @@ export function createTerminateAgentTool(
         targetHost.abort();
         registry.unregister(params.agent_id);
       }
+
+      onTerminate?.();
 
       return {
         content: [

--- a/packages/server/src/agents/tools/terminate-agent.ts
+++ b/packages/server/src/agents/tools/terminate-agent.ts
@@ -121,7 +121,13 @@ export function createTerminateAgentTool(
         registry.unregister(params.agent_id);
       }
 
-      onTerminate?.();
+      if (onTerminate) {
+        try {
+          onTerminate();
+        } catch {
+          // Best-effort notification: termination has already completed.
+        }
+      }
 
       return {
         content: [

--- a/packages/server/src/agents/tools/write-system2-db.test.ts
+++ b/packages/server/src/agents/tools/write-system2-db.test.ts
@@ -1,5 +1,5 @@
 import type { Agent, Artifact, Project, Task, TaskComment, TaskLink } from '@dscarabelli/shared';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { DatabaseClient } from '../../db/client.js';
 import { createWriteSystem2DbTool } from './write-system2-db.js';
 
@@ -92,6 +92,13 @@ function createMockDb() {
       return a;
     },
     deleteArtifact: (id: number) => artifacts.delete(id),
+    runSql: (sql: string) => {
+      const trimmed = sql.trim().toUpperCase();
+      if (trimmed.startsWith('SELECT')) {
+        return { changes: 0, rows: [{ count: 42 }] };
+      }
+      return { changes: 1 };
+    },
   };
 }
 
@@ -571,5 +578,233 @@ describe('write_system2_db tool', () => {
     } as unknown as WriteDbParams);
 
     expect((result.content[0] as { text: string }).text).toContain('Unknown operation');
+  });
+
+  describe('rawSql', () => {
+    it('executes a SELECT query', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+        sql: 'SELECT count(*) AS count FROM task',
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('42');
+    });
+
+    it('executes a DML statement', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+        sql: "UPDATE task SET status = 'done' WHERE id = 1",
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('changes');
+    });
+
+    it('blocks CREATE statements', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+        sql: 'CREATE TABLE test (id INTEGER)',
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('blocks DDL');
+    });
+
+    it('blocks ALTER statements', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+        sql: 'ALTER TABLE task ADD COLUMN new_col TEXT',
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('blocks DDL');
+    });
+
+    it('blocks DROP statements', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+        sql: 'DROP TABLE task',
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('blocks DDL');
+    });
+
+    it('blocks PRAGMA statements', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+        sql: 'PRAGMA journal_mode=DELETE',
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('blocks DDL');
+    });
+
+    it('blocks ATTACH statements', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+        sql: "ATTACH DATABASE '/tmp/other.db' AS other",
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('blocks DDL');
+    });
+
+    it('blocks DETACH statements', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+        sql: 'DETACH DATABASE other',
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('blocks DDL');
+    });
+
+    it('returns error when sql is missing', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('requires: sql');
+    });
+  });
+
+  describe('onWrite callback', () => {
+    it('fires with "project" for createProject', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const onWrite = vi.fn();
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1, onWrite);
+
+      await tool.execute('test', {
+        operation: 'createProject',
+        name: 'Test',
+        description: 'Desc',
+      } as WriteDbParams);
+
+      expect(onWrite).toHaveBeenCalledWith('project');
+    });
+
+    it('fires with "task" for createTask', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const onWrite = vi.fn();
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1, onWrite);
+
+      await tool.execute('test', {
+        operation: 'createTask',
+        project: 10,
+        title: 'Task',
+        description: 'Desc',
+      } as WriteDbParams);
+
+      expect(onWrite).toHaveBeenCalledWith('task');
+    });
+
+    it('fires with "artifact" for createArtifact', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const onWrite = vi.fn();
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1, onWrite);
+
+      await tool.execute('test', {
+        operation: 'createArtifact',
+        file_path: '/tmp/report.html',
+        title: 'Report',
+      } as WriteDbParams);
+
+      expect(onWrite).toHaveBeenCalledWith('artifact');
+    });
+
+    it('fires with "unknown" for rawSql', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const onWrite = vi.fn();
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1, onWrite);
+
+      await tool.execute('test', {
+        operation: 'rawSql',
+        sql: "UPDATE task SET status = 'done' WHERE id = 1",
+      } as WriteDbParams);
+
+      expect(onWrite).toHaveBeenCalledWith('unknown');
+    });
+
+    it('does not fire on error', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const onWrite = vi.fn();
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1, onWrite);
+
+      await tool.execute('test', {
+        operation: 'rawSql',
+        sql: 'CREATE TABLE nope (id INTEGER)',
+      } as WriteDbParams);
+
+      expect(onWrite).not.toHaveBeenCalled();
+    });
+
+    it('fires with "task_link" for createTaskLink', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      addTask(db, 50, 10);
+      addTask(db, 51, 10);
+      const onWrite = vi.fn();
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1, onWrite);
+
+      await tool.execute('test', {
+        operation: 'createTaskLink',
+        source: 50,
+        target: 51,
+        relationship: 'relates_to',
+      } as WriteDbParams);
+
+      expect(onWrite).toHaveBeenCalledWith('task_link');
+    });
+
+    it('fires with "task_comment" for createTaskComment', async () => {
+      const db = createMockDb();
+      addAgent(db, 2, 'conductor', 10);
+      addTask(db, 50, 10);
+      const onWrite = vi.fn();
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 2, onWrite);
+
+      await tool.execute('test', {
+        operation: 'createTaskComment',
+        task: 50,
+        content: 'Hello',
+      } as WriteDbParams);
+
+      expect(onWrite).toHaveBeenCalledWith('task_comment');
+    });
   });
 });

--- a/packages/server/src/agents/tools/write-system2-db.test.ts
+++ b/packages/server/src/agents/tools/write-system2-db.test.ts
@@ -685,6 +685,32 @@ describe('write_system2_db tool', () => {
       expect((result.content[0] as { text: string }).text).toContain('blocks DDL');
     });
 
+    it('blocks DDL preceded by SQL comments', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+        sql: '-- comment\nCREATE TABLE test (id INTEGER)',
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('blocks DDL');
+    });
+
+    it('blocks DDL preceded by block comments', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+        sql: '/* bypass */ DROP TABLE task',
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('blocks DDL');
+    });
+
     it('returns error when sql is missing', async () => {
       const db = createMockDb();
       addAgent(db, 1, 'guide', null);
@@ -757,6 +783,20 @@ describe('write_system2_db tool', () => {
       } as WriteDbParams);
 
       expect(onWrite).toHaveBeenCalledWith('unknown');
+    });
+
+    it('does not fire for rawSql SELECT', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const onWrite = vi.fn();
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1, onWrite);
+
+      await tool.execute('test', {
+        operation: 'rawSql',
+        sql: 'SELECT count(*) AS count FROM task',
+      } as WriteDbParams);
+
+      expect(onWrite).not.toHaveBeenCalled();
     });
 
     it('does not fire on error', async () => {

--- a/packages/server/src/agents/tools/write-system2-db.test.ts
+++ b/packages/server/src/agents/tools/write-system2-db.test.ts
@@ -93,8 +93,24 @@ function createMockDb() {
     },
     deleteArtifact: (id: number) => artifacts.delete(id),
     runSql: (sql: string) => {
-      const trimmed = sql.trim().toUpperCase();
-      if (trimmed.startsWith('SELECT')) {
+      // Strip leading line comments (-- ...) and block comments (/* ... */) before checking keyword
+      let remaining = sql;
+      for (;;) {
+        const t = remaining.trimStart();
+        if (t.startsWith('--')) {
+          const nl = t.indexOf('\n');
+          remaining = nl === -1 ? '' : t.slice(nl + 1);
+          continue;
+        }
+        if (t.startsWith('/*')) {
+          const end = t.indexOf('*/');
+          remaining = end === -1 ? '' : t.slice(end + 2);
+          continue;
+        }
+        remaining = t;
+        break;
+      }
+      if (remaining.toUpperCase().startsWith('SELECT')) {
         return { changes: 0, rows: [{ count: 42 }] };
       }
       return { changes: 1 };
@@ -709,6 +725,58 @@ describe('write_system2_db tool', () => {
       } as WriteDbParams);
 
       expect((result.content[0] as { text: string }).text).toContain('blocks DDL');
+    });
+
+    it('blocks VACUUM statements', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+        sql: 'VACUUM',
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('only allows');
+    });
+
+    it('blocks REINDEX statements', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+        sql: 'REINDEX',
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('only allows');
+    });
+
+    it('blocks ANALYZE statements', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+        sql: 'ANALYZE',
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('only allows');
+    });
+
+    it('allows SELECT after SQL comments', async () => {
+      const db = createMockDb();
+      addAgent(db, 1, 'guide', null);
+      const tool = createWriteSystem2DbTool(db as unknown as DatabaseClient, 1);
+
+      const result: WriteDbResult = await tool.execute('test', {
+        operation: 'rawSql',
+        sql: '-- comment\nSELECT count(*) AS count FROM task',
+      } as WriteDbParams);
+
+      expect((result.content[0] as { text: string }).text).toContain('42');
     });
 
     it('returns error when sql is missing', async () => {

--- a/packages/server/src/agents/tools/write-system2-db.ts
+++ b/packages/server/src/agents/tools/write-system2-db.ts
@@ -33,8 +33,9 @@ export type WriteEntityType =
 /** Callback fired after every successful write_system2_db operation. */
 export type OnDatabaseWrite = (entityType: WriteEntityType) => void;
 
-/** Blocked SQL patterns: DDL, PRAGMA, ATTACH/DETACH. */
-const BLOCKED_SQL_PATTERNS = /^\s*(CREATE|ALTER|DROP|PRAGMA|ATTACH|DETACH)\b/i;
+/** Blocked SQL patterns: DDL, PRAGMA, ATTACH/DETACH (strips leading SQL comments). */
+const BLOCKED_SQL_PATTERNS =
+  /^(?:\s|--[^\r\n]*(?:\r?\n|$)|\/\*[\s\S]*?\*\/)*(CREATE|ALTER|DROP|PRAGMA|ATTACH|DETACH)\b/i;
 
 function checkProjectScope(
   agentProject: number | null,
@@ -472,7 +473,14 @@ export function createWriteSystem2DbTool(
               );
             }
             const result = db.runSql(params.sql);
-            return ok(result, 'unknown');
+            // Only fire onWrite for statements that modified data
+            if (result.changes > 0) {
+              return ok(result, 'unknown');
+            }
+            return {
+              content: [{ type: 'text', text: JSON.stringify(result) }],
+              details: result,
+            };
           }
 
           default:

--- a/packages/server/src/agents/tools/write-system2-db.ts
+++ b/packages/server/src/agents/tools/write-system2-db.ts
@@ -37,6 +37,27 @@ export type OnDatabaseWrite = (entityType: WriteEntityType) => void;
 const BLOCKED_SQL_PATTERNS =
   /^(?:\s|--[^\r\n]*(?:\r?\n|$)|\/\*[\s\S]*?\*\/)*(CREATE|ALTER|DROP|PRAGMA|ATTACH|DETACH)\b/i;
 
+/** Strip leading SQL comments (line and block) to find the actual statement keyword. */
+function stripLeadingSqlComments(sql: string): string {
+  let remaining = sql;
+  for (;;) {
+    const trimmed = remaining.trimStart();
+    if (trimmed.startsWith('--')) {
+      const nl = trimmed.indexOf('\n');
+      remaining = nl === -1 ? '' : trimmed.slice(nl + 1);
+      continue;
+    }
+    if (trimmed.startsWith('/*')) {
+      const end = trimmed.indexOf('*/');
+      remaining = end === -1 ? '' : trimmed.slice(end + 2);
+      continue;
+    }
+    return trimmed;
+  }
+}
+
+const ALLOWED_RAW_SQL = /^(SELECT|INSERT|UPDATE|DELETE|WITH|REPLACE)\b/i;
+
 function checkProjectScope(
   agentProject: number | null,
   recordProject: number | null
@@ -332,16 +353,7 @@ export function createWriteSystem2DbTool(
               };
             }
 
-            notify('task');
-            return {
-              content: [
-                {
-                  type: 'text' as const,
-                  text: JSON.stringify({ claimed: true, task: result.task }, null, 2),
-                },
-              ],
-              details: { result: { claimed: true, task: result.task } },
-            };
+            return ok({ claimed: true, task: result.task }, 'task');
           }
 
           case 'createTaskLink': {
@@ -472,6 +484,12 @@ export function createWriteSystem2DbTool(
                 'rawSql blocks DDL (CREATE/ALTER/DROP), PRAGMA, and ATTACH/DETACH statements. Only DML (INSERT/UPDATE/DELETE) and SELECT are allowed.'
               );
             }
+            const stripped = stripLeadingSqlComments(params.sql);
+            if (!ALLOWED_RAW_SQL.test(stripped)) {
+              return err(
+                'rawSql only allows SELECT, INSERT, UPDATE, DELETE, WITH, and REPLACE statements.'
+              );
+            }
             const result = db.runSql(params.sql);
             // Only fire onWrite for statements that modified data
             if (result.changes > 0) {
@@ -479,7 +497,7 @@ export function createWriteSystem2DbTool(
             }
             return {
               content: [{ type: 'text', text: JSON.stringify(result) }],
-              details: result,
+              details: { result },
             };
           }
 

--- a/packages/server/src/agents/tools/write-system2-db.ts
+++ b/packages/server/src/agents/tools/write-system2-db.ts
@@ -21,6 +21,21 @@ type ProjectStatus = (typeof PROJECT_STATUSES)[number];
 type TaskPriority = (typeof TASK_PRIORITIES)[number];
 type TaskLinkRelationship = (typeof TASK_LINK_RELATIONSHIPS)[number];
 
+/** Entity categories affected by a write operation. */
+export type WriteEntityType =
+  | 'project'
+  | 'task'
+  | 'task_link'
+  | 'task_comment'
+  | 'artifact'
+  | 'unknown';
+
+/** Callback fired after every successful write_system2_db operation. */
+export type OnDatabaseWrite = (entityType: WriteEntityType) => void;
+
+/** Blocked SQL patterns: DDL, PRAGMA, ATTACH/DETACH. */
+const BLOCKED_SQL_PATTERNS = /^\s*(CREATE|ALTER|DROP|PRAGMA|ATTACH|DETACH)\b/i;
+
 function checkProjectScope(
   agentProject: number | null,
   recordProject: number | null
@@ -33,7 +48,11 @@ function checkProjectScope(
   return null;
 }
 
-export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
+export function createWriteSystem2DbTool(
+  db: DatabaseClient,
+  agentId: number,
+  onWrite?: OnDatabaseWrite
+) {
   const params = Type.Object({
     operation: Type.Union(
       [
@@ -49,10 +68,11 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
         Type.Literal('createArtifact'),
         Type.Literal('updateArtifact'),
         Type.Literal('deleteArtifact'),
+        Type.Literal('rawSql'),
       ],
       {
         description:
-          'Operation to perform. createProject/updateProject manage projects. createTask/updateTask manage tasks. claimTask atomically claims an unassigned todo task (pull model, secondary to assignment). createTaskLink/deleteTaskLink manage task relationships. createTaskComment/deleteTaskComment manage task comments. createArtifact/updateArtifact/deleteArtifact manage artifact metadata (file_path is absolute).',
+          'Operation to perform. createProject/updateProject manage projects. createTask/updateTask manage tasks. claimTask atomically claims an unassigned todo task (pull model, secondary to assignment). createTaskLink/deleteTaskLink manage task relationships. createTaskComment/deleteTaskComment manage task comments. createArtifact/updateArtifact/deleteArtifact manage artifact metadata (file_path is absolute). rawSql executes arbitrary DML (INSERT/UPDATE/DELETE) or SELECT — DDL (CREATE/ALTER/DROP), PRAGMA, and ATTACH are blocked.',
       }
     ),
     // Shared: ID for updates/deletes
@@ -121,13 +141,29 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
         description: 'Array of string tags for artifact categorization.',
       })
     ),
+    // rawSql field
+    sql: Type.Optional(
+      Type.String({
+        description:
+          'SQL statement — required for rawSql. DML (INSERT/UPDATE/DELETE) and SELECT only. DDL (CREATE/ALTER/DROP), PRAGMA, and ATTACH are blocked.',
+      })
+    ),
   });
+
+  /** Notify after a successful write. */
+  const notify = (entityType: WriteEntityType) => {
+    try {
+      onWrite?.(entityType);
+    } catch {
+      // Broadcast failures must not break the tool result
+    }
+  };
 
   const tool: AgentTool<typeof params> = {
     name: 'write_system2_db',
     label: 'Write System2 DB',
     description:
-      "Create or update records in the System2 app database (~/.system2/app.db). Use named operations to manage projects, tasks, task links, task comments, and artifacts. updated_at is maintained automatically. The author field on task comments is filled automatically from your agent ID. claimTask atomically claims a todo task — only use this when operating in pull mode at the Conductor's direction, not as a substitute for working your assigned tasks. createArtifact/updateArtifact/deleteArtifact manage artifact metadata (file_path must be absolute; deleteArtifact removes the DB record only, not the file). This tool is only for the System2 management database — not for data pipeline databases (use bash for those). For ad-hoc or complex SQL not covered by these operations, you can also use bash with sqlite3 ~/.system2/app.db.",
+      "Create or update records in the System2 app database (~/.system2/app.db). Use named operations to manage projects, tasks, task links, task comments, and artifacts. updated_at is maintained automatically. The author field on task comments is filled automatically from your agent ID. claimTask atomically claims a todo task — only use this when operating in pull mode at the Conductor's direction, not as a substitute for working your assigned tasks. createArtifact/updateArtifact/deleteArtifact manage artifact metadata (file_path must be absolute; deleteArtifact removes the DB record only, not the file). rawSql is a last-resort escape hatch for ad-hoc DML or SELECT queries not covered by the named operations. This tool is only for the System2 management database — not for data pipeline databases (use bash for those).",
     parameters: params,
     execute: async (_toolCallId, params, _signal, _onUpdate) => {
       const err = (msg: string) => ({
@@ -135,15 +171,18 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
         details: { error: msg },
       });
 
-      const ok = (result: unknown) => ({
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(result, null, 2),
-          },
-        ],
-        details: { result },
-      });
+      const ok = (result: unknown, entityType?: WriteEntityType) => {
+        if (entityType) notify(entityType);
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify(result, null, 2),
+            },
+          ],
+          details: { result },
+        };
+      };
 
       try {
         const self = db.getAgent(agentId);
@@ -173,7 +212,7 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
               start_at: params.start_at ?? null,
               end_at: params.end_at ?? null,
             });
-            return ok(result);
+            return ok(result, 'project');
           }
 
           case 'updateProject': {
@@ -203,7 +242,7 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
             });
             if (!result) return err(`No project found with id ${params.id}`);
 
-            return ok(result);
+            return ok(result, 'project');
           }
 
           case 'createTask': {
@@ -238,7 +277,7 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
               end_at: params.end_at ?? null,
             });
 
-            return ok(result);
+            return ok(result, 'task');
           }
 
           case 'updateTask': {
@@ -273,7 +312,7 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
             });
             if (!result) return err(`No task found with id ${params.id}`);
 
-            return ok(result);
+            return ok(result, 'task');
           }
 
           case 'claimTask': {
@@ -292,7 +331,16 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
               };
             }
 
-            return ok({ claimed: true, task: result.task });
+            notify('task');
+            return {
+              content: [
+                {
+                  type: 'text' as const,
+                  text: JSON.stringify({ claimed: true, task: result.task }, null, 2),
+                },
+              ],
+              details: { result: { claimed: true, task: result.task } },
+            };
           }
 
           case 'createTaskLink': {
@@ -314,7 +362,7 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
               relationship: params.relationship as TaskLinkRelationship,
             });
 
-            return ok(result);
+            return ok(result, 'task_link');
           }
 
           case 'deleteTaskLink': {
@@ -329,7 +377,7 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
             const deleted = db.deleteTaskLink(params.id);
             if (!deleted) return err(`No task link found with id ${params.id}`);
 
-            return ok({ deleted: true, id: params.id });
+            return ok({ deleted: true, id: params.id }, 'task_link');
           }
 
           case 'createTaskComment': {
@@ -345,7 +393,7 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
               content: params.content,
             });
 
-            return ok(result);
+            return ok(result, 'task_comment');
           }
 
           case 'deleteTaskComment': {
@@ -359,7 +407,7 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
             }
             const deleted = db.deleteTaskComment(params.id);
             if (!deleted) return err(`No task comment found with id ${params.id}`);
-            return ok({ deleted: true, id: params.id });
+            return ok({ deleted: true, id: params.id }, 'task_comment');
           }
 
           case 'createArtifact': {
@@ -377,7 +425,7 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
               tags: params.tags ?? [],
             });
 
-            return ok(result);
+            return ok(result, 'artifact');
           }
 
           case 'updateArtifact': {
@@ -398,7 +446,7 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
             });
             if (!result) return err(`No artifact found with id ${params.id}`);
 
-            return ok(result);
+            return ok(result, 'artifact');
           }
 
           case 'deleteArtifact': {
@@ -413,7 +461,18 @@ export function createWriteSystem2DbTool(db: DatabaseClient, agentId: number) {
             const deleted = db.deleteArtifact(params.id);
             if (!deleted) return err(`No artifact found with id ${params.id}`);
 
-            return ok({ deleted: true, id: params.id });
+            return ok({ deleted: true, id: params.id }, 'artifact');
+          }
+
+          case 'rawSql': {
+            if (!params.sql) return err('rawSql requires: sql');
+            if (BLOCKED_SQL_PATTERNS.test(params.sql)) {
+              return err(
+                'rawSql blocks DDL (CREATE/ALTER/DROP), PRAGMA, and ATTACH/DETACH statements. Only DML (INSERT/UPDATE/DELETE) and SELECT are allowed.'
+              );
+            }
+            const result = db.runSql(params.sql);
+            return ok(result, 'unknown');
           }
 
           default:

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -565,6 +565,23 @@ export class DatabaseClient {
     }
   }
 
+  /**
+   * Execute a DML statement (INSERT, UPDATE, DELETE) or SELECT query.
+   * Used by the rawSql operation in write_system2_db.
+   * DDL and ATTACH statements must be blocked by the caller.
+   */
+  runSql(sql: string): { changes: number; rows?: unknown[] } {
+    const trimmed = sql.trim().toUpperCase();
+    if (trimmed.startsWith('SELECT')) {
+      const stmt = this.db.prepare(sql);
+      const rows = stmt.all();
+      return { changes: 0, rows };
+    }
+    const stmt = this.db.prepare(sql);
+    const result = stmt.run();
+    return { changes: result.changes };
+  }
+
   close(): void {
     this.db.close();
   }

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -571,13 +571,13 @@ export class DatabaseClient {
    * DDL and ATTACH statements must be blocked by the caller.
    */
   runSql(sql: string): { changes: number; rows?: unknown[] } {
-    const trimmed = sql.trim().toUpperCase();
-    if (trimmed.startsWith('SELECT')) {
-      const stmt = this.db.prepare(sql);
+    const stmt = this.db.prepare(sql);
+
+    if (stmt.reader) {
       const rows = stmt.all();
       return { changes: 0, rows };
     }
-    const stmt = this.db.prepare(sql);
+
     const result = stmt.run();
     return { changes: result.changes };
   }

--- a/packages/server/src/db/client.ts
+++ b/packages/server/src/db/client.ts
@@ -575,7 +575,13 @@ export class DatabaseClient {
 
     if (stmt.reader) {
       const rows = stmt.all();
-      return { changes: 0, rows };
+      // DML with RETURNING is a reader (returns rows) but still mutates data.
+      // Check if the SQL is DML and query changes() to get the actual mutation count.
+      const isDml = /^\s*(?:WITH\b[\s\S]*?\)\s*)?(?:INSERT|UPDATE|DELETE|REPLACE)\b/i.test(sql);
+      const changes = isDml
+        ? (this.db.prepare('SELECT changes() AS changes').get() as { changes: number }).changes
+        : 0;
+      return { changes, rows };
     }
 
     const result = stmt.run();

--- a/packages/server/src/scheduler/jobs.test.ts
+++ b/packages/server/src/scheduler/jobs.test.ts
@@ -1158,4 +1158,34 @@ describe('trackJobExecution', () => {
 
     expect(db.completeJobExecution).toHaveBeenCalledWith(42);
   });
+
+  it('does not break when onJobChange callback throws', async () => {
+    const db = mockDbForTracking();
+    const handler = vi.fn();
+    const onJobChange = vi.fn(() => {
+      throw new Error('broadcast failed');
+    });
+
+    await trackJobExecution(db, 'test-job', 'cron', handler, onJobChange);
+
+    expect(handler).toHaveBeenCalled();
+    expect(db.completeJobExecution).toHaveBeenCalledWith(42);
+    expect(onJobChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not break on failure path when onJobChange callback throws', async () => {
+    const db = mockDbForTracking();
+    const handler = vi.fn(() => {
+      throw new Error('handler failed');
+    });
+    const onJobChange = vi.fn(() => {
+      throw new Error('broadcast failed');
+    });
+
+    await expect(trackJobExecution(db, 'test-job', 'cron', handler, onJobChange)).rejects.toThrow(
+      'handler failed'
+    );
+
+    expect(db.failJobExecution).toHaveBeenCalledWith(42, expect.stringContaining('handler failed'));
+  });
 });

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -741,20 +741,27 @@ export async function trackJobExecution(
   onJobChange?: () => void
 ): Promise<void> {
   const execution = db.createJobExecution(jobName, triggerType);
-  onJobChange?.();
+  const notifyChange = () => {
+    try {
+      onJobChange?.();
+    } catch {
+      // Best-effort notification: job tracking must not break due to callback failure.
+    }
+  };
+  notifyChange();
   try {
     await handler();
     db.completeJobExecution(execution.id);
-    onJobChange?.();
+    notifyChange();
   } catch (error) {
     if (error instanceof JobSkipped) {
       db.skipJobExecution(execution.id, error.reason);
-      onJobChange?.();
+      notifyChange();
       return;
     }
     const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
     db.failJobExecution(execution.id, message);
-    onJobChange?.();
+    notifyChange();
     throw error;
   }
 }

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -737,19 +737,24 @@ export async function trackJobExecution(
   db: DatabaseClient,
   jobName: string,
   triggerType: JobExecution['trigger_type'],
-  handler: () => void | Promise<void>
+  handler: () => void | Promise<void>,
+  onJobChange?: () => void
 ): Promise<void> {
   const execution = db.createJobExecution(jobName, triggerType);
+  onJobChange?.();
   try {
     await handler();
     db.completeJobExecution(execution.id);
+    onJobChange?.();
   } catch (error) {
     if (error instanceof JobSkipped) {
       db.skipJobExecution(execution.id, error.reason);
+      onJobChange?.();
       return;
     }
     const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
     db.failJobExecution(execution.id, message);
+    onJobChange?.();
     throw error;
   }
 }
@@ -763,30 +768,49 @@ export function registerNarratorJobs(
   narratorId: number,
   db: DatabaseClient,
   system2Dir: string,
-  intervalMinutes: number
+  intervalMinutes: number,
+  onJobChange?: () => void
 ): void {
   // Daily summary — configurable interval
   const cronPattern = 60 % intervalMinutes === 0 ? `*/${intervalMinutes} * * * *` : '*/30 * * * *';
 
   scheduler.schedule('daily-summary', cronPattern, async () => {
-    await trackJobExecution(db, 'daily-summary', 'cron', async () => {
-      if (!(await isNetworkAvailable())) {
-        throw new JobSkipped('no network connectivity');
-      }
-      console.log('[Scheduler] Triggering daily-summary job (project logs + daily summary)');
-      await buildAndDeliverDailySummary(db, narratorHost, narratorId, system2Dir, intervalMinutes);
-    });
+    await trackJobExecution(
+      db,
+      'daily-summary',
+      'cron',
+      async () => {
+        if (!(await isNetworkAvailable())) {
+          throw new JobSkipped('no network connectivity');
+        }
+        console.log('[Scheduler] Triggering daily-summary job (project logs + daily summary)');
+        await buildAndDeliverDailySummary(
+          db,
+          narratorHost,
+          narratorId,
+          system2Dir,
+          intervalMinutes
+        );
+      },
+      onJobChange
+    );
   });
 
   // Memory update — daily at 11 AM
   scheduler.schedule('memory-update', '0 11 * * *', async () => {
-    await trackJobExecution(db, 'memory-update', 'cron', async () => {
-      if (!(await isNetworkAvailable())) {
-        throw new JobSkipped('no network connectivity');
-      }
-      console.log('[Scheduler] Triggering memory-update job');
-      await buildAndDeliverMemoryUpdate(narratorHost, narratorId, system2Dir);
-    });
+    await trackJobExecution(
+      db,
+      'memory-update',
+      'cron',
+      async () => {
+        if (!(await isNetworkAvailable())) {
+          throw new JobSkipped('no network connectivity');
+        }
+        console.log('[Scheduler] Triggering memory-update job');
+        await buildAndDeliverMemoryUpdate(narratorHost, narratorId, system2Dir);
+      },
+      onJobChange
+    );
   });
 }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -733,7 +733,15 @@ export class Server {
     const data = JSON.stringify(message);
     for (const client of this.wss.clients) {
       if (client.readyState === WebSocket.OPEN) {
-        client.send(data);
+        try {
+          client.send(data);
+        } catch {
+          try {
+            client.terminate();
+          } catch {
+            // Client is already unusable; nothing more we can do.
+          }
+        }
       }
     }
   }
@@ -797,6 +805,12 @@ export class Server {
   }
 
   async stop(): Promise<void> {
+    // Cancel pending debounced broadcasts so they don't fire during/after shutdown
+    for (const timer of this.pendingBroadcasts.values()) {
+      clearTimeout(timer);
+    }
+    this.pendingBroadcasts.clear();
+
     // Clean up conversation summarizer
     this.conversationSummarizer?.cleanup();
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -22,7 +22,7 @@ import type { Api, Model } from '@mariozechner/pi-ai';
 import { type AgentSessionEvent, ModelRegistry } from '@mariozechner/pi-coding-agent';
 import express from 'express';
 import matter from 'gray-matter';
-import { WebSocketServer } from 'ws';
+import { WebSocket, WebSocketServer } from 'ws';
 import { AuthResolver } from './agents/auth-resolver.js';
 import { AgentHost } from './agents/host.js';
 import { AgentRegistry } from './agents/registry.js';
@@ -732,7 +732,7 @@ export class Server {
   private broadcastToAll(message: ServerMessage): void {
     const data = JSON.stringify(message);
     for (const client of this.wss.clients) {
-      if (client.readyState === 1 /* WebSocket.OPEN */) {
+      if (client.readyState === WebSocket.OPEN) {
         client.send(data);
       }
     }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -406,7 +406,7 @@ export class Server {
       const newHost = await this.initializeAgentHost(newAgent.id);
 
       // Notify UI that agent list changed
-      this.broadcastToAll({ type: 'agents_changed' });
+      this.debouncedBroadcast({ type: 'agents_changed' });
 
       // Deliver the initial message from the caller (fire-and-forget)
       newHost
@@ -432,7 +432,7 @@ export class Server {
       const host = await this.initializeAgentHost(agentId);
 
       // Notify UI that agent list changed
-      this.broadcastToAll({ type: 'agents_changed' });
+      this.debouncedBroadcast({ type: 'agents_changed' });
 
       host
         .deliverMessage(message, {
@@ -487,7 +487,7 @@ export class Server {
 
     // Start scheduled jobs
     const intervalMinutes = this.config.schedulerConfig?.daily_summary_interval_minutes ?? 30;
-    const onJobChange = () => this.broadcastToAll({ type: 'job_executions_changed' });
+    const onJobChange = () => this.debouncedBroadcast({ type: 'job_executions_changed' });
     registerNarratorJobs(
       this.scheduler,
       this.narratorHost,
@@ -533,7 +533,7 @@ export class Server {
     }
 
     const intervalMinutes = this.config.schedulerConfig?.daily_summary_interval_minutes ?? 30;
-    const onJobChange = () => this.broadcastToAll({ type: 'job_executions_changed' });
+    const onJobChange = () => this.debouncedBroadcast({ type: 'job_executions_changed' });
 
     // Daily summary catch-up
     const { lastRunTs } = resolveDailySummaryTimestamp(SYSTEM2_DIR, intervalMinutes);
@@ -738,6 +738,32 @@ export class Server {
     }
   }
 
+  /**
+   * Debounced broadcast: coalesces rapid successive pushes of the same message type
+   * into a single broadcast (e.g., creating 10 tasks triggers one board_changed).
+   * agent_busy_changed is sent immediately since it carries per-message payload.
+   */
+  private pendingBroadcasts = new Map<string, ReturnType<typeof setTimeout>>();
+  private static readonly BROADCAST_DEBOUNCE_MS = 50;
+
+  private debouncedBroadcast(message: ServerMessage): void {
+    // Messages with per-event payload must be sent immediately
+    if (message.type === 'agent_busy_changed') {
+      this.broadcastToAll(message);
+      return;
+    }
+    const key = message.type;
+    const existing = this.pendingBroadcasts.get(key);
+    if (existing) clearTimeout(existing);
+    this.pendingBroadcasts.set(
+      key,
+      setTimeout(() => {
+        this.pendingBroadcasts.delete(key);
+        this.broadcastToAll(message);
+      }, Server.BROADCAST_DEBOUNCE_MS)
+    );
+  }
+
   /** Map a write_system2_db entity type to the appropriate push notification(s). */
   private handleDatabaseWrite(entityType: WriteEntityType): void {
     switch (entityType) {
@@ -745,15 +771,17 @@ export class Server {
       case 'task':
       case 'task_link':
       case 'task_comment':
-        this.broadcastToAll({ type: 'board_changed' });
+        this.debouncedBroadcast({ type: 'board_changed' });
         break;
       case 'artifact':
-        this.broadcastToAll({ type: 'artifacts_changed' });
+        this.debouncedBroadcast({ type: 'artifacts_changed' });
         break;
       case 'unknown':
-        // rawSql: we don't know what changed, broadcast both
-        this.broadcastToAll({ type: 'board_changed' });
-        this.broadcastToAll({ type: 'artifacts_changed' });
+        // rawSql: we don't know what changed, invalidate all UI panels
+        this.debouncedBroadcast({ type: 'board_changed' });
+        this.debouncedBroadcast({ type: 'artifacts_changed' });
+        this.debouncedBroadcast({ type: 'agents_changed' });
+        this.debouncedBroadcast({ type: 'job_executions_changed' });
         break;
     }
   }
@@ -763,8 +791,8 @@ export class Server {
     return {
       onDatabaseWrite: (entityType: WriteEntityType) => this.handleDatabaseWrite(entityType),
       onBusyChange: (agentId: number, busy: boolean, contextPercent: number | null) =>
-        this.broadcastToAll({ type: 'agent_busy_changed', agentId, busy, contextPercent }),
-      onAgentTerminate: () => this.broadcastToAll({ type: 'agents_changed' }),
+        this.debouncedBroadcast({ type: 'agent_busy_changed', agentId, busy, contextPercent }),
+      onAgentTerminate: () => this.debouncedBroadcast({ type: 'agents_changed' }),
     };
   }
 

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -14,6 +14,7 @@ import type {
   JobExecution,
   LlmConfig,
   SchedulerConfig,
+  ServerMessage,
   ServicesConfig,
   ToolsConfig,
 } from '@dscarabelli/shared';
@@ -27,6 +28,7 @@ import { AgentHost } from './agents/host.js';
 import { AgentRegistry } from './agents/registry.js';
 import type { AgentResurrector } from './agents/tools/resurrect-agent.js';
 import type { AgentSpawner } from './agents/tools/spawn-agent.js';
+import type { WriteEntityType } from './agents/tools/write-system2-db.js';
 import { createHistoryCaptureSubscriber } from './chat/history-capture.js';
 import { ConversationSummarizer } from './chat/summarizer.js';
 import { DatabaseClient } from './db/client.js';
@@ -101,6 +103,7 @@ export class Server {
 
     const guideAgent = this.db.getOrCreateGuideAgent();
     this.guideAgentId = guideAgent.id;
+    const callbacks = this.buildAgentCallbacks();
     this.agentHost = new AgentHost({
       db: this.db,
       agentId: guideAgent.id,
@@ -113,6 +116,7 @@ export class Server {
       chatMaxMessages,
       authResolver: this.authResolver,
       reminderManager: this.reminderManager,
+      ...callbacks,
     });
     this.agentRegistry.register(guideAgent.id, this.agentHost);
 
@@ -129,6 +133,7 @@ export class Server {
       chatMaxMessages,
       authResolver: this.authResolver,
       reminderManager: this.reminderManager,
+      ...callbacks,
     });
     this.agentRegistry.register(narratorAgent.id, this.narratorHost);
 
@@ -374,6 +379,7 @@ export class Server {
       chatMaxMessages,
       authResolver: this.authResolver,
       reminderManager: this.reminderManager,
+      ...this.buildAgentCallbacks(),
     });
 
     // Subscribe for chat cache capture before initialize() so no events are missed
@@ -399,6 +405,9 @@ export class Server {
 
       const newHost = await this.initializeAgentHost(newAgent.id);
 
+      // Notify UI that agent list changed
+      this.broadcastToAll({ type: 'agents_changed' });
+
       // Deliver the initial message from the caller (fire-and-forget)
       newHost
         .deliverMessage(initialMessage, {
@@ -421,6 +430,9 @@ export class Server {
   private makeResurrector(): AgentResurrector {
     return async (agentId, callerAgentId, message) => {
       const host = await this.initializeAgentHost(agentId);
+
+      // Notify UI that agent list changed
+      this.broadcastToAll({ type: 'agents_changed' });
 
       host
         .deliverMessage(message, {
@@ -475,13 +487,15 @@ export class Server {
 
     // Start scheduled jobs
     const intervalMinutes = this.config.schedulerConfig?.daily_summary_interval_minutes ?? 30;
+    const onJobChange = () => this.broadcastToAll({ type: 'job_executions_changed' });
     registerNarratorJobs(
       this.scheduler,
       this.narratorHost,
       this.narratorId,
       this.db,
       SYSTEM2_DIR,
-      intervalMinutes
+      intervalMinutes,
+      onJobChange
     );
 
     // Check if narrator needs catch-up after sleep/shutdown.
@@ -519,6 +533,7 @@ export class Server {
     }
 
     const intervalMinutes = this.config.schedulerConfig?.daily_summary_interval_minutes ?? 30;
+    const onJobChange = () => this.broadcastToAll({ type: 'job_executions_changed' });
 
     // Daily summary catch-up
     const { lastRunTs } = resolveDailySummaryTimestamp(SYSTEM2_DIR, intervalMinutes);
@@ -531,14 +546,19 @@ export class Server {
           `[Server] Daily summary stale by ${Math.round(staleness / 60000)} min, queuing catch-up`
         );
         try {
-          await trackJobExecution(this.db, 'daily-summary', 'catch-up', () =>
-            buildAndDeliverDailySummary(
-              this.db,
-              this.narratorHost,
-              this.narratorId,
-              SYSTEM2_DIR,
-              intervalMinutes
-            )
+          await trackJobExecution(
+            this.db,
+            'daily-summary',
+            'catch-up',
+            () =>
+              buildAndDeliverDailySummary(
+                this.db,
+                this.narratorHost,
+                this.narratorId,
+                SYSTEM2_DIR,
+                intervalMinutes
+              ),
+            onJobChange
           );
         } catch (error) {
           console.error('[Server] Daily summary catch-up failed:', error);
@@ -558,8 +578,12 @@ export class Server {
           `[Server] Memory stale by ${Math.round(memoryStaleness / 3600000)}h, queuing memory-update catch-up`
         );
         try {
-          await trackJobExecution(this.db, 'memory-update', 'catch-up', () =>
-            buildAndDeliverMemoryUpdate(this.narratorHost, this.narratorId, SYSTEM2_DIR)
+          await trackJobExecution(
+            this.db,
+            'memory-update',
+            'catch-up',
+            () => buildAndDeliverMemoryUpdate(this.narratorHost, this.narratorId, SYSTEM2_DIR),
+            onJobChange
           );
         } catch (error) {
           console.error('[Server] Memory update catch-up failed:', error);
@@ -702,6 +726,46 @@ export class Server {
         }
       }
     });
+  }
+
+  /** Send a message to all connected WebSocket clients. */
+  private broadcastToAll(message: ServerMessage): void {
+    const data = JSON.stringify(message);
+    for (const client of this.wss.clients) {
+      if (client.readyState === 1 /* WebSocket.OPEN */) {
+        client.send(data);
+      }
+    }
+  }
+
+  /** Map a write_system2_db entity type to the appropriate push notification(s). */
+  private handleDatabaseWrite(entityType: WriteEntityType): void {
+    switch (entityType) {
+      case 'project':
+      case 'task':
+      case 'task_link':
+      case 'task_comment':
+        this.broadcastToAll({ type: 'board_changed' });
+        break;
+      case 'artifact':
+        this.broadcastToAll({ type: 'artifacts_changed' });
+        break;
+      case 'unknown':
+        // rawSql: we don't know what changed, broadcast both
+        this.broadcastToAll({ type: 'board_changed' });
+        this.broadcastToAll({ type: 'artifacts_changed' });
+        break;
+    }
+  }
+
+  /** Build the standard callback set for AgentHost instances. */
+  private buildAgentCallbacks() {
+    return {
+      onDatabaseWrite: (entityType: WriteEntityType) => this.handleDatabaseWrite(entityType),
+      onBusyChange: (agentId: number, busy: boolean, contextPercent: number | null) =>
+        this.broadcastToAll({ type: 'agent_busy_changed', agentId, busy, contextPercent }),
+      onAgentTerminate: () => this.broadcastToAll({ type: 'agents_changed' }),
+    };
   }
 
   async stop(): Promise<void> {

--- a/packages/shared/src/types/messages.ts
+++ b/packages/shared/src/types/messages.ts
@@ -55,4 +55,4 @@ export type ServerMessage =
       agentId: number;
       busy: boolean;
       contextPercent: number | null;
-    }; // Agent busy state or context usage changed
+    }; // Agent busy state changed; includes current context usage snapshot

--- a/packages/shared/src/types/messages.ts
+++ b/packages/shared/src/types/messages.ts
@@ -44,4 +44,15 @@ export type ServerMessage =
   | { type: 'provider_info'; provider: string; agentId: number } // Sent on connect/switch — current LLM provider for an agent
   | { type: 'provider_change'; provider: string; reason?: string; agentId: number } // Sent on failover — provider switched
   | { type: 'compaction_start'; agentId?: number } // Sent when auto-compaction begins
-  | { type: 'compaction_end'; agentId?: number }; // Sent when auto-compaction completes
+  | { type: 'compaction_end'; agentId?: number } // Sent when auto-compaction completes
+  // Push notifications: tell UI panels to refetch data
+  | { type: 'board_changed' } // Kanban data changed (projects/tasks/links/comments)
+  | { type: 'agents_changed' } // Agent list changed (spawn/terminate/resurrect)
+  | { type: 'artifacts_changed' } // Artifact catalog changed
+  | { type: 'job_executions_changed' } // Scheduler job execution changed
+  | {
+      type: 'agent_busy_changed';
+      agentId: number;
+      busy: boolean;
+      contextPercent: number | null;
+    }; // Agent busy state or context usage changed

--- a/packages/ui/src/components/AgentPane.tsx
+++ b/packages/ui/src/components/AgentPane.tsx
@@ -8,8 +8,8 @@
 import { ChevronDownIcon, ChevronRightIcon } from '@primer/octicons-react';
 import { Box, Text } from '@primer/react';
 import { type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { POLL_ERROR_BACKOFF_MS, POLL_INTERVAL_MS } from '../constants';
 import { useChatStore } from '../stores/chat';
+import { usePushStore } from '../stores/push';
 import { colors, contextColor } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
 
@@ -58,36 +58,29 @@ export function AgentPane() {
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const initialized = useRef(false);
   const activeAgentId = useChatStore((s) => s.activeAgentId);
+  const agentsVersion = usePushStore((s) => s.agentsVersion);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: agentsVersion is an intentional trigger to refetch on push
   useEffect(() => {
     const controller = new AbortController();
-    let timeoutId: ReturnType<typeof setTimeout>;
 
-    const fetchData = () => {
-      if (!initialized.current) setLoading(true);
+    if (!initialized.current) setLoading(true);
 
-      fetch('/api/agents', { signal: controller.signal })
-        .then((res) => res.json())
-        .then((data) => {
-          setAgents(data.agents || []);
-          initialized.current = true;
+    fetch('/api/agents', { signal: controller.signal })
+      .then((res) => res.json())
+      .then((data) => {
+        setAgents(data.agents || []);
+        initialized.current = true;
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if ((err as { name?: string }).name !== 'AbortError') {
           setLoading(false);
-          timeoutId = setTimeout(fetchData, POLL_INTERVAL_MS);
-        })
-        .catch((err: unknown) => {
-          if ((err as { name?: string }).name !== 'AbortError') {
-            setLoading(false);
-            timeoutId = setTimeout(fetchData, POLL_ERROR_BACKOFF_MS);
-          }
-        });
-    };
+        }
+      });
 
-    fetchData();
-    return () => {
-      controller.abort();
-      clearTimeout(timeoutId);
-    };
-  }, []);
+    return () => controller.abort();
+  }, [agentsVersion]);
 
   const toggleGroupCollapse = useCallback((group: string) => {
     setCollapsedGroups((prev) => {

--- a/packages/ui/src/components/AgentPane.tsx
+++ b/packages/ui/src/components/AgentPane.tsx
@@ -59,6 +59,18 @@ export function AgentPane() {
   const initialized = useRef(false);
   const activeAgentId = useChatStore((s) => s.activeAgentId);
   const agentsVersion = usePushStore((s) => s.agentsVersion);
+  const agentBusy = usePushStore((s) => s.agentBusy);
+
+  // Overlay real-time busy state from push store onto fetched agent data
+  const agentsWithBusy = useMemo(
+    () =>
+      agents.map((a) => {
+        const live = agentBusy.get(a.id);
+        if (!live) return a;
+        return { ...a, busy: live.busy, contextPercent: live.contextPercent ?? a.contextPercent };
+      }),
+    [agents, agentBusy]
+  );
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: agentsVersion is an intentional trigger to refetch on push
   useEffect(() => {
@@ -95,10 +107,10 @@ export function AgentPane() {
   const grouped = useMemo(() => {
     const groups = new Map<string, AgentInfo[]>();
 
-    const system = agents.filter((a) => a.project === null);
+    const system = agentsWithBusy.filter((a) => a.project === null);
     if (system.length > 0) groups.set('System', system);
 
-    const projectAgents = agents.filter((a) => a.project !== null);
+    const projectAgents = agentsWithBusy.filter((a) => a.project !== null);
     for (const agent of projectAgents) {
       const key = agent.project_name || `Project #${agent.project}`;
       const list = groups.get(key) || [];
@@ -107,7 +119,7 @@ export function AgentPane() {
     }
 
     return groups;
-  }, [agents]);
+  }, [agentsWithBusy]);
 
   return (
     <Box

--- a/packages/ui/src/components/AgentPane.tsx
+++ b/packages/ui/src/components/AgentPane.tsx
@@ -67,7 +67,7 @@ export function AgentPane() {
       agents.map((a) => {
         const live = agentBusy.get(a.id);
         if (!live) return a;
-        return { ...a, busy: live.busy, contextPercent: live.contextPercent ?? a.contextPercent };
+        return { ...a, busy: live.busy, contextPercent: live.contextPercent };
       }),
     [agents, agentBusy]
   );

--- a/packages/ui/src/components/ArtifactCatalog.tsx
+++ b/packages/ui/src/components/ArtifactCatalog.tsx
@@ -8,8 +8,8 @@
 import { ChevronDownIcon, ChevronRightIcon, SearchIcon } from '@primer/octicons-react';
 import { Box, Text, TextInput } from '@primer/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { POLL_ERROR_BACKOFF_MS, POLL_INTERVAL_MS } from '../constants';
 import { useArtifactStore } from '../stores/artifact';
+import { usePushStore } from '../stores/push';
 import { useAccentColors } from '../theme/useAccentColors';
 import { MultiSelectDropdown } from './MultiSelectDropdown';
 
@@ -41,88 +41,81 @@ export function ArtifactCatalog() {
   const projectsInitialized = useRef(false);
   const knownTags = useRef<Set<string>>(new Set());
   const knownProjects = useRef<Set<string>>(new Set());
+  const artifactsVersion = usePushStore((s) => s.artifactsVersion);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: artifactsVersion is an intentional trigger to refetch on push
   useEffect(() => {
     const controller = new AbortController();
-    let timeoutId: ReturnType<typeof setTimeout>;
 
-    const fetchData = () => {
-      if (!initialized.current) setLoading(true);
+    if (!initialized.current) setLoading(true);
 
-      fetch('/api/artifacts', { signal: controller.signal })
-        .then((res) => res.json())
-        .then((data) => {
-          const parsed = (data.artifacts || []).map((a: CatalogArtifactRaw) => {
-            let tags: string[] = [];
-            if (a.tags) {
-              try {
-                tags = JSON.parse(a.tags);
-              } catch {
-                // ignore malformed tags
-              }
-            }
-            return { ...a, tags };
-          });
-          setArtifacts(parsed);
-          const tags = [...new Set<string>(parsed.flatMap((a: CatalogArtifact) => a.tags))];
-          const tagValues = ['', ...tags];
-          if (!tagsInitialized.current) {
-            tagsInitialized.current = true;
-            knownTags.current = new Set(tagValues);
-            setSelectedTags(new Set<string>(tagValues));
-          } else {
-            const newTags = tagValues.filter((t) => !knownTags.current.has(t));
-            if (newTags.length > 0) {
-              for (const t of newTags) knownTags.current.add(t);
-              setSelectedTags((prev) => {
-                const next = new Set(prev);
-                for (const t of newTags) next.add(t);
-                return next;
-              });
+    fetch('/api/artifacts', { signal: controller.signal })
+      .then((res) => res.json())
+      .then((data) => {
+        const parsed = (data.artifacts || []).map((a: CatalogArtifactRaw) => {
+          let tags: string[] = [];
+          if (a.tags) {
+            try {
+              tags = JSON.parse(a.tags);
+            } catch {
+              // ignore malformed tags
             }
           }
-          const projectNames = [
-            ...new Set<string>(
-              parsed
-                .filter((a: CatalogArtifact) => a.project_name)
-                .map((a: CatalogArtifact) => a.project_name as string)
-            ),
-          ];
-          const hasNullProject = parsed.some((a: CatalogArtifact) => !a.project_name);
-          const projectValues = [...(hasNullProject ? [''] : []), ...projectNames];
-          if (!projectsInitialized.current) {
-            projectsInitialized.current = true;
-            knownProjects.current = new Set(projectValues);
-            setSelectedProjects(new Set<string>(projectValues));
-          } else {
-            const newProjects = projectValues.filter((p) => !knownProjects.current.has(p));
-            if (newProjects.length > 0) {
-              for (const p of newProjects) knownProjects.current.add(p);
-              setSelectedProjects((prev) => {
-                const next = new Set(prev);
-                for (const p of newProjects) next.add(p);
-                return next;
-              });
-            }
-          }
-          initialized.current = true;
-          setLoading(false);
-          timeoutId = setTimeout(fetchData, POLL_INTERVAL_MS);
-        })
-        .catch((err: unknown) => {
-          if ((err as { name?: string }).name !== 'AbortError') {
-            setLoading(false);
-            timeoutId = setTimeout(fetchData, POLL_ERROR_BACKOFF_MS);
-          }
+          return { ...a, tags };
         });
-    };
+        setArtifacts(parsed);
+        const tags = [...new Set<string>(parsed.flatMap((a: CatalogArtifact) => a.tags))];
+        const tagValues = ['', ...tags];
+        if (!tagsInitialized.current) {
+          tagsInitialized.current = true;
+          knownTags.current = new Set(tagValues);
+          setSelectedTags(new Set<string>(tagValues));
+        } else {
+          const newTags = tagValues.filter((t) => !knownTags.current.has(t));
+          if (newTags.length > 0) {
+            for (const t of newTags) knownTags.current.add(t);
+            setSelectedTags((prev) => {
+              const next = new Set(prev);
+              for (const t of newTags) next.add(t);
+              return next;
+            });
+          }
+        }
+        const projectNames = [
+          ...new Set<string>(
+            parsed
+              .filter((a: CatalogArtifact) => a.project_name)
+              .map((a: CatalogArtifact) => a.project_name as string)
+          ),
+        ];
+        const hasNullProject = parsed.some((a: CatalogArtifact) => !a.project_name);
+        const projectValues = [...(hasNullProject ? [''] : []), ...projectNames];
+        if (!projectsInitialized.current) {
+          projectsInitialized.current = true;
+          knownProjects.current = new Set(projectValues);
+          setSelectedProjects(new Set<string>(projectValues));
+        } else {
+          const newProjects = projectValues.filter((p) => !knownProjects.current.has(p));
+          if (newProjects.length > 0) {
+            for (const p of newProjects) knownProjects.current.add(p);
+            setSelectedProjects((prev) => {
+              const next = new Set(prev);
+              for (const p of newProjects) next.add(p);
+              return next;
+            });
+          }
+        }
+        initialized.current = true;
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if ((err as { name?: string }).name !== 'AbortError') {
+          setLoading(false);
+        }
+      });
 
-    fetchData();
-    return () => {
-      controller.abort();
-      clearTimeout(timeoutId);
-    };
-  }, []);
+    return () => controller.abort();
+  }, [artifactsVersion]);
 
   const handleClick = useCallback(
     (artifact: CatalogArtifact) => {

--- a/packages/ui/src/components/CronJobsPane.tsx
+++ b/packages/ui/src/components/CronJobsPane.tsx
@@ -9,7 +9,7 @@ import { TriangleDownIcon, TriangleUpIcon } from '@primer/octicons-react';
 import { Box, Text } from '@primer/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { POLL_ERROR_BACKOFF_MS, POLL_INTERVAL_MS } from '../constants';
+import { usePushStore } from '../stores/push';
 import { colors } from '../theme/colors';
 import { JobExecutionDetailModal } from './JobExecutionDetailModal';
 import type { MultiSelectOption } from './MultiSelectDropdown';
@@ -146,6 +146,7 @@ export function CronJobsPane() {
   const [sortKey, setSortKey] = useState<SortKey>('started_at');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
   const initialized = useRef(false);
+  const jobsVersion = usePushStore((s) => s.jobsVersion);
 
   // Filter state: initialized with all options on first data load
   const [statusFilter, setStatusFilter] = useState<Set<string>>(
@@ -158,46 +159,37 @@ export function CronJobsPane() {
   const [jobOptions, setJobOptions] = useState<MultiSelectOption[]>([]);
   const jobsSeeded = useRef(false);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: jobsVersion is an intentional trigger to refetch on push
   useEffect(() => {
     const controller = new AbortController();
-    let timeoutId: ReturnType<typeof setTimeout>;
 
-    const fetchData = () => {
-      if (!initialized.current) setLoading(true);
+    if (!initialized.current) setLoading(true);
 
-      fetch('/api/job-executions?limit=50', { signal: controller.signal })
-        .then((res) => res.json())
-        .then((data) => {
-          const items: JobExecutionInfo[] = data.executions || [];
-          setExecutions(items);
-          initialized.current = true;
+    fetch('/api/job-executions?limit=50', { signal: controller.signal })
+      .then((res) => res.json())
+      .then((data) => {
+        const items: JobExecutionInfo[] = data.executions || [];
+        setExecutions(items);
+        initialized.current = true;
+        setLoading(false);
+
+        // Seed job options on first data load
+        if (!jobsSeeded.current && items.length > 0) {
+          jobsSeeded.current = true;
+          const names = [...new Set(items.map((e) => e.job_name))].sort();
+          const opts = names.map((n) => ({ value: n, label: n }));
+          setJobOptions(opts);
+          setJobFilter(new Set(names));
+        }
+      })
+      .catch((err: unknown) => {
+        if ((err as { name?: string }).name !== 'AbortError') {
           setLoading(false);
+        }
+      });
 
-          // Seed job options on first data load
-          if (!jobsSeeded.current && items.length > 0) {
-            jobsSeeded.current = true;
-            const names = [...new Set(items.map((e) => e.job_name))].sort();
-            const opts = names.map((n) => ({ value: n, label: n }));
-            setJobOptions(opts);
-            setJobFilter(new Set(names));
-          }
-
-          timeoutId = setTimeout(fetchData, POLL_INTERVAL_MS);
-        })
-        .catch((err: unknown) => {
-          if ((err as { name?: string }).name !== 'AbortError') {
-            setLoading(false);
-            timeoutId = setTimeout(fetchData, POLL_ERROR_BACKOFF_MS);
-          }
-        });
-    };
-
-    fetchData();
-    return () => {
-      controller.abort();
-      clearTimeout(timeoutId);
-    };
-  }, []);
+    return () => controller.abort();
+  }, [jobsVersion]);
 
   const closeModal = useCallback(() => setSelectedId(null), []);
 

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -2,13 +2,13 @@
  * KanbanBoard Component
  *
  * Live kanban dashboard showing tasks grouped by project in a swimlane layout.
- * Fetches from /api/kanban and polls every 2 seconds for updates.
+ * Fetches from /api/kanban on mount and refetches on WebSocket push notifications.
  */
 
 import { ChevronDownIcon, ChevronRightIcon, InfoIcon, SearchIcon } from '@primer/octicons-react';
 import { Box, IconButton, Text, TextInput } from '@primer/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { POLL_ERROR_BACKOFF_MS, POLL_INTERVAL_MS } from '../constants';
+import { usePushStore } from '../stores/push';
 import { colors } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
 import { MultiSelectDropdown } from './MultiSelectDropdown';
@@ -170,6 +170,7 @@ export function KanbanBoard() {
   const [data, setData] = useState<KanbanData | null>(null);
   const [loading, setLoading] = useState(true);
   const initialized = useRef(false);
+  const boardVersion = usePushStore((s) => s.boardVersion);
   const [filterKeyword, setFilterKeyword] = useState('');
   const [filterPriorities, setFilterPriorities] = useState<Set<string>>(new Set(ALL_PRIORITIES));
   const [filterAssignees, setFilterAssignees] = useState<Set<string>>(new Set());
@@ -200,78 +201,70 @@ export function KanbanBoard() {
   const handleNavigate = useCallback((id: number) => setSelectedTaskId(id), []);
   const handleCloseProjectModal = useCallback(() => setSelectedProjectId(null), []);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: boardVersion is an intentional trigger to refetch on push
   useEffect(() => {
     const controller = new AbortController();
-    let timeoutId: ReturnType<typeof setTimeout>;
 
-    const fetchData = () => {
-      if (!initialized.current) setLoading(true);
+    if (!initialized.current) setLoading(true);
 
-      fetch('/api/kanban', { signal: controller.signal })
-        .then((r) => r.json())
-        .then((raw) => {
-          const tasks: KanbanTask[] = raw.tasks.map((t: KanbanTask & { labels: string }) => ({
-            ...t,
-            labels: (() => {
-              if (typeof t.labels !== 'string') return t.labels;
-              try {
-                return JSON.parse(t.labels) as string[];
-              } catch {
-                return [];
-              }
-            })(),
-          }));
-          setData({ ...raw, tasks });
-          const agentValues = ['', ...raw.agents.map((a: KanbanAgent) => String(a.id))];
-          if (!assigneesInitialized.current) {
-            assigneesInitialized.current = true;
-            knownAssignees.current = new Set(agentValues);
-            setFilterAssignees(new Set(agentValues));
-          } else {
-            const newAssignees = agentValues.filter((v) => !knownAssignees.current.has(v));
-            if (newAssignees.length > 0) {
-              for (const v of newAssignees) knownAssignees.current.add(v);
-              setFilterAssignees((prev) => {
-                const next = new Set(prev);
-                for (const v of newAssignees) next.add(v);
-                return next;
-              });
+    fetch('/api/kanban', { signal: controller.signal })
+      .then((r) => r.json())
+      .then((raw) => {
+        const tasks: KanbanTask[] = raw.tasks.map((t: KanbanTask & { labels: string }) => ({
+          ...t,
+          labels: (() => {
+            if (typeof t.labels !== 'string') return t.labels;
+            try {
+              return JSON.parse(t.labels) as string[];
+            } catch {
+              return [];
             }
+          })(),
+        }));
+        setData({ ...raw, tasks });
+        const agentValues = ['', ...raw.agents.map((a: KanbanAgent) => String(a.id))];
+        if (!assigneesInitialized.current) {
+          assigneesInitialized.current = true;
+          knownAssignees.current = new Set(agentValues);
+          setFilterAssignees(new Set(agentValues));
+        } else {
+          const newAssignees = agentValues.filter((v) => !knownAssignees.current.has(v));
+          if (newAssignees.length > 0) {
+            for (const v of newAssignees) knownAssignees.current.add(v);
+            setFilterAssignees((prev) => {
+              const next = new Set(prev);
+              for (const v of newAssignees) next.add(v);
+              return next;
+            });
           }
-          const labelValues = ['', ...new Set(tasks.flatMap((t: KanbanTask) => t.labels))];
-          if (!labelsInitialized.current) {
-            labelsInitialized.current = true;
-            knownLabels.current = new Set(labelValues);
-            setFilterLabels(new Set(labelValues));
-          } else {
-            const newLabels = labelValues.filter((v) => !knownLabels.current.has(v));
-            if (newLabels.length > 0) {
-              for (const v of newLabels) knownLabels.current.add(v);
-              setFilterLabels((prev) => {
-                const next = new Set(prev);
-                for (const v of newLabels) next.add(v);
-                return next;
-              });
-            }
+        }
+        const labelValues = ['', ...new Set(tasks.flatMap((t: KanbanTask) => t.labels))];
+        if (!labelsInitialized.current) {
+          labelsInitialized.current = true;
+          knownLabels.current = new Set(labelValues);
+          setFilterLabels(new Set(labelValues));
+        } else {
+          const newLabels = labelValues.filter((v) => !knownLabels.current.has(v));
+          if (newLabels.length > 0) {
+            for (const v of newLabels) knownLabels.current.add(v);
+            setFilterLabels((prev) => {
+              const next = new Set(prev);
+              for (const v of newLabels) next.add(v);
+              return next;
+            });
           }
-          initialized.current = true;
+        }
+        initialized.current = true;
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if ((err as { name?: string }).name !== 'AbortError') {
           setLoading(false);
-          timeoutId = setTimeout(fetchData, POLL_INTERVAL_MS);
-        })
-        .catch((err: unknown) => {
-          if ((err as { name?: string }).name !== 'AbortError') {
-            setLoading(false);
-            timeoutId = setTimeout(fetchData, POLL_ERROR_BACKOFF_MS);
-          }
-        });
-    };
+        }
+      });
 
-    fetchData();
-    return () => {
-      controller.abort();
-      clearTimeout(timeoutId);
-    };
-  }, []);
+    return () => controller.abort();
+  }, [boardVersion]);
 
   // Visible columns based on status filter
   const visibleColumns = useMemo(() => {

--- a/packages/ui/src/components/TaskDetailModal.tsx
+++ b/packages/ui/src/components/TaskDetailModal.tsx
@@ -150,24 +150,26 @@ export function TaskDetailModal({
   const [data, setData] = useState<TaskDetailData | null>(null);
   const [loading, setLoading] = useState(true);
   const panelRef = useRef<HTMLDivElement>(null);
-  const initialized = useRef(false);
   const boardVersion = usePushStore((s) => s.boardVersion);
+
+  const prevTaskIdRef = useRef<number>(taskId);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: boardVersion is an intentional trigger to refetch on push
   useEffect(() => {
     const controller = new AbortController();
-    initialized.current = false;
+    const isNewTask = prevTaskIdRef.current !== taskId;
+    prevTaskIdRef.current = taskId;
 
-    if (panelRef.current) panelRef.current.scrollTop = 0;
-
-    setLoading(true);
-    setData(null);
+    if (isNewTask) {
+      setLoading(true);
+      setData(null);
+      if (panelRef.current) panelRef.current.scrollTop = 0;
+    }
 
     fetch(`/api/tasks/${taskId}`, { signal: controller.signal })
       .then((r) => r.json())
       .then((d: TaskDetailData) => {
         setData(d);
-        initialized.current = true;
         setLoading(false);
       })
       .catch((err: unknown) => {

--- a/packages/ui/src/components/TaskDetailModal.tsx
+++ b/packages/ui/src/components/TaskDetailModal.tsx
@@ -9,7 +9,7 @@ import { XIcon } from '@primer/octicons-react';
 import { Box, IconButton, Text } from '@primer/react';
 import { useEffect, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
-import { POLL_ERROR_BACKOFF_MS, POLL_INTERVAL_MS } from '../constants';
+import { usePushStore } from '../stores/push';
 import { colors } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
 
@@ -151,42 +151,33 @@ export function TaskDetailModal({
   const [loading, setLoading] = useState(true);
   const panelRef = useRef<HTMLDivElement>(null);
   const initialized = useRef(false);
+  const boardVersion = usePushStore((s) => s.boardVersion);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: boardVersion is an intentional trigger to refetch on push
   useEffect(() => {
     const controller = new AbortController();
-    let timeoutId: ReturnType<typeof setTimeout>;
     initialized.current = false;
 
     if (panelRef.current) panelRef.current.scrollTop = 0;
 
-    const fetchData = () => {
-      if (!initialized.current) {
-        setLoading(true);
-        setData(null);
-      }
+    setLoading(true);
+    setData(null);
 
-      fetch(`/api/tasks/${taskId}`, { signal: controller.signal })
-        .then((r) => r.json())
-        .then((d: TaskDetailData) => {
-          setData(d);
-          initialized.current = true;
+    fetch(`/api/tasks/${taskId}`, { signal: controller.signal })
+      .then((r) => r.json())
+      .then((d: TaskDetailData) => {
+        setData(d);
+        initialized.current = true;
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if ((err as { name?: string }).name !== 'AbortError') {
           setLoading(false);
-          timeoutId = setTimeout(fetchData, POLL_INTERVAL_MS);
-        })
-        .catch((err: unknown) => {
-          if ((err as { name?: string }).name !== 'AbortError') {
-            setLoading(false);
-            timeoutId = setTimeout(fetchData, POLL_ERROR_BACKOFF_MS);
-          }
-        });
-    };
+        }
+      });
 
-    fetchData();
-    return () => {
-      controller.abort();
-      clearTimeout(timeoutId);
-    };
-  }, [taskId]);
+    return () => controller.abort();
+  }, [taskId, boardVersion]);
 
   // Close on backdrop click
   const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -19,6 +19,7 @@ export function useWebSocket() {
   const wsRef = useRef<WebSocket | null>(null);
   const activeAgentId = useChatStore((s) => s.activeAgentId);
   const prevAgentRef = useRef<number | null>(null);
+  const hasConnectedOnce = useRef(false);
 
   // Send switch_agent when activeAgentId changes (user-initiated switch via AgentPane)
   useEffect(() => {
@@ -43,13 +44,13 @@ export function useWebSocket() {
       console.log('WebSocket connected');
       const state = useChatStore.getState();
       state.setConnected(true);
-      // On reconnect, bump all push version counters so UI panels refetch
-      // any changes that may have been missed during the disconnect
-      const push = usePushStore.getState();
-      push.bumpBoard();
-      push.bumpAgents();
-      push.bumpArtifacts();
-      push.bumpJobs();
+      if (hasConnectedOnce.current) {
+        // On reconnect, bump all push version counters so UI panels refetch
+        // any changes that may have been missed during the disconnect
+        const push = usePushStore.getState();
+        push.bumpAll();
+      }
+      hasConnectedOnce.current = true;
       // Re-subscribe to the active agent if it's not the Guide
       if (
         state.activeAgentId !== null &&
@@ -222,8 +223,10 @@ export function useWebSocket() {
           break;
 
         case 'agent_busy_changed':
-          // Bump agents version so AgentPane refetches (includes busy + contextPercent)
-          usePushStore.getState().bumpAgents();
+          // Update busy state inline (no refetch needed)
+          usePushStore
+            .getState()
+            .setAgentBusy(message.agentId, message.busy, message.contextPercent);
           break;
 
         case 'error': {

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -43,7 +43,14 @@ export function useWebSocket() {
       console.log('WebSocket connected');
       const state = useChatStore.getState();
       state.setConnected(true);
-      // On reconnect, re-subscribe to the active agent if it's not the Guide
+      // On reconnect, bump all push version counters so UI panels refetch
+      // any changes that may have been missed during the disconnect
+      const push = usePushStore.getState();
+      push.bumpBoard();
+      push.bumpAgents();
+      push.bumpArtifacts();
+      push.bumpJobs();
+      // Re-subscribe to the active agent if it's not the Guide
       if (
         state.activeAgentId !== null &&
         state.guideAgentId !== null &&

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -45,9 +45,10 @@ export function useWebSocket() {
       const state = useChatStore.getState();
       state.setConnected(true);
       if (hasConnectedOnce.current) {
-        // On reconnect, bump all push version counters so UI panels refetch
-        // any changes that may have been missed during the disconnect
+        // On reconnect, clear stale busy state and bump all version counters
+        // so UI panels refetch any changes missed during the disconnect
         const push = usePushStore.getState();
+        push.clearAgentBusy();
         push.bumpAll();
       }
       hasConnectedOnce.current = true;

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -11,6 +11,7 @@ import type { ClientMessage, ServerMessage } from '@dscarabelli/shared';
 import { useCallback, useEffect, useRef } from 'react';
 import { useArtifactStore } from '../stores/artifact';
 import { useChatStore } from '../stores/chat';
+import { usePushStore } from '../stores/push';
 
 const WS_URL = `ws://${window.location.hostname}:3000`;
 
@@ -196,6 +197,27 @@ export function useWebSocket() {
           if (aid !== null) state.finishCompaction(aid);
           break;
         }
+
+        case 'board_changed':
+          usePushStore.getState().bumpBoard();
+          break;
+
+        case 'agents_changed':
+          usePushStore.getState().bumpAgents();
+          break;
+
+        case 'artifacts_changed':
+          usePushStore.getState().bumpArtifacts();
+          break;
+
+        case 'job_executions_changed':
+          usePushStore.getState().bumpJobs();
+          break;
+
+        case 'agent_busy_changed':
+          // Bump agents version so AgentPane refetches (includes busy + contextPercent)
+          usePushStore.getState().bumpAgents();
+          break;
 
         case 'error': {
           console.error('Server error:', message.message);

--- a/packages/ui/src/stores/push.ts
+++ b/packages/ui/src/stores/push.ts
@@ -8,6 +8,11 @@
 
 import { create } from 'zustand';
 
+interface AgentBusyState {
+  busy: boolean;
+  contextPercent: number | null;
+}
+
 interface PushStore {
   /** Incremented on board_changed (projects/tasks/links/comments). */
   boardVersion: number;
@@ -17,11 +22,15 @@ interface PushStore {
   artifactsVersion: number;
   /** Incremented on job_executions_changed. */
   jobsVersion: number;
+  /** Per-agent busy state updated inline from agent_busy_changed (no refetch needed). */
+  agentBusy: Map<number, AgentBusyState>;
 
   bumpBoard: () => void;
   bumpAgents: () => void;
   bumpArtifacts: () => void;
   bumpJobs: () => void;
+  bumpAll: () => void;
+  setAgentBusy: (agentId: number, busy: boolean, contextPercent: number | null) => void;
 }
 
 export const usePushStore = create<PushStore>((set) => ({
@@ -29,9 +38,23 @@ export const usePushStore = create<PushStore>((set) => ({
   agentsVersion: 0,
   artifactsVersion: 0,
   jobsVersion: 0,
+  agentBusy: new Map(),
 
   bumpBoard: () => set((s) => ({ boardVersion: s.boardVersion + 1 })),
   bumpAgents: () => set((s) => ({ agentsVersion: s.agentsVersion + 1 })),
   bumpArtifacts: () => set((s) => ({ artifactsVersion: s.artifactsVersion + 1 })),
   bumpJobs: () => set((s) => ({ jobsVersion: s.jobsVersion + 1 })),
+  bumpAll: () =>
+    set((s) => ({
+      boardVersion: s.boardVersion + 1,
+      agentsVersion: s.agentsVersion + 1,
+      artifactsVersion: s.artifactsVersion + 1,
+      jobsVersion: s.jobsVersion + 1,
+    })),
+  setAgentBusy: (agentId, busy, contextPercent) =>
+    set((s) => {
+      const next = new Map(s.agentBusy);
+      next.set(agentId, { busy, contextPercent });
+      return { agentBusy: next };
+    }),
 }));

--- a/packages/ui/src/stores/push.ts
+++ b/packages/ui/src/stores/push.ts
@@ -1,0 +1,37 @@
+/**
+ * Push Store
+ *
+ * Lightweight Zustand store for WebSocket push notifications.
+ * Each version counter is bumped when the server broadcasts a change.
+ * UI components subscribe to the relevant counter and refetch data when it changes.
+ */
+
+import { create } from 'zustand';
+
+interface PushStore {
+  /** Incremented on board_changed (projects/tasks/links/comments). */
+  boardVersion: number;
+  /** Incremented on agents_changed (spawn/terminate/resurrect). */
+  agentsVersion: number;
+  /** Incremented on artifacts_changed. */
+  artifactsVersion: number;
+  /** Incremented on job_executions_changed. */
+  jobsVersion: number;
+
+  bumpBoard: () => void;
+  bumpAgents: () => void;
+  bumpArtifacts: () => void;
+  bumpJobs: () => void;
+}
+
+export const usePushStore = create<PushStore>((set) => ({
+  boardVersion: 0,
+  agentsVersion: 0,
+  artifactsVersion: 0,
+  jobsVersion: 0,
+
+  bumpBoard: () => set((s) => ({ boardVersion: s.boardVersion + 1 })),
+  bumpAgents: () => set((s) => ({ agentsVersion: s.agentsVersion + 1 })),
+  bumpArtifacts: () => set((s) => ({ artifactsVersion: s.artifactsVersion + 1 })),
+  bumpJobs: () => set((s) => ({ jobsVersion: s.jobsVersion + 1 })),
+}));

--- a/packages/ui/src/stores/push.ts
+++ b/packages/ui/src/stores/push.ts
@@ -31,6 +31,7 @@ interface PushStore {
   bumpJobs: () => void;
   bumpAll: () => void;
   setAgentBusy: (agentId: number, busy: boolean, contextPercent: number | null) => void;
+  clearAgentBusy: () => void;
 }
 
 export const usePushStore = create<PushStore>((set) => ({
@@ -57,4 +58,5 @@ export const usePushStore = create<PushStore>((set) => ({
       next.set(agentId, { busy, contextPercent });
       return { agentBusy: next };
     }),
+  clearAgentBusy: () => set({ agentBusy: new Map() }),
 }));


### PR DESCRIPTION
## Summary

- Replace REST polling with WebSocket push notifications for all UI panels (kanban, agents, artifacts, cron jobs). Server broadcasts lightweight change notifications on database writes, agent lifecycle events, and scheduler state changes. UI components subscribe to Zustand version counters that trigger refetches.
- Add `rawSql` operation to `write_system2_db` for ad-hoc DML/SELECT, with DDL/PRAGMA/ATTACH blocking and a positive allowlist (SELECT/INSERT/UPDATE/DELETE/WITH/REPLACE). Prohibit `bash` + `sqlite3` for app.db writes (bypasses push).
- Add bash command guardrails: hard-block catastrophic patterns (recursive rm of /, ~, $HOME; mkfs; dd to raw devices) and instruction-level guidelines for destructive commands.

## Changes

**Server (push infrastructure):**
- 5 new `ServerMessage` types: `board_changed`, `agents_changed`, `artifacts_changed`, `job_executions_changed`, `agent_busy_changed`
- `onDatabaseWrite`, `onBusyChange`, `onAgentTerminate` callbacks threaded through `AgentHost` to tools
- `broadcastToAll` (with try/catch + terminate fallback) + debounced broadcast (50ms) + `handleDatabaseWrite` + `buildAgentCallbacks` in `Server`
- `onJobChange` callback through `trackJobExecution`/`registerNarratorJobs` (wrapped in try/catch)
- Spawn/resurrect paths broadcast `agents_changed`
- Pending debounce timers cleared on server shutdown

**Server (rawSql + guardrails):**
- `rawSql` operation in `write_system2_db` with `BLOCKED_SQL_PATTERNS` + positive allowlist
- `runSql` method on `DatabaseClient`
- `BLOCKED_BASH_PATTERNS` in bash tool (7 patterns including sqlite3 app.db)
- Bash safety guidelines in `agents.md`

**UI (push consumption):**
- New `push.ts` Zustand store with version counters + `agentBusy` Map + `clearAgentBusy`
- `useWebSocket.ts` dispatches push messages; clears stale busy state + bumps all counters on reconnect
- `hasConnectedOnce` prevents double-fetch on initial connect
- `AgentPane` overlays inline busy state via useMemo (no refetch for busy changes)
- `TaskDetailModal` uses `prevTaskIdRef` to avoid flicker on boardVersion bumps
- 5 components converted from polling to push-triggered refetch

**Docs:**
- `websocket-protocol.md`: push message types, reconnect behavior
- `tools.md`: bash blocklist, rawSql operation (with allowlist), sqlite3 prohibition
- `agents.md`: bash safety, rawSql docs (with allowlist), sqlite3 prohibition

## Test plan

- [x] 15 new tests for rawSql (DDL blocking, entity types, missing sql, allowlist)
- [x] 7 new tests for onWrite callback (fires per entity type, no fire on error)
- [x] 17 new tests for bash blocklist (rm variants, mkfs, dd + quote/space variants, sqlite3)
- [x] 2 new tests for onJobChange callback resilience (throwing doesn't break tracking)
- [x] 1 new test for onTerminate callback resilience (throwing doesn't break termination)
- [x] All 552 tests pass across 36 test files
- [x] `pnpm check`, `pnpm build`, `pnpm typecheck` clean

Closes #97