### PR TITLE
feat: add timestamped logger module for server logs

### DIFF
--- a/packages/server/src/agents/auth-resolver.ts
+++ b/packages/server/src/agents/auth-resolver.ts
@@ -13,6 +13,7 @@
 
 import type { LlmConfig, LlmKey, LlmProvider } from '@dscarabelli/shared';
 import { AuthStorage } from '@mariozechner/pi-coding-agent';
+import { log } from '../utils/logger.js';
 
 /** Default cooldown durations */
 const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 90 * 1000;
@@ -80,7 +81,7 @@ export class AuthResolver {
     if (cooldown) {
       if (Date.now() >= cooldown.expiresAt) {
         this.cooldowns.delete(keyId);
-        console.log(`[AuthResolver] Cooldown expired for ${keyId}, key available again`);
+        log.info(`[AuthResolver] Cooldown expired for ${keyId}, key available again`);
         return false;
       }
       return true;
@@ -194,17 +195,15 @@ export class AuthResolver {
         reason,
       });
       const detail = errorMessage ? `: ${errorMessage}` : '';
-      console.log(
-        `[AuthResolver] Key in cooldown: ${keyId}, expires in ${duration / 1000}s${detail}`
-      );
+      log.info(`[AuthResolver] Key in cooldown: ${keyId}, expires in ${duration / 1000}s${detail}`);
     } else {
-      console.log(`[AuthResolver] Key ${keyId} already in cooldown, skipping`);
+      log.info(`[AuthResolver] Key ${keyId} already in cooldown, skipping`);
     }
 
     // Try to find next valid key for this provider
     const nextKey = this.getFirstValidKey(provider);
     if (nextKey) {
-      console.log(`[AuthResolver] Switching to next key for ${provider}`);
+      log.info(`[AuthResolver] Switching to next key for ${provider}`);
       return true;
     }
 
@@ -214,12 +213,12 @@ export class AuthResolver {
       const fallbackProvider = this.providerOrder[i];
       const fallbackKey = this.getFirstValidKey(fallbackProvider);
       if (fallbackKey) {
-        console.log(`[AuthResolver] Falling back to provider: ${fallbackProvider}`);
+        log.info(`[AuthResolver] Falling back to provider: ${fallbackProvider}`);
         return true;
       }
     }
 
-    console.log('[AuthResolver] No more fallback keys available');
+    log.info('[AuthResolver] No more fallback keys available');
     return false;
   }
 
@@ -248,7 +247,7 @@ export class AuthResolver {
         this.activeKeys.set(provider, 0);
       }
     }
