### PR TITLE
feat: add error state and retry button for push-triggered panel fetches

### DIFF
--- a/packages/ui/src/components/AgentPane.tsx
+++ b/packages/ui/src/components/AgentPane.tsx
@@ -7,11 +7,13 @@
 
 import { ChevronDownIcon, ChevronRightIcon } from '@primer/octicons-react';
 import { Box, Text } from '@primer/react';
-import { type KeyboardEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type KeyboardEvent, useCallback, useMemo, useState } from 'react';
+import { usePushFetch } from '../hooks/usePushFetch';
 import { useChatStore } from '../stores/chat';
 import { usePushStore } from '../stores/push';
 import { colors, contextColor } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
+import { FetchErrorBanner } from './FetchErrorBanner';
 
 interface AgentInfo {
   id: number;
@@ -53,13 +55,17 @@ function TableHeaders() {
 
 export function AgentPane() {
   const [agents, setAgents] = useState<AgentInfo[]>([]);
-  const [loading, setLoading] = useState(true);
   const { accent } = useAccentColors();
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
-  const initialized = useRef(false);
   const activeAgentId = useChatStore((s) => s.activeAgentId);
   const agentsVersion = usePushStore((s) => s.agentsVersion);
   const agentBusy = usePushStore((s) => s.agentBusy);
+
+  const handleData = useCallback((data: { agents?: AgentInfo[] }) => {
+    setAgents(data.agents || []);
+  }, []);
+
+  const { loading, error, retry } = usePushFetch('/api/agents', agentsVersion, handleData);
 
   // Overlay real-time busy state from push store onto fetched agent data
   const agentsWithBusy = useMemo(
@@ -71,28 +77,6 @@ export function AgentPane() {
       }),
     [agents, agentBusy]
   );
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: agentsVersion is an intentional trigger to refetch on push
-  useEffect(() => {
-    const controller = new AbortController();
-
-    if (!initialized.current) setLoading(true);
-
-    fetch('/api/agents', { signal: controller.signal })
-      .then((res) => res.json())
-      .then((data) => {
-        setAgents(data.agents || []);
-        initialized.current = true;
-        setLoading(false);
-      })
-      .catch((err: unknown) => {
-        if ((err as { name?: string }).name !== 'AbortError') {
-          setLoading(false);
-        }
-      });
-
-    return () => controller.abort();
-  }, [agentsVersion]);
 
   const toggleGroupCollapse = useCallback((group: string) => {
     setCollapsedGroups((prev) => {
@@ -144,12 +128,14 @@ export function AgentPane() {
         </Box>
       </Box>
 
+      {error && <FetchErrorBanner onRetry={retry} />}
+
       <Box sx={{ flex: 1, overflow: 'auto' }}>
         {loading && (
           <Text sx={{ color: 'fg.muted', fontSize: 0, p: 2, display: 'block' }}>Loading...</Text>
         )}
 
-        {!loading && agents.length === 0 && (
+        {!loading && agents.length === 0 && !error && (
           <Text sx={{ color: 'fg.muted', fontSize: 0, p: 2, display: 'block' }}>
             No active agents.
           </Text>

--- a/packages/ui/src/components/AgentPane.tsx
+++ b/packages/ui/src/components/AgentPane.tsx
@@ -128,7 +128,7 @@ export function AgentPane() {
         </Box>
       </Box>
 
-      {error && <FetchErrorBanner onRetry={retry} />}
+      {error && <FetchErrorBanner message={error} onRetry={retry} />}
 
       <Box sx={{ flex: 1, overflow: 'auto' }}>
         {loading && (

--- a/packages/ui/src/components/ArtifactCatalog.tsx
+++ b/packages/ui/src/components/ArtifactCatalog.tsx
@@ -8,9 +8,11 @@
 import { ChevronDownIcon, ChevronRightIcon, SearchIcon } from '@primer/octicons-react';
 import { Box, Text, TextInput } from '@primer/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { usePushFetch } from '../hooks/usePushFetch';
 import { useArtifactStore } from '../stores/artifact';
 import { usePushStore } from '../stores/push';
 import { useAccentColors } from '../theme/useAccentColors';
+import { FetchErrorBanner } from './FetchErrorBanner';
 import { MultiSelectDropdown } from './MultiSelectDropdown';
 
 interface CatalogArtifactRaw {
@@ -30,92 +32,74 @@ interface CatalogArtifact extends Omit<CatalogArtifactRaw, 'tags'> {
 
 export function ArtifactCatalog() {
   const [artifacts, setArtifacts] = useState<CatalogArtifact[]>([]);
-  const [loading, setLoading] = useState(true);
   const openArtifact = useArtifactStore((s) => s.openArtifact);
   const { accent, accentSubtle } = useAccentColors();
   const [query, setQuery] = useState('');
   const [selectedTags, setSelectedTags] = useState<Set<string>>(new Set());
   const [selectedProjects, setSelectedProjects] = useState<Set<string>>(new Set());
-  const initialized = useRef(false);
   const tagsInitialized = useRef(false);
   const projectsInitialized = useRef(false);
   const knownTags = useRef<Set<string>>(new Set());
   const knownProjects = useRef<Set<string>>(new Set());
   const artifactsVersion = usePushStore((s) => s.artifactsVersion);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: artifactsVersion is an intentional trigger to refetch on push
-  useEffect(() => {
-    const controller = new AbortController();
-
-    if (!initialized.current) setLoading(true);
-
-    fetch('/api/artifacts', { signal: controller.signal })
-      .then((res) => res.json())
-      .then((data) => {
-        const parsed = (data.artifacts || []).map((a: CatalogArtifactRaw) => {
-          let tags: string[] = [];
-          if (a.tags) {
-            try {
-              tags = JSON.parse(a.tags);
-            } catch {
-              // ignore malformed tags
-            }
-          }
-          return { ...a, tags };
+  const handleData = useCallback((data: { artifacts?: CatalogArtifactRaw[] }) => {
+    const parsed = (data.artifacts || []).map((a: CatalogArtifactRaw) => {
+      let tags: string[] = [];
+      if (a.tags) {
+        try {
+          tags = JSON.parse(a.tags);
+        } catch {
+          // ignore malformed tags
+        }
+      }
+      return { ...a, tags };
+    });
+    setArtifacts(parsed);
+    const tags = [...new Set<string>(parsed.flatMap((a: CatalogArtifact) => a.tags))];
+    const tagValues = ['', ...tags];
+    if (!tagsInitialized.current) {
+      tagsInitialized.current = true;
+      knownTags.current = new Set(tagValues);
+      setSelectedTags(new Set<string>(tagValues));
+    } else {
+      const newTags = tagValues.filter((t) => !knownTags.current.has(t));
+      if (newTags.length > 0) {
+        for (const t of newTags) knownTags.current.add(t);
+        setSelectedTags((prev) => {
+          const next = new Set(prev);
+          for (const t of newTags) next.add(t);
+          return next;
         });
-        setArtifacts(parsed);
-        const tags = [...new Set<string>(parsed.flatMap((a: CatalogArtifact) => a.tags))];
-        const tagValues = ['', ...tags];
-        if (!tagsInitialized.current) {
-          tagsInitialized.current = true;
-          knownTags.current = new Set(tagValues);
-          setSelectedTags(new Set<string>(tagValues));
-        } else {
-          const newTags = tagValues.filter((t) => !knownTags.current.has(t));
-          if (newTags.length > 0) {
-            for (const t of newTags) knownTags.current.add(t);
-            setSelectedTags((prev) => {
-              const next = new Set(prev);
-              for (const t of newTags) next.add(t);
-              return next;
-            });
-          }
-        }
-        const projectNames = [
-          ...new Set<string>(
-            parsed
-              .filter((a: CatalogArtifact) => a.project_name)
-              .map((a: CatalogArtifact) => a.project_name as string)
-          ),
-        ];
-        const hasNullProject = parsed.some((a: CatalogArtifact) => !a.project_name);
-        const projectValues = [...(hasNullProject ? [''] : []), ...projectNames];
-        if (!projectsInitialized.current) {
-          projectsInitialized.current = true;
-          knownProjects.current = new Set(projectValues);
-          setSelectedProjects(new Set<string>(projectValues));
-        } else {
-          const newProjects = projectValues.filter((p) => !knownProjects.current.has(p));
-          if (newProjects.length > 0) {
-            for (const p of newProjects) knownProjects.current.add(p);
-            setSelectedProjects((prev) => {
-              const next = new Set(prev);
-              for (const p of newProjects) next.add(p);
-              return next;
-            });
-          }
-        }
-        initialized.current = true;
-        setLoading(false);
-      })
-      .catch((err: unknown) => {
-        if ((err as { name?: string }).name !== 'AbortError') {
-          setLoading(false);
-        }
-      });
+      }
+    }
+    const projectNames = [
+      ...new Set<string>(
+        parsed
+          .filter((a: CatalogArtifact) => a.project_name)
+          .map((a: CatalogArtifact) => a.project_name as string)
+      ),
+    ];
+    const hasNullProject = parsed.some((a: CatalogArtifact) => !a.project_name);
+    const projectValues = [...(hasNullProject ? [''] : []), ...projectNames];
+    if (!projectsInitialized.current) {
+      projectsInitialized.current = true;
+      knownProjects.current = new Set(projectValues);
+      setSelectedProjects(new Set<string>(projectValues));
+    } else {
+      const newProjects = projectValues.filter((p) => !knownProjects.current.has(p));
+      if (newProjects.length > 0) {
+        for (const p of newProjects) knownProjects.current.add(p);
+        setSelectedProjects((prev) => {
+          const next = new Set(prev);
+          for (const p of newProjects) next.add(p);
+          return next;
+        });
+      }
+    }
+  }, []);
 
-    return () => controller.abort();
-  }, [artifactsVersion]);
+  const { loading, error, retry } = usePushFetch('/api/artifacts', artifactsVersion, handleData);
 
   const handleClick = useCallback(
     (artifact: CatalogArtifact) => {
@@ -271,11 +255,13 @@ export function ArtifactCatalog() {
         </Box>
       </Box>
 
+      {error && <FetchErrorBanner onRetry={retry} />}
+
       {/* Content */}
       <Box sx={{ flex: 1, overflow: 'auto', p: 2 }}>
         {loading && <Text sx={{ color: 'fg.muted', fontSize: 0 }}>Loading...</Text>}
 
-        {!loading && artifacts.length === 0 && (
+        {!loading && artifacts.length === 0 && !error && (
           <Text sx={{ color: 'fg.muted', fontSize: 0 }}>No artifacts registered.</Text>
         )}
 

--- a/packages/ui/src/components/ArtifactCatalog.tsx
+++ b/packages/ui/src/components/ArtifactCatalog.tsx
@@ -255,7 +255,7 @@ export function ArtifactCatalog() {
         </Box>
       </Box>
 
-      {error && <FetchErrorBanner onRetry={retry} />}
+      {error && <FetchErrorBanner message={error} onRetry={retry} />}
 
       {/* Content */}
       <Box sx={{ flex: 1, overflow: 'auto', p: 2 }}>

--- a/packages/ui/src/components/CronJobsPane.tsx
+++ b/packages/ui/src/components/CronJobsPane.tsx
@@ -252,7 +252,7 @@ export function CronJobsPane() {
         )}
       </Box>
 
-      {error && <FetchErrorBanner onRetry={retry} />}
+      {error && <FetchErrorBanner message={error} onRetry={retry} />}
 
       <Box sx={{ flex: 1, overflow: 'auto' }}>
         {loading && (

--- a/packages/ui/src/components/CronJobsPane.tsx
+++ b/packages/ui/src/components/CronJobsPane.tsx
@@ -7,10 +7,12 @@
 
 import { TriangleDownIcon, TriangleUpIcon } from '@primer/octicons-react';
 import { Box, Text } from '@primer/react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 
+import { usePushFetch } from '../hooks/usePushFetch';
 import { usePushStore } from '../stores/push';
 import { colors } from '../theme/colors';
+import { FetchErrorBanner } from './FetchErrorBanner';
 import { JobExecutionDetailModal } from './JobExecutionDetailModal';
 import type { MultiSelectOption } from './MultiSelectDropdown';
 import { MultiSelectDropdown } from './MultiSelectDropdown';
@@ -141,11 +143,9 @@ function TableHeaders({ sortKey, sortDir, onSort }: TableHeadersProps) {
 
 export function CronJobsPane() {
   const [executions, setExecutions] = useState<JobExecutionInfo[]>([]);
-  const [loading, setLoading] = useState(true);
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [sortKey, setSortKey] = useState<SortKey>('started_at');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
-  const initialized = useRef(false);
   const jobsVersion = usePushStore((s) => s.jobsVersion);
 
   // Filter state: initialized with all options on first data load
@@ -159,37 +159,25 @@ export function CronJobsPane() {
   const [jobOptions, setJobOptions] = useState<MultiSelectOption[]>([]);
   const jobsSeeded = useRef(false);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: jobsVersion is an intentional trigger to refetch on push
-  useEffect(() => {
-    const controller = new AbortController();
+  const handleData = useCallback((data: { executions?: JobExecutionInfo[] }) => {
+    const items: JobExecutionInfo[] = data.executions || [];
+    setExecutions(items);
 
-    if (!initialized.current) setLoading(true);
+    // Seed job options on first data load
+    if (!jobsSeeded.current && items.length > 0) {
+      jobsSeeded.current = true;
+      const names = [...new Set(items.map((e) => e.job_name))].sort();
+      const opts = names.map((n) => ({ value: n, label: n }));
+      setJobOptions(opts);
+      setJobFilter(new Set(names));
+    }
+  }, []);
 
-    fetch('/api/job-executions?limit=50', { signal: controller.signal })
-      .then((res) => res.json())
-      .then((data) => {
-        const items: JobExecutionInfo[] = data.executions || [];
-        setExecutions(items);
-        initialized.current = true;
-        setLoading(false);
-
-        // Seed job options on first data load
-        if (!jobsSeeded.current && items.length > 0) {
-          jobsSeeded.current = true;
-          const names = [...new Set(items.map((e) => e.job_name))].sort();
-          const opts = names.map((n) => ({ value: n, label: n }));
-          setJobOptions(opts);
-          setJobFilter(new Set(names));
-        }
-      })
-      .catch((err: unknown) => {
-        if ((err as { name?: string }).name !== 'AbortError') {
-          setLoading(false);
-        }
-      });
-
-    return () => controller.abort();
-  }, [jobsVersion]);
+  const { loading, error, retry } = usePushFetch(
+    '/api/job-executions?limit=50',
+    jobsVersion,
+    handleData
+  );
 
   const closeModal = useCallback(() => setSelectedId(null), []);
 
@@ -264,12 +252,14 @@ export function CronJobsPane() {
         )}
       </Box>
 
+      {error && <FetchErrorBanner onRetry={retry} />}
+
       <Box sx={{ flex: 1, overflow: 'auto' }}>
         {loading && (
           <Text sx={{ color: 'fg.muted', fontSize: 0, p: 2, display: 'block' }}>Loading...</Text>
         )}
 
-        {!loading && executions.length === 0 && (
+        {!loading && executions.length === 0 && !error && (
           <Text sx={{ color: 'fg.muted', fontSize: 0, p: 2, display: 'block' }}>
             No executions recorded.
           </Text>

--- a/packages/ui/src/components/FetchErrorBanner.test.tsx
+++ b/packages/ui/src/components/FetchErrorBanner.test.tsx
@@ -1,0 +1,24 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FetchErrorBanner } from './FetchErrorBanner';
+
+afterEach(cleanup);
+
+describe('FetchErrorBanner', () => {
+  it('renders the error message', () => {
+    render(<FetchErrorBanner message="404 Not Found" onRetry={vi.fn()} />);
+    expect(screen.getByText(/404 Not Found/)).toBeDefined();
+  });
+
+  it('has role="alert" for accessibility', () => {
+    render(<FetchErrorBanner message="server error" onRetry={vi.fn()} />);
+    expect(screen.getByRole('alert')).toBeDefined();
+  });
+
+  it('calls onRetry when the Retry button is clicked', () => {
+    const onRetry = vi.fn();
+    render(<FetchErrorBanner message="timeout" onRetry={onRetry} />);
+    fireEvent.click(screen.getByText('Retry'));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ui/src/components/FetchErrorBanner.tsx
+++ b/packages/ui/src/components/FetchErrorBanner.tsx
@@ -1,0 +1,49 @@
+/**
+ * Inline error banner shown when a push-triggered panel fetch fails.
+ * Displays the error message and a retry button. Auto-cleared by the
+ * parent when the next fetch succeeds.
+ */
+
+import { Box, Text } from '@primer/react';
+import { colors } from '../theme/colors';
+
+export function FetchErrorBanner({ onRetry }: { onRetry: () => void }) {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 2,
+        px: 2,
+        py: 1,
+        backgroundColor: `${colors.coral}15`,
+        borderBottom: '1px solid',
+        borderColor: `${colors.coral}40`,
+        fontSize: 0,
+        flexShrink: 0,
+      }}
+    >
+      <Text sx={{ color: colors.coral, flex: 1 }}>Failed to load data</Text>
+      <Box
+        as="button"
+        type="button"
+        onClick={onRetry}
+        sx={{
+          background: 'none',
+          border: '1px solid',
+          borderColor: `${colors.coral}60`,
+          borderRadius: 1,
+          color: colors.coral,
+          cursor: 'pointer',
+          fontSize: 0,
+          px: 2,
+          py: '2px',
+          flexShrink: 0,
+          '&:hover': { backgroundColor: `${colors.coral}20` },
+        }}
+      >
+        Retry
+      </Box>
+    </Box>
+  );
+}

--- a/packages/ui/src/components/FetchErrorBanner.tsx
+++ b/packages/ui/src/components/FetchErrorBanner.tsx
@@ -7,9 +7,10 @@
 import { Box, Text } from '@primer/react';
 import { colors } from '../theme/colors';
 
-export function FetchErrorBanner({ onRetry }: { onRetry: () => void }) {
+export function FetchErrorBanner({ message, onRetry }: { message: string; onRetry: () => void }) {
   return (
     <Box
+      role="alert"
       sx={{
         display: 'flex',
         alignItems: 'center',
@@ -23,7 +24,7 @@ export function FetchErrorBanner({ onRetry }: { onRetry: () => void }) {
         flexShrink: 0,
       }}
     >
-      <Text sx={{ color: colors.coral, flex: 1 }}>Failed to load data</Text>
+      <Text sx={{ color: colors.coral, flex: 1 }}>Failed to load data: {message}</Text>
       <Box
         as="button"
         type="button"
@@ -40,6 +41,7 @@ export function FetchErrorBanner({ onRetry }: { onRetry: () => void }) {
           py: '2px',
           flexShrink: 0,
           '&:hover': { backgroundColor: `${colors.coral}20` },
+          '&:focus-visible': { outline: '2px solid', outlineColor: colors.coral },
         }}
       >
         Retry

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -365,7 +365,7 @@ export function KanbanBoard() {
   if (!data && error) {
     return (
       <Box sx={{ p: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
-        <FetchErrorBanner onRetry={retry} />
+        <FetchErrorBanner message={error} onRetry={retry} />
       </Box>
     );
   }
@@ -376,7 +376,7 @@ export function KanbanBoard() {
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
-      {error && <FetchErrorBanner onRetry={retry} />}
+      {error && <FetchErrorBanner message={error} onRetry={retry} />}
       {/* Filter toolbar */}
       <Box
         sx={{

--- a/packages/ui/src/components/KanbanBoard.tsx
+++ b/packages/ui/src/components/KanbanBoard.tsx
@@ -8,9 +8,11 @@
 import { ChevronDownIcon, ChevronRightIcon, InfoIcon, SearchIcon } from '@primer/octicons-react';
 import { Box, IconButton, Text, TextInput } from '@primer/react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { usePushFetch } from '../hooks/usePushFetch';
 import { usePushStore } from '../stores/push';
 import { colors } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
+import { FetchErrorBanner } from './FetchErrorBanner';
 import { MultiSelectDropdown } from './MultiSelectDropdown';
 import { ProjectDetailModal } from './ProjectDetailModal';
 import { TaskDetailModal } from './TaskDetailModal';
@@ -168,8 +170,6 @@ const ALL_STATUSES = new Set(['todo', 'in progress', 'review', 'done', 'abandone
 export function KanbanBoard() {
   const { accent, highlight } = useAccentColors();
   const [data, setData] = useState<KanbanData | null>(null);
-  const [loading, setLoading] = useState(true);
-  const initialized = useRef(false);
   const boardVersion = usePushStore((s) => s.boardVersion);
   const [filterKeyword, setFilterKeyword] = useState('');
   const [filterPriorities, setFilterPriorities] = useState<Set<string>>(new Set(ALL_PRIORITIES));
@@ -201,70 +201,61 @@ export function KanbanBoard() {
   const handleNavigate = useCallback((id: number) => setSelectedTaskId(id), []);
   const handleCloseProjectModal = useCallback(() => setSelectedProjectId(null), []);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: boardVersion is an intentional trigger to refetch on push
-  useEffect(() => {
-    const controller = new AbortController();
-
-    if (!initialized.current) setLoading(true);
-
-    fetch('/api/kanban', { signal: controller.signal })
-      .then((r) => r.json())
-      .then((raw) => {
-        const tasks: KanbanTask[] = raw.tasks.map((t: KanbanTask & { labels: string }) => ({
-          ...t,
-          labels: (() => {
-            if (typeof t.labels !== 'string') return t.labels;
-            try {
-              return JSON.parse(t.labels) as string[];
-            } catch {
-              return [];
-            }
-          })(),
-        }));
-        setData({ ...raw, tasks });
-        const agentValues = ['', ...raw.agents.map((a: KanbanAgent) => String(a.id))];
-        if (!assigneesInitialized.current) {
-          assigneesInitialized.current = true;
-          knownAssignees.current = new Set(agentValues);
-          setFilterAssignees(new Set(agentValues));
-        } else {
-          const newAssignees = agentValues.filter((v) => !knownAssignees.current.has(v));
-          if (newAssignees.length > 0) {
-            for (const v of newAssignees) knownAssignees.current.add(v);
-            setFilterAssignees((prev) => {
-              const next = new Set(prev);
-              for (const v of newAssignees) next.add(v);
-              return next;
-            });
+  const handleData = useCallback(
+    (raw: {
+      tasks: (KanbanTask & { labels: string })[];
+      projects: KanbanProject[];
+      agents: KanbanAgent[];
+    }) => {
+      const tasks: KanbanTask[] = raw.tasks.map((t) => ({
+        ...t,
+        labels: (() => {
+          if (typeof t.labels !== 'string') return t.labels;
+          try {
+            return JSON.parse(t.labels) as string[];
+          } catch {
+            return [];
           }
+        })(),
+      }));
+      setData({ ...raw, tasks });
+      const agentValues = ['', ...raw.agents.map((a: KanbanAgent) => String(a.id))];
+      if (!assigneesInitialized.current) {
+        assigneesInitialized.current = true;
+        knownAssignees.current = new Set(agentValues);
+        setFilterAssignees(new Set(agentValues));
+      } else {
+        const newAssignees = agentValues.filter((v) => !knownAssignees.current.has(v));
+        if (newAssignees.length > 0) {
+          for (const v of newAssignees) knownAssignees.current.add(v);
+          setFilterAssignees((prev) => {
+            const next = new Set(prev);
+            for (const v of newAssignees) next.add(v);
+            return next;
+          });
         }
-        const labelValues = ['', ...new Set(tasks.flatMap((t: KanbanTask) => t.labels))];
-        if (!labelsInitialized.current) {
-          labelsInitialized.current = true;
-          knownLabels.current = new Set(labelValues);
-          setFilterLabels(new Set(labelValues));
-        } else {
-          const newLabels = labelValues.filter((v) => !knownLabels.current.has(v));
-          if (newLabels.length > 0) {
-            for (const v of newLabels) knownLabels.current.add(v);
-            setFilterLabels((prev) => {
-              const next = new Set(prev);
-              for (const v of newLabels) next.add(v);
-              return next;
-            });
-          }
+      }
+      const labelValues = ['', ...new Set(tasks.flatMap((t: KanbanTask) => t.labels))];
+      if (!labelsInitialized.current) {
+        labelsInitialized.current = true;
+        knownLabels.current = new Set(labelValues);
+        setFilterLabels(new Set(labelValues));
+      } else {
+        const newLabels = labelValues.filter((v) => !knownLabels.current.has(v));
+        if (newLabels.length > 0) {
+          for (const v of newLabels) knownLabels.current.add(v);
+          setFilterLabels((prev) => {
+            const next = new Set(prev);
+            for (const v of newLabels) next.add(v);
+            return next;
+          });
         }
-        initialized.current = true;
-        setLoading(false);
-      })
-      .catch((err: unknown) => {
-        if ((err as { name?: string }).name !== 'AbortError') {
-          setLoading(false);
-        }
-      });
+      }
+    },
+    []
+  );
 
-    return () => controller.abort();
-  }, [boardVersion]);
+  const { loading, error, retry } = usePushFetch('/api/kanban', boardVersion, handleData);
 
   // Visible columns based on status filter
   const visibleColumns = useMemo(() => {
@@ -371,16 +362,21 @@ export function KanbanBoard() {
     );
   }
 
-  if (!data) {
+  if (!data && error) {
     return (
-      <Box sx={{ p: 4, color: 'fg.muted', textAlign: 'center' }}>
-        <Text>Failed to load board data.</Text>
+      <Box sx={{ p: 4, display: 'flex', flexDirection: 'column', gap: 2 }}>
+        <FetchErrorBanner onRetry={retry} />
       </Box>
     );
   }
 
+  if (!data) {
+    return null;
+  }
+
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', overflow: 'hidden' }}>
+      {error && <FetchErrorBanner onRetry={retry} />}
       {/* Filter toolbar */}
       <Box
         sx={{

--- a/packages/ui/src/hooks/usePushFetch.test.ts
+++ b/packages/ui/src/hooks/usePushFetch.test.ts
@@ -1,0 +1,133 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { usePushFetch } from './usePushFetch';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function mockFetchOk(data: unknown) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+  } as Response);
+}
+
+function mockFetchFail(status: number, statusText: string) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+    ok: false,
+    status,
+    statusText,
+    json: () => Promise.resolve({}),
+  } as Response);
+}
+
+describe('usePushFetch', () => {
+  it('starts in loading state', () => {
+    mockFetchOk({ items: [] });
+    const onData = vi.fn();
+    const { result } = renderHook(() => usePushFetch('/api/test', 0, onData));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('calls onData and clears loading on success', async () => {
+    const payload = { items: [1, 2, 3] };
+    mockFetchOk(payload);
+    const onData = vi.fn();
+    const { result } = renderHook(() => usePushFetch('/api/test', 0, onData));
+
+    // Wait for fetch to resolve
+    await act(() => Promise.resolve());
+
+    expect(onData).toHaveBeenCalledWith(payload);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets error on non-OK response', async () => {
+    mockFetchFail(500, 'Internal Server Error');
+    const onData = vi.fn();
+    const { result } = renderHook(() => usePushFetch('/api/test', 0, onData));
+
+    await act(() => Promise.resolve());
+
+    expect(onData).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe('500 Internal Server Error');
+  });
+
+  it('clears error on successful retry', async () => {
+    const spy = mockFetchFail(503, 'Service Unavailable');
+    const onData = vi.fn();
+    const { result } = renderHook(() => usePushFetch('/api/test', 0, onData));
+
+    await act(() => Promise.resolve());
+    expect(result.current.error).toBe('503 Service Unavailable');
+
+    // Fix the server and retry
+    spy.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    } as Response);
+
+    await act(() => {
+      result.current.retry();
+    });
+    await act(() => Promise.resolve());
+
+    expect(result.current.error).toBeNull();
+    expect(result.current.loading).toBe(false);
+    expect(onData).toHaveBeenCalledWith({ ok: true });
+  });
+
+  it('refetches when version changes', async () => {
+    const spy = mockFetchOk({ v: 1 });
+    const onData = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ version }) => usePushFetch('/api/test', version, onData),
+      { initialProps: { version: 0 } }
+    );
+
+    await act(() => Promise.resolve());
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(result.current.loading).toBe(false);
+
+    spy.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ v: 2 }),
+    } as Response);
+
+    rerender({ version: 1 });
+    await act(() => Promise.resolve());
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(onData).toHaveBeenLastCalledWith({ v: 2 });
+  });
+
+  it('resets error and loading when URL changes', async () => {
+    mockFetchFail(404, 'Not Found');
+    const onData = vi.fn();
+    const { result, rerender } = renderHook(({ url }) => usePushFetch(url, 0, onData), {
+      initialProps: { url: '/api/old' },
+    });
+
+    await act(() => Promise.resolve());
+    expect(result.current.error).toBe('404 Not Found');
+
+    // Change URL: should reset to loading with no error
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ fresh: true }),
+    } as Response);
+
+    rerender({ url: '/api/new' });
+    // Synchronous reset happens before the fetch resolves
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBeNull();
+
+    await act(() => Promise.resolve());
+    expect(result.current.loading).toBe(false);
+    expect(onData).toHaveBeenCalledWith({ fresh: true });
+  });
+});

--- a/packages/ui/src/hooks/usePushFetch.ts
+++ b/packages/ui/src/hooks/usePushFetch.ts
@@ -25,6 +25,8 @@ export function usePushFetch<T>(
   if (lastUrl.current !== url) {
     lastUrl.current = url;
     initialized.current = false;
+    setLoading(true);
+    setError(null);
   }
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: version and retryCount are intentional refetch triggers

--- a/packages/ui/src/hooks/usePushFetch.ts
+++ b/packages/ui/src/hooks/usePushFetch.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared hook for push-triggered panel fetches with error state and retry.
+ *
+ * Encapsulates the version-counter refetch pattern used by all push-driven panels.
+ * On failure, exposes an error message and a retry function so the panel can
+ * show an inline banner instead of silently swallowing the error.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export function usePushFetch<T>(
+  url: string,
+  version: number,
+  onData: (data: T) => void
+): { loading: boolean; error: string | null; retry: () => void } {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const initialized = useRef(false);
+  const [retryCount, setRetryCount] = useState(0);
+  const onDataRef = useRef(onData);
+  onDataRef.current = onData;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: version and retryCount are intentional refetch triggers
+  useEffect(() => {
+    const controller = new AbortController();
+
+    if (!initialized.current) setLoading(true);
+
+    fetch(url, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+        return res.json();
+      })
+      .then((data: T) => {
+        onDataRef.current(data);
+        initialized.current = true;
+        setLoading(false);
+        setError(null);
+      })
+      .catch((err: unknown) => {
+        if ((err as { name?: string }).name !== 'AbortError') {
+          setLoading(false);
+          setError(err instanceof Error ? err.message : 'Fetch failed');
+        }
+      });
+
+    return () => controller.abort();
+  }, [url, version, retryCount]);
+
+  const retry = useCallback(() => setRetryCount((c) => c + 1), []);
+
+  return { loading, error, retry };
+}

--- a/packages/ui/src/hooks/usePushFetch.ts
+++ b/packages/ui/src/hooks/usePushFetch.ts
@@ -16,9 +16,16 @@ export function usePushFetch<T>(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const initialized = useRef(false);
+  const lastUrl = useRef(url);
   const [retryCount, setRetryCount] = useState(0);
   const onDataRef = useRef(onData);
   onDataRef.current = onData;
+
+  // Reset when URL changes so a new resource starts fresh
+  if (lastUrl.current !== url) {
+    lastUrl.current = url;
+    initialized.current = false;
+  }
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: version and retryCount are intentional refetch triggers
   useEffect(() => {


### PR DESCRIPTION
## Summary

- Extract shared `usePushFetch` hook from the duplicated fetch+version-counter pattern in all 4 push-driven panels
- Add inline `FetchErrorBanner` component (coral styling, Retry button) shown when a fetch fails
- Errors auto-clear on the next successful fetch (whether from retry or a subsequent WebSocket push)
- Stale data remains visible below the banner when a refetch fails after initial load

## Test plan

- [ ] Verify banner appears when server is temporarily unreachable (stop server, trigger a push, see banner)
- [ ] Verify Retry button re-triggers the fetch and clears the banner on success
- [ ] Verify banner auto-clears when a subsequent push-triggered fetch succeeds
- [ ] Verify initial loading state still shows "Loading..." spinner on first mount
- [ ] Verify all 4 panels (KanbanBoard, AgentPane, ArtifactCatalog, CronJobsPane) behave consistently

Closes #105