-    console.log('[AuthResolver] All failures and cooldowns reset');
+    log.info('[AuthResolver] All failures and cooldowns reset');
   }
 
   /**
@@ -259,7 +258,7 @@ export class AuthResolver {
     for (const [keyId, cooldown] of this.cooldowns) {
       if (now >= cooldown.expiresAt) {
         this.cooldowns.delete(keyId);
-        console.log(`[AuthResolver] Cooldown expired for ${keyId}`);
+        log.info(`[AuthResolver] Cooldown expired for ${keyId}`);
       }
     }
   }

--- a/packages/server/src/agents/host.ts
+++ b/packages/server/src/agents/host.ts
@@ -34,6 +34,7 @@ import type { DatabaseClient } from '../db/client.js';
 import { resolveProjectDir } from '../projects/dir.js';
 import type { ReminderManager } from '../reminders/manager.js';
 import { filterByRole } from '../skills/loader.js';
+import { log } from '../utils/logger.js';
 import { AuthResolver } from './auth-resolver.js';
 import type { AgentRegistry } from './registry.js';
 import {
@@ -212,7 +213,7 @@ export class AgentHost {
     this.currentProvider = this.authResolver.primaryProvider;
     this.currentKeyIndex = this.authResolver.getActiveKey(this.currentProvider)?.keyIndex ?? 0;
 
-    console.log('[AgentHost] Auth status:', this.authResolver.getStatus());
+    log.info('[AgentHost] Auth status:', this.authResolver.getStatus());
   }
 
   /**
@@ -241,7 +242,7 @@ export class AgentHost {
       }
     }
     this.agentRole = agentRecord.role;
-    console.log('[AgentHost] Agent:', { id: agentRecord.id, role: agentRecord.role });
+    log.info('[AgentHost] Agent:', { id: agentRecord.id, role: agentRecord.role });
 
     // Session directory — use role_id format (e.g., sessions/guide_1/)
     const sessionDirName = `${agentRecord.role}_${agentRecord.id}`;
@@ -272,7 +273,7 @@ export class AgentHost {
     if (!this.session) {
       const rotated = rotateSessionIfNeeded(agentSessionDir, SYSTEM2_DIR);
       if (rotated) {
-        console.log('[AgentHost] Session file rotated to new file');
+        log.info('[AgentHost] Session file rotated to new file');
       }
     }
 
@@ -291,7 +292,7 @@ export class AgentHost {
 
     let llmProvider = this.currentProvider;
 
-    console.log('[AgentHost] Agent config loaded:', {
+    log.info('[AgentHost] Agent config loaded:', {
       name: agentConfig.name,
       models: agentConfig.models,
       provider: llmProvider,
@@ -339,7 +340,7 @@ export class AgentHost {
           modelId = id;
           resolvedProvider = provider;
           if (provider !== llmProvider) {
-            console.log(
+            log.info(
               `[AgentHost] No model for ${llmProvider} in ${agentConfig.name}, falling back to ${provider}`
             );
           }
@@ -356,7 +357,7 @@ export class AgentHost {
       this.currentKeyIndex = this.authResolver.getActiveKey(resolvedProvider)?.keyIndex ?? 0;
     }
 
-    console.log('[AgentHost] Selected model:', modelId, 'for provider:', llmProvider);
+    log.info('[AgentHost] Selected model:', modelId, 'for provider:', llmProvider);
 
     // Find model using registry
     const model = this.modelRegistry.find(llmProvider, modelId);
@@ -364,7 +365,7 @@ export class AgentHost {
       throw new Error(`Model not found: ${llmProvider}/${modelId}`);
     }
 
-    console.log('[AgentHost] Model found:', model ? 'YES' : 'NO');
+    log.info('[AgentHost] Model found:', model ? 'YES' : 'NO');
 
     // Store context window size for overflow recovery
     this.contextWindow = model.contextWindow;
@@ -428,7 +429,7 @@ export class AgentHost {
     this.compactionDepth = agentConfig.compaction_depth ?? 0;
     if (this.compactionDepth > 0) {
       this.compactionCount = this.readCompactionCount();
-      console.log(
+      log.info(
         `[AgentHost] Compaction pruning enabled: depth=${this.compactionDepth}, count=${this.compactionCount}`
       );
     }
@@ -438,8 +439,8 @@ export class AgentHost {
       this.handleSessionEvent(event);
     });
 
-    console.log(`[AgentHost] ${agentRecord.role} agent session initialized with JSONL persistence`);
-    console.log('[AgentHost] Using provider:', this.currentProvider);
+    log.info(`[AgentHost] ${agentRecord.role} agent session initialized with JSONL persistence`);
+    log.info('[AgentHost] Using provider:', this.currentProvider);
   }
 
   /**
@@ -451,7 +452,7 @@ export class AgentHost {
   private handleSessionEvent(event: AgentSessionEvent): void {
     // Check for API errors that need failover handling (async, errors logged internally)
     void this.handlePotentialError(event).catch((err) => {
-      console.error('[AgentHost] handlePotentialError threw unexpectedly:', err);
+      log.error('[AgentHost] handlePotentialError threw unexpectedly:', err);
     });
 
     // Track busy state from agent activity
@@ -518,14 +519,14 @@ export class AgentHost {
     this.lastTurnErrored = true;
 
     const errorMessage = message.errorMessage;
-    console.log('[AgentHost] API error detected:', errorMessage);
+    log.info('[AgentHost] API error detected:', errorMessage);
 
     // Categorize the error and build human-readable prefix for chat messages
     const category = categorizeError({ message: errorMessage });
     const statusCode = extractStatusCode({ message: errorMessage });
     const label = categoryLabel(category);
     const errorPrefix = statusCode ? `${statusCode} ${label}` : label;
-    console.log('[AgentHost] Error category:', category);
+    log.info('[AgentHost] Error category:', category);
 
     // Get retry key for this error type
     const retryKey = `${this.currentProvider}:${category}`;
@@ -555,7 +556,7 @@ export class AgentHost {
           nextProvider === this.currentProvider
             ? `on ${this.currentProvider}, rotating to next key`
             : `on ${this.currentProvider} (key already in cooldown), switching to ${nextProvider}`;
-        console.log(
+        log.info(
           `[AgentHost] Key ${this.currentProvider}:${this.currentKeyIndex} already in cooldown`
         );
         await this.reinitializeWithProvider(
@@ -572,9 +573,7 @@ export class AgentHost {
     // Check if we should retry
     if (shouldRetry(category, currentAttempts)) {
       const delay = calculateDelay(currentAttempts);
-      console.log(
-        `[AgentHost] Retrying in ${Math.round(delay)}ms (attempt ${currentAttempts + 1})`
-      );
+      log.info(`[AgentHost] Retrying in ${Math.round(delay)}ms (attempt ${currentAttempts + 1})`);
 
       this.retryAttempts.set(retryKey, currentAttempts + 1);
 
@@ -583,14 +582,14 @@ export class AgentHost {
 
       // Retry the pending prompt if there is one
       if (promptToRetry && this.session) {
-        console.log('[AgentHost] Retrying prompt...');
+        log.info('[AgentHost] Retrying prompt...');
         // Restore only if nothing newer arrived during sleep — a new prompt() call during the
         // delay would have set pendingPrompt to the newer message; don't overwrite it.
         this.pendingPrompt = this.pendingPrompt ?? promptToRetry;
         try {
           await this.resourceLoader?.reload();
         } catch (reloadErr) {
-          console.warn(
+          log.warn(
             '[AgentHost] Resource reload failed before prompt retry, using cached:',
             reloadErr
           );
@@ -603,14 +602,14 @@ export class AgentHost {
       // Without this, deliveries beyond [0] stay in pendingDeliveries forever
       // and their promises never resolve, blocking trackJobExecution.
       if (deliveriesToRetry.length > 0 && this.session) {
-        console.log(
+        log.info(
           `[AgentHost] Resending ${deliveriesToRetry.length} pending delivery(ies) after retry...`
         );
         if (!promptToRetry) {
           try {
             await this.resourceLoader?.reload();
           } catch (reloadErr) {
-            console.warn(
+            log.warn(
               '[AgentHost] Resource reload failed before delivery retry, using cached:',
               reloadErr
             );
@@ -635,7 +634,7 @@ export class AgentHost {
               this.deliverySendCount++;
             })
             .catch((error) => {
-              console.error('[AgentHost] Failed to resend delivery after retry:', error);
+              log.error('[AgentHost] Failed to resend delivery after retry:', error);
               const idx = this.pendingDeliveries.indexOf(d);
               if (idx !== -1) this.pendingDeliveries.splice(idx, 1);
               d.reject(error instanceof Error ? error : new Error(String(error)));
@@ -668,7 +667,7 @@ export class AgentHost {
           if (nextProvider === this.currentProvider) {
             const reason = `${errorPrefix}, rotating to next key`;
             const detail = `on ${this.currentProvider}, rotating to next key`;
-            console.log(`[AgentHost] Rotating to next key for ${this.currentProvider}`);
+            log.info(`[AgentHost] Rotating to next key for ${this.currentProvider}`);
             await this.reinitializeWithProvider(
               nextProvider,
               promptToRetry,
@@ -686,7 +685,7 @@ export class AgentHost {
 
             const reason = `${errorPrefix}, switched to ${nextProvider}`;
             const detail = `on ${fromProvider}, switching to ${nextProvider}`;
-            console.log(`[AgentHost] Failing over from ${fromProvider} to ${nextProvider}`);
+            log.info(`[AgentHost] Failing over from ${fromProvider} to ${nextProvider}`);
             await this.reinitializeWithProvider(
               nextProvider,
               promptToRetry,
@@ -702,7 +701,7 @@ export class AgentHost {
       this.pushSystemMessage(
         `${errorPrefix}, all providers unavailable\n\non ${this.currentProvider}, all providers unavailable`
       );
-      console.log('[AgentHost] No fallback providers available, error will be surfaced to user');
+      log.info('[AgentHost] No fallback providers available, error will be surfaced to user');
     }
 
     // Context overflow: truncate JSONL, compact, restore tail, reinitialize.
@@ -738,10 +737,7 @@ export class AgentHost {
                 this.deliverySendCount++;
               })
               .catch((error) => {
-                console.error(
-                  '[AgentHost] Failed to replay delivery after context overflow:',
-                  error
-                );
+                log.error('[AgentHost] Failed to replay delivery after context overflow:', error);
                 const idx = this.pendingDeliveries.indexOf(delivery);
                 if (idx !== -1) this.pendingDeliveries.splice(idx, 1);
                 delivery.reject(error instanceof Error ? error : new Error(String(error)));
@@ -766,7 +762,7 @@ export class AgentHost {
 
       const reason = `${errorPrefix}, switched to ${nextProvider}`;
       const detail = `on ${fromProvider}, switching to ${nextProvider}`;
-      console.log(`[AgentHost] Recovery: switching from ${fromProvider} to ${nextProvider}`);
+      log.info(`[AgentHost] Recovery: switching from ${fromProvider} to ${nextProvider}`);
       await this.reinitializeWithProvider(
         nextProvider,
         promptToRetry,
@@ -811,12 +807,12 @@ export class AgentHost {
     detail?: string
   ): Promise<void> {
     if (this.isReinitializing) {
-      console.log('[AgentHost] Already reinitializing, skipping');
+      log.info('[AgentHost] Already reinitializing, skipping');
       return;
     }
 
     this.isReinitializing = true;
-    console.log(`[AgentHost] Reinitializing with provider: ${provider}`);
+    log.info(`[AgentHost] Reinitializing with provider: ${provider}`);
 
     // Old session is dead; clear busy so the agent doesn't appear stuck
     if (this.busy) {
@@ -866,7 +862,7 @@ export class AgentHost {
 
       // Retry the pending prompt with the new provider
       if (promptToRetry && this.session) {
-        console.log('[AgentHost] Retrying prompt with new provider...');
+        log.info('[AgentHost] Retrying prompt with new provider...');
         // Restore only if nothing newer arrived during reinitialization.
         this.pendingPrompt = this.pendingPrompt ?? promptToRetry;
         await this.session.prompt(promptToRetry, { streamingBehavior: 'followUp' });
@@ -877,7 +873,7 @@ export class AgentHost {
       // Uses sendCustomMessage directly (not deliverMessage) to avoid duplicating
       // chat cache entries that were already added by the original delivery.
       if (deliveriesToRetry && deliveriesToRetry.length > 0 && this.session) {
-        console.log(
+        log.info(
           `[AgentHost] Replaying ${deliveriesToRetry.length} pending deliveries with new provider...`
         );
         // Merge: deliveries queued by concurrent deliverMessage() during async
@@ -906,7 +902,7 @@ export class AgentHost {
               this.deliverySendCount++;
             })
             .catch((error) => {
-              console.error('[AgentHost] Failed to replay delivery after failover:', error);
+              log.error('[AgentHost] Failed to replay delivery after failover:', error);
               const idx = this.pendingDeliveries.indexOf(d);
               if (idx !== -1) this.pendingDeliveries.splice(idx, 1);
               d.reject(error instanceof Error ? error : new Error(String(error)));
@@ -914,7 +910,7 @@ export class AgentHost {
         }
       }
     } catch (error) {
-      console.error('[AgentHost] Failed to reinitialize:', error);
+      log.error('[AgentHost] Failed to reinitialize:', error);
       if (reason) {
         const msg = error instanceof Error ? error.message : String(error);
         this.pushSystemMessage(`Failed to switch provider\n\n${msg}`);
@@ -1026,7 +1022,7 @@ export class AgentHost {
     const braveKey = this.servicesConfig?.brave_search?.key;
     if (braveKey && this.toolsConfig?.web_search?.enabled !== false) {
       tools.push(createWebSearchTool(braveKey, this.toolsConfig?.web_search?.max_results));
-      console.log('[AgentHost] web_search tool enabled');
+      log.info('[AgentHost] web_search tool enabled');
     }
 
     // All agents can show artifacts — any agent can now interact with the user directly
@@ -1179,7 +1175,7 @@ export class AgentHost {
     const reload = this.resourceLoader
       ? this.resourceLoader
           .reload()
-          .catch((err) => console.warn('[AgentHost] reload failed, using cached knowledge:', err))
+          .catch((err) => log.warn('[AgentHost] reload failed, using cached knowledge:', err))
       : Promise.resolve();
 
     reload
@@ -1206,7 +1202,7 @@ export class AgentHost {
         this.deliverySendCount++;
       })
       .catch((err) => {
-        console.error('[AgentHost] deliverMessage error:', err);
+        log.error('[AgentHost] deliverMessage error:', err);
         // Send itself failed (session destroyed, etc.). The message never
         // reached the agent, so remove from queue and reject immediately.
         const idx = this.pendingDeliveries.findIndex((d) => d.resolve === resolve);
@@ -1307,7 +1303,7 @@ export class AgentHost {
       if (usage?.percent != null && usage.percent >= 30) {
         this.isPruning = true;
         this.triggerPruningCompaction()
-          .catch((err: unknown) => console.error('[AgentHost] Pruning compaction error:', err))
+          .catch((err: unknown) => log.error('[AgentHost] Pruning compaction error:', err))
           .finally(() => {
             this.isPruning = false;
           });
@@ -1348,7 +1344,7 @@ export class AgentHost {
 
     const baseline = this.findBaselineSummary();
     if (!baseline) {
-      console.log('[AgentHost] No baseline found for pruning, skipping');
+      log.info('[AgentHost] No baseline found for pruning, skipping');
       return;
     }
 
@@ -1366,7 +1362,7 @@ export class AgentHost {
     await this.session.compact(customInstructions);
     this.compactionCount = 0;
     this.writeCompactionCount(0);
-    console.log(`[AgentHost] Pruning compaction completed for agent ${this.agentId}`);
+    log.info(`[AgentHost] Pruning compaction completed for agent ${this.agentId}`);
   }
 
   /**
@@ -1462,7 +1458,7 @@ export class AgentHost {
     if (currentUsage?.tokens == null) return;
 
     if (currentUsage.tokens > candidateModel.contextWindow) {
-      console.log(
+      log.info(
         `[AgentHost] Context (${currentUsage.tokens} tokens) exceeds ${provider}/${candidateModelId} ` +
           `window (${candidateModel.contextWindow}), compacting before failover`
       );
@@ -1490,11 +1486,11 @@ export class AgentHost {
   ): Promise<boolean> {
     const sessionDir = this.sessionDir;
     if (!this.session || !sessionDir) {
-      console.log('[AgentHost] Context overflow: no session or sessionDir, cannot recover');
+      log.info('[AgentHost] Context overflow: no session or sessionDir, cannot recover');
       return false;
     }
 
-    console.log('[AgentHost] Starting context overflow recovery...');
+    log.info('[AgentHost] Starting context overflow recovery...');
 
     // Hoisted so the catch block can restore the tail if recovery fails mid-way
     let activeFile: string | undefined;
@@ -1513,7 +1509,7 @@ export class AgentHost {
         .sort((a, b) => b.mtime - a.mtime);
 
       if (jsonlFiles.length === 0) {
-        console.log('[AgentHost] Context overflow: no JSONL files found');
+        log.info('[AgentHost] Context overflow: no JSONL files found');
         return false;
       }
 
@@ -1544,14 +1540,14 @@ export class AgentHost {
       }
 
       if (splitIndex === -1) {
-        console.log('[AgentHost] Context overflow: no safe split point found');
+        log.info('[AgentHost] Context overflow: no safe split point found');
         return false;
       }
 
       // Step 3: Split into head and tail
       const headLines = lines.slice(0, splitIndex + 1);
       tailLines = lines.slice(splitIndex + 1);
-      console.log(
+      log.info(
         `[AgentHost] Context overflow: split at line ${splitIndex + 1}, tail has ${tailLines.length} entries`
       );
 
@@ -1568,34 +1564,34 @@ export class AgentHost {
 
       // Step 6: Compact to reduce head context to ~5%
       if (this.session) {
-        console.log('[AgentHost] Context overflow: compacting...');
+        log.info('[AgentHost] Context overflow: compacting...');
         await this.session.compact();
         // Synthesize compaction_end so the pruning counter stays accurate
         this.handleCompactionTracking({ type: 'compaction_end' });
-        console.log('[AgentHost] Context overflow: compaction complete');
+        log.info('[AgentHost] Context overflow: compaction complete');
       }
 
       // Step 7: Append tail and reinitialize — session loads compact summary + tail
       if (tailLines.length > 0) {
         appendFileSync(activeFile, `${tailLines.join('\n')}\n`, 'utf-8');
         tailAppended = true;
-        console.log('[AgentHost] Context overflow: tail restored, reinitializing...');
+        log.info('[AgentHost] Context overflow: tail restored, reinitializing...');
         await this.reinitializeWithProvider(provider, null);
       }
 
-      console.log('[AgentHost] Context overflow recovery complete');
+      log.info('[AgentHost] Context overflow recovery complete');
       // Re-arm guard so future overflows on this session can recover again
       this.contextOverflowHandled = false;
       return true;
     } catch (error) {
-      console.error('[AgentHost] Context overflow recovery failed:', error);
+      log.error('[AgentHost] Context overflow recovery failed:', error);
       // Best-effort: if the file was truncated but the tail was not yet appended,
       // restore the tail so no history is permanently lost. Skip if tail was
       // already written to avoid duplicating entries.
       if (fileTruncated && !tailAppended && tailLines.length > 0 && activeFile) {
         try {
           appendFileSync(activeFile, `${tailLines.join('\n')}\n`, 'utf-8');
-          console.log('[AgentHost] Context overflow: tail restored after recovery failure');
+          log.info('[AgentHost] Context overflow: tail restored after recovery failure');
         } catch {
           // Ignore — best-effort only
         }

--- a/packages/server/src/agents/session-rotation.ts
+++ b/packages/server/src/agents/session-rotation.ts
@@ -8,6 +8,7 @@
 import { randomUUID } from 'node:crypto';
 import { readdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
+import { log } from '../utils/logger.js';
 
 const SESSION_FILE_SIZE_LIMIT = 10 * 1024 * 1024; // 10MB
 
@@ -143,21 +144,21 @@ export function rotateSessionIfNeeded(
     return false;
   }
 
-  console.log(
+  log.info(
     `[SessionRotation] File size ${(stat.size / 1024 / 1024).toFixed(2)}MB exceeds threshold, rotating...`
   );
 
   // Parse entries
   const entries = parseSessionEntries(currentFile);
   if (entries.length === 0) {
-    console.log('[SessionRotation] No entries found, skipping rotation');
+    log.info('[SessionRotation] No entries found, skipping rotation');
     return false;
   }
 
   // Find compaction entry
   const compaction = findLastCompaction(entries);
   if (!compaction) {
-    console.log(
+    log.info(
       '[SessionRotation] No compaction found, SDK will compact naturally. Skipping rotation.'
     );
     return false;
@@ -167,16 +168,14 @@ export function rotateSessionIfNeeded(
   const firstKeptEntryId = compactionEntry.firstKeptEntryId;
 
   if (!firstKeptEntryId) {
-    console.log('[SessionRotation] Compaction has no firstKeptEntryId, skipping rotation');
+    log.info('[SessionRotation] Compaction has no firstKeptEntryId, skipping rotation');
     return false;
   }
 
   // Find index of firstKeptEntryId
   const firstKeptIndex = entries.findIndex((e) => e.id === firstKeptEntryId);
   if (firstKeptIndex === -1) {
-    console.log(
-      `[SessionRotation] firstKeptEntryId ${firstKeptEntryId} not found, skipping rotation`
-    );
+    log.info(`[SessionRotation] firstKeptEntryId ${firstKeptEntryId} not found, skipping rotation`);
     return false;
   }
 
@@ -213,10 +212,10 @@ export function rotateSessionIfNeeded(
   const archivedPath = `${currentFile}.archived`;
   renameSync(currentFile, archivedPath);
 
-  console.log(
+  log.info(
     `[SessionRotation] Created new session file: ${newFilename} with ${newEntries.length} entries`
   );
-  console.log(`[SessionRotation] Old file archived: ${basename(currentFile)}.archived`);
+  log.info(`[SessionRotation] Old file archived: ${basename(currentFile)}.archived`);
 
   return true;
 }

--- a/packages/server/src/agents/tools/message-agent.ts
+++ b/packages/server/src/agents/tools/message-agent.ts
@@ -9,6 +9,7 @@
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { Type } from '@sinclair/typebox';
 import type { DatabaseClient } from '../../db/client.js';
+import { log } from '../../utils/logger.js';
 import type { AgentRegistry } from '../registry.js';
 
 export function createMessageAgentTool(
@@ -88,7 +89,7 @@ export function createMessageAgentTool(
       try {
         receiverHost
           .deliverMessage(content, { sender: selfId, receiver: agent_id, timestamp }, urgent)
-          .catch((err) => console.error('[message-agent] delivery failed:', err));
+          .catch((err) => log.error('[message-agent] delivery failed:', err));
 
         return {
           content: [

--- a/packages/server/src/agents/tools/trigger-project-story.ts
+++ b/packages/server/src/agents/tools/trigger-project-story.ts
@@ -26,6 +26,7 @@ import {
   readFrontmatterField,
   readTailChars,
 } from '../../scheduler/jobs.js';
+import { log } from '../../utils/logger.js';
 import type { AgentRegistry } from '../registry.js';
 
 const SYSTEM2_DIR = join(homedir(), '.system2');
@@ -187,7 +188,7 @@ ${projectDbChanges}`;
             receiver: narratorId,
             timestamp: Date.now(),
           })
-          .catch((err) => console.error('[trigger-project-story] log delivery failed:', err));
+          .catch((err) => log.error('[trigger-project-story] log delivery failed:', err));
 
         // --- Message 2: Project story data ---
         // Full app.db snapshot (not time-windowed)
@@ -260,7 +261,7 @@ ${logContent}`;
             receiver: narratorId,
             timestamp: Date.now(),
           })
-          .catch((err) => console.error('[trigger-project-story] story delivery failed:', err));
+          .catch((err) => log.error('[trigger-project-story] story delivery failed:', err));
 
         return {
           content: [

--- a/packages/server/src/chat/summarizer.ts
+++ b/packages/server/src/chat/summarizer.ts
@@ -12,6 +12,7 @@ import type { Api, Model } from '@mariozechner/pi-ai';
 import type { ModelRegistry } from '@mariozechner/pi-coding-agent';
 import type { AgentHost } from '../agents/host.js';
 import { oneShotComplete } from '../llm/oneshot.js';
+import { log } from '../utils/logger.js';
 
 export interface BufferedEvent {
   type: 'user_message' | 'thinking' | 'tool_call' | 'assistant_reply';
@@ -139,9 +140,9 @@ export class ConversationSummarizer {
           receiver: this.guideAgentId,
           timestamp: Date.now(),
         })
-        .catch((err) => console.error('[ConversationSummarizer] delivery failed:', err));
+        .catch((err) => log.error('[ConversationSummarizer] delivery failed:', err));
     } catch (err) {
-      console.error('[ConversationSummarizer] Failed to generate summary:', err);
+      log.error('[ConversationSummarizer] Failed to generate summary:', err);
     }
 
     // Start new timer only if: additional messages existed in the window AND no timer was

--- a/packages/server/src/knowledge/git.ts
+++ b/packages/server/src/knowledge/git.ts
@@ -8,6 +8,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { log } from '../utils/logger.js';
 
 const GITIGNORE_CONTENT = `# Database (binary, use SQL timestamps for change detection)
 app.db
@@ -62,5 +63,5 @@ export function initializeGitRepo(system2Dir: string): void {
     stdio: 'ignore',
   });
 
-  console.log('[Knowledge] Initialized git repository in', system2Dir);
+  log.info('[Knowledge] Initialized git repository in', system2Dir);
 }

--- a/packages/server/src/knowledge/init.ts
+++ b/packages/server/src/knowledge/init.ts
@@ -7,6 +7,7 @@
 
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { log } from '../utils/logger.js';
 import {
   CONDUCTOR_TEMPLATE,
   createMemoryTemplate,
@@ -55,7 +56,7 @@ export function initializeKnowledge(system2Dir: string): void {
   for (const [filePath, content] of templates) {
     if (!existsSync(filePath)) {
       writeFileSync(filePath, content, 'utf-8');
-      console.log(`[Knowledge] Created ${filePath}`);
+      log.info(`[Knowledge] Created ${filePath}`);
     }
   }
 }

--- a/packages/server/src/reminders/manager.test.ts
+++ b/packages/server/src/reminders/manager.test.ts
@@ -128,7 +128,10 @@ describe('ReminderManager', () => {
     manager.schedule(1, 'orphaned reminder', 5);
     vi.advanceTimersByTime(5 * 60_000);
 
-    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Agent 1 not active'));
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.stringContaining('Agent 1 not active')
+    );
     warnSpy.mockRestore();
   });
 

--- a/packages/server/src/reminders/manager.ts
+++ b/packages/server/src/reminders/manager.ts
@@ -7,6 +7,7 @@
  */
 
 import type { AgentRegistry } from '../agents/registry.js';
+import { log } from '../utils/logger.js';
 
 export interface PendingReminder {
   id: number;
@@ -79,7 +80,7 @@ export class ReminderManager {
 
     const host = this.registry.get(reminder.agentId);
     if (!host) {
-      console.warn(
+      log.warn(
         `[ReminderManager] Agent ${reminder.agentId} not active, dropping reminder #${reminderId}`
       );
       return;
@@ -88,6 +89,6 @@ export class ReminderManager {
     const content = `[Reminder #${reminderId}]\n\n${reminder.message}`;
     host
       .deliverMessage(content, { sender: 0, receiver: reminder.agentId, timestamp: Date.now() })
-      .catch((err) => console.error('[ReminderManager] delivery failed:', err));
+      .catch((err) => log.error('[ReminderManager] delivery failed:', err));
   }
 }

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -14,6 +14,7 @@ import type { JobExecution } from '@dscarabelli/shared';
 import type { AgentHost } from '../agents/host.js';
 import type { DatabaseClient } from '../db/client.js';
 import { resolveProjectDir } from '../projects/dir.js';
+import { log } from '../utils/logger.js';
 import { isNetworkAvailable } from './network.js';
 import type { Scheduler } from './scheduler.js';
 
@@ -791,7 +792,7 @@ export function registerNarratorJobs(
         if (!(await isNetworkAvailable())) {
           throw new JobSkipped('no network connectivity');
         }
-        console.log('[Scheduler] Triggering daily-summary job (project logs + daily summary)');
+        log.info('[Scheduler] Triggering daily-summary job (project logs + daily summary)');
         await buildAndDeliverDailySummary(
           db,
           narratorHost,
@@ -814,7 +815,7 @@ export function registerNarratorJobs(
         if (!(await isNetworkAvailable())) {
           throw new JobSkipped('no network connectivity');
         }
-        console.log('[Scheduler] Triggering memory-update job');
+        log.info('[Scheduler] Triggering memory-update job');
         await buildAndDeliverMemoryUpdate(
           narratorHost,
           narratorId,

--- a/packages/server/src/scheduler/scheduler.ts
+++ b/packages/server/src/scheduler/scheduler.ts
@@ -9,6 +9,7 @@
  */
 
 import { Cron } from 'croner';
+import { log } from '../utils/logger.js';
 
 interface ScheduledJob {
   name: string;
@@ -27,7 +28,7 @@ export class Scheduler {
   schedule(name: string, pattern: string, handler: () => void | Promise<void>): void {
     const cron = new Cron(pattern, handler);
     this.jobs.push({ name, cron });
-    console.log(`[Scheduler] Registered job "${name}" with pattern "${pattern}"`);
+    log.info(`[Scheduler] Registered job "${name}" with pattern "${pattern}"`);
   }
 
   /**
@@ -36,7 +37,7 @@ export class Scheduler {
   stop(): void {
     for (const job of this.jobs) {
       job.cron.stop();
-      console.log(`[Scheduler] Stopped job "${job.name}"`);
+      log.info(`[Scheduler] Stopped job "${job.name}"`);
     }
     this.jobs = [];
   }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -46,6 +46,7 @@ import {
 } from './scheduler/jobs.js';
 import { isNetworkAvailable } from './scheduler/network.js';
 import { Scheduler } from './scheduler/scheduler.js';
+import { log } from './utils/logger.js';
 import { WebSocketHandler } from './websocket/handler.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -354,7 +355,7 @@ export class Server {
 
     // Handle WebSocket connections
     this.wss.on('connection', (ws) => {
-      console.log('Client connected');
+      log.info('Client connected');
       new WebSocketHandler(
         ws,
         this.agentRegistry,
@@ -420,7 +421,7 @@ export class Server {
           receiver: newAgent.id,
           timestamp: Date.now(),
         })
-        .catch((err) => console.error('[Server] spawner delivery failed:', err));
+        .catch((err) => log.error('[Server] spawner delivery failed:', err));
 
       return newAgent.id;
     };
@@ -445,7 +446,7 @@ export class Server {
           receiver: agentId,
           timestamp: Date.now(),
         })
-        .catch((err) => console.error('[Server] resurrector delivery failed:', err));
+        .catch((err) => log.error('[Server] resurrector delivery failed:', err));
     };
   }
 
@@ -475,10 +476,10 @@ export class Server {
         );
         // Subscribe non-Guide agents for summarizer event capture
         this.subscribeForSummarizerCapture(this.narratorHost);
-        console.log('[Server] Conversation summarizer initialized');
+        log.info('[Server] Conversation summarizer initialized');
       }
     } catch (err) {
-      console.warn('[Server] Failed to initialize conversation summarizer:', err);
+      log.warn('[Server] Failed to initialize conversation summarizer:', err);
     }
 
     // Restore previously active spawned agents (conductors, reviewers, etc.)
@@ -487,7 +488,7 @@ export class Server {
     // Mark any stale 'running' job executions from a previous crash as failed
     const staleCount = this.db.failStaleJobExecutions('server shutdown');
     if (staleCount > 0) {
-      console.log(`[Server] Recovered ${staleCount} stale job execution(s) from previous process`);
+      log.info(`[Server] Recovered ${staleCount} stale job execution(s) from previous process`);
     }
 
     // Start scheduled jobs
@@ -507,12 +508,12 @@ export class Server {
     // Check if narrator needs catch-up after sleep/shutdown.
     // Fire-and-forget: don't block the HTTP server from starting.
     this.checkNarratorCatchUp().catch((err) =>
-      console.error('[Server] Narrator catch-up failed:', err)
+      log.error('[Server] Narrator catch-up failed:', err)
     );
 
     // Graceful shutdown handlers
     const shutdown = async () => {
-      console.log('Shutting down...');
+      log.info('Shutting down...');
       await this.stop();
       process.exit(0);
     };
@@ -521,8 +522,8 @@ export class Server {
 
     return new Promise((resolve) => {
       this.httpServer.listen(this.config.port, () => {
-        console.log(`System2 Gateway running on http://localhost:${this.config.port}`);
-        console.log(`WebSocket server ready`);
+        log.info(`System2 Gateway running on http://localhost:${this.config.port}`);
+        log.info(`WebSocket server ready`);
         resolve();
       });
     });
@@ -534,7 +535,7 @@ export class Server {
    */
   private async checkNarratorCatchUp(): Promise<void> {
     if (!(await isNetworkAvailable())) {
-      console.log('[Server] No network connectivity, skipping narrator catch-up');
+      log.info('[Server] No network connectivity, skipping narrator catch-up');
       return;
     }
 
@@ -544,11 +545,11 @@ export class Server {
     // Daily summary catch-up
     const { lastRunTs } = resolveDailySummaryTimestamp(SYSTEM2_DIR, intervalMinutes);
     if (!lastRunTs) {
-      console.log('[Server] No daily summary timestamps found, skipping daily-summary catch-up');
+      log.info('[Server] No daily summary timestamps found, skipping daily-summary catch-up');
     } else {
       const staleness = Date.now() - new Date(lastRunTs).getTime();
       if (staleness > intervalMinutes * 60 * 1000) {
-        console.log(
+        log.info(
           `[Server] Daily summary stale by ${Math.round(staleness / 60000)} min, queuing catch-up`
         );
         try {
@@ -567,7 +568,7 @@ export class Server {
             onJobChange
           );
         } catch (error) {
-          console.error('[Server] Daily summary catch-up failed:', error);
+          log.error('[Server] Daily summary catch-up failed:', error);
         }
       }
     }
@@ -580,7 +581,7 @@ export class Server {
       const memoryStaleness = Date.now() - new Date(memoryTs).getTime();
       const ONE_DAY_MS = 24 * 60 * 60 * 1000;
       if (memoryStaleness > ONE_DAY_MS) {
-        console.log(
+        log.info(
           `[Server] Memory stale by ${Math.round(memoryStaleness / 3600000)}h, queuing memory-update catch-up`
         );
         try {
@@ -598,7 +599,7 @@ export class Server {
             onJobChange
           );
         } catch (error) {
-          console.error('[Server] Memory update catch-up failed:', error);
+          log.error('[Server] Memory update catch-up failed:', error);
         }
       }
     }
@@ -614,14 +615,14 @@ export class Server {
     ) as import('@dscarabelli/shared').Agent[];
     if (agents.length === 0) return;
 
-    console.log(`[Server] Restoring ${agents.length} agent(s)...`);
+    log.info(`[Server] Restoring ${agents.length} agent(s)...`);
 
     for (const agent of agents) {
       try {
         await this.initializeAgentHost(agent.id);
-        console.log(`[Server] Restored ${agent.role} agent (id=${agent.id})`);
+        log.info(`[Server] Restored ${agent.role} agent (id=${agent.id})`);
       } catch (error) {
-        console.error(`[Server] Failed to restore ${agent.role} agent (id=${agent.id}):`, error);
+        log.error(`[Server] Failed to restore ${agent.role} agent (id=${agent.id}):`, error);
 
         // Notify the Guide about the restore failure (agent stays active in DB)
         const errorMsg =
@@ -634,7 +635,7 @@ export class Server {
             receiver: this.agentHost.agentId,
             timestamp: Date.now(),
           })
-          .catch((err) => console.error('[Server] restore error delivery failed:', err));
+          .catch((err) => log.error('[Server] restore error delivery failed:', err));
       }
     }
   }
@@ -649,7 +650,7 @@ export class Server {
     const narratorPath = join(agentDir, 'library', 'narrator.md');
 
     if (!existsSync(narratorPath)) {
-      console.warn('[Server] Narrator definition not found at', narratorPath);
+      log.warn('[Server] Narrator definition not found at', narratorPath);
       return null;
     }
 
@@ -667,7 +668,7 @@ export class Server {
       }
     }
 
-    console.warn('[Server] No narrator model found for any configured provider');
+    log.warn('[Server] No narrator model found for any configured provider');
     return null;
   }
 

--- a/packages/server/src/utils/logger.test.ts
+++ b/packages/server/src/utils/logger.test.ts
@@ -43,6 +43,7 @@ describe('log', () => {
 
   it('passes through multiple arguments', () => {
     log.info('a', 'b', 3, { key: 'val' });
+    expect(logSpy).toHaveBeenCalledOnce();
     const [_timestamp, ...rest] = logSpy.mock.calls[0];
     expect(rest).toEqual(['a', 'b', 3, { key: 'val' }]);
   });

--- a/packages/server/src/utils/logger.test.ts
+++ b/packages/server/src/utils/logger.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { log } from './logger.js';
+
+describe('log', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('log.info prepends an ISO timestamp', () => {
+    log.info('[Server] started');
+    expect(logSpy).toHaveBeenCalledOnce();
+    const [timestamp, ...rest] = logSpy.mock.calls[0];
+    expect(timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(rest).toEqual(['[Server] started']);
+  });
+
+  it('log.warn prepends an ISO timestamp', () => {
+    log.warn('[Server] degraded');
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const [timestamp, ...rest] = warnSpy.mock.calls[0];
+    expect(timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(rest).toEqual(['[Server] degraded']);
+  });
+
+  it('log.error prepends an ISO timestamp', () => {
+    const err = new Error('boom');
+    log.error('[Server] fail:', err);
+    expect(errorSpy).toHaveBeenCalledOnce();
+    const [timestamp, ...rest] = errorSpy.mock.calls[0];
+    expect(timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(rest).toEqual(['[Server] fail:', err]);
+  });
+
+  it('passes through multiple arguments', () => {
+    log.info('a', 'b', 3, { key: 'val' });
+    const [_timestamp, ...rest] = logSpy.mock.calls[0];
+    expect(rest).toEqual(['a', 'b', 3, { key: 'val' }]);
+  });
+});

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -1,0 +1,14 @@
+/**
+ * Timestamped logger that prepends ISO timestamps to all output.
+ *
+ * Usage:
+ *   import { log } from './utils/logger.js';
+ *   log.info('[Server] started');   // 2026-03-26T14:30:05.123Z [Server] started
+ *   log.error('[Server] fail:', e); // 2026-03-26T14:30:05.456Z [Server] fail: Error: ...
+ */
+
+export const log = {
+  info: (...args: unknown[]) => console.log(new Date().toISOString(), ...args),
+  warn: (...args: unknown[]) => console.warn(new Date().toISOString(), ...args),
+  error: (...args: unknown[]) => console.error(new Date().toISOString(), ...args),
+};

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -2,7 +2,7 @@
  * Timestamped logger that prepends ISO timestamps to all output.
  *
  * Usage:
- *   import { log } from './utils/logger.js';
+ *   import { log } from './logger.js';
  *   log.info('[Server] started');   // 2026-03-26T14:30:05.123Z [Server] started
  *   log.error('[Server] fail:', e); // 2026-03-26T14:30:05.456Z [Server] fail: Error: ...
  */

--- a/packages/server/src/utils/logger.ts
+++ b/packages/server/src/utils/logger.ts
@@ -2,7 +2,6 @@
  * Timestamped logger that prepends ISO timestamps to all output.
  *
  * Usage:
- *   import { log } from './logger.js';
  *   log.info('[Server] started');   // 2026-03-26T14:30:05.123Z [Server] started
  *   log.error('[Server] fail:', e); // 2026-03-26T14:30:05.456Z [Server] fail: Error: ...
  */

--- a/packages/server/src/websocket/handler.ts
+++ b/packages/server/src/websocket/handler.ts
@@ -14,6 +14,7 @@ import type { WebSocket, WebSocketServer } from 'ws';
 import type { AgentHost } from '../agents/host.js';
 import type { AgentRegistry } from '../agents/registry.js';
 import type { ConversationSummarizer } from '../chat/summarizer.js';
+import { log } from '../utils/logger.js';
 
 export class WebSocketHandler {
   private ws: WebSocket;
@@ -66,7 +67,7 @@ export class WebSocketHandler {
         const message = JSON.parse(data.toString()) as ClientMessage;
         this.handleClientMessage(message);
       } catch (error) {
-        console.error('Failed to parse client message:', error);
+        log.error('Failed to parse client message:', error);
         this.sendError('Invalid message format');
       }
     });
@@ -77,7 +78,7 @@ export class WebSocketHandler {
     });
 
     ws.on('error', (error) => {
-      console.error('WebSocket error:', error);
+      log.error('WebSocket error:', error);
       this.cleanup();
     });
   }
@@ -139,7 +140,7 @@ export class WebSocketHandler {
         host
           .prompt(message.content, isSteering ? { isSteering: true } : undefined)
           .catch((error) => {
-            console.error('Agent prompt failed:', error);
+            log.error('Agent prompt failed:', error);
             this.sendError('Failed to process message');
           });
         break;
@@ -300,7 +301,7 @@ export class WebSocketHandler {
           const details = event.result?.details as
             | { url?: string; absolutePath?: string; title?: string }
             | undefined;
-          console.log('[WebSocket] show_artifact result:', JSON.stringify(event.result));
+          log.info('[WebSocket] show_artifact result:', JSON.stringify(event.result));
           if (details?.url && details?.absolutePath) {
             this.send({
               type: 'artifact',
@@ -310,7 +311,7 @@ export class WebSocketHandler {
             });
             this.watchArtifact(details.url, details.absolutePath);
           } else {
-            console.warn('[WebSocket] show_artifact missing details:', details);
+            log.warn('[WebSocket] show_artifact missing details:', details);
           }
         }
         break;
@@ -318,7 +319,7 @@ export class WebSocketHandler {
 
       case 'agent_end': {
         // Agent finished processing
-        console.log(
+        log.info(
           'Agent finished. Stop reason:',
           (host.state as unknown as Record<string, unknown>).stopReason
         );
@@ -350,7 +351,7 @@ export class WebSocketHandler {
 
       default:
         // Log other events for debugging
-        console.log('Agent event:', event.type);
+        log.info('Agent event:', event.type);
     }
   }
 
@@ -382,25 +383,25 @@ export class WebSocketHandler {
     }
 
     this.artifactUrl = url;
-    console.log('[WebSocket] Watching artifact:', absolutePath);
+    log.info('[WebSocket] Watching artifact:', absolutePath);
 
     try {
       this.artifactWatcher = watch(absolutePath, (eventType, filename) => {
-        console.log('[WebSocket] fs.watch event:', eventType, filename);
+        log.info('[WebSocket] fs.watch event:', eventType, filename);
         if (eventType === 'change') {
           // Cache-bust so the iframe actually reloads (use & since URL already has ?path=)
           const separator = this.artifactUrl?.includes('?') ? '&' : '?';
           const bustUrl = `${this.artifactUrl}${separator}t=${Date.now()}`;
-          console.log('[WebSocket] Sending artifact reload:', bustUrl);
+          log.info('[WebSocket] Sending artifact reload:', bustUrl);
           this.send({ type: 'artifact', url: bustUrl, filePath: absolutePath });
         }
       });
 
       this.artifactWatcher.on('error', (err) => {
-        console.error('[WebSocket] Watcher error:', err);
+        log.error('[WebSocket] Watcher error:', err);
       });
     } catch (error) {
-      console.error('[WebSocket] Failed to watch artifact:', error);
+      log.error('[WebSocket] Failed to watch artifact:', error);
     }
   }
 


### PR DESCRIPTION
## Summary

- Introduce a thin `log` module (`packages/server/src/utils/logger.ts`) with `info`, `warn`, and `error` methods that prepend ISO timestamps to all output
- Replace all 105+ `console.log/error/warn` calls across 13 server source files with the new logger
- Update `manager.test.ts` to account for the timestamp argument in warn assertions

Every log line now looks like:
```
2026-04-12T03:50:04.384Z [Scheduler] Triggering daily-summary job
2026-04-12T03:50:26.661Z [SessionRotation] File size 0.00MB exceeds threshold, rotating...
```

Closes #52

## Test plan

- [x] New `logger.test.ts` with 4 tests covering info/warn/error timestamp format and multi-arg passthrough
- [x] All 563 existing tests pass (37 test files)
- [x] `pnpm check` clean (no new lint/format issues)
- [x] `pnpm build` succeeds
- [x] `pnpm typecheck` passes