### PR TITLE
feat: add heartbeat protocol and dual timeouts for bash tool

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -24,8 +24,18 @@ Execute shell commands with streaming output and optional background execution. 
 | `command` | string | Shell command to execute |
 | `cwd` | string? | Working directory (defaults to user home) |
 | `run_in_background` | boolean? | If true, return immediately and deliver output as a follow-up message on completion |
+| `inactivity_timeout_seconds` | number? | Inactivity timeout in seconds (10-600, default 60). Resets on every stdout/stderr output. Only takes effect when explicitly provided. |
+| `total_timeout_seconds` | number? | Total wall-clock timeout in seconds (10-600, default 600). Hard cap, never resets. Only takes effect when explicitly provided. |
 
-- **Timeout:** 120 seconds (foreground only; background commands have no timeout)
+- **Timeout (legacy):** 120 seconds fixed timeout when neither `inactivity_timeout_seconds` nor `total_timeout_seconds` is provided. Background commands have no timeout.
+- **Timeout (dual mode):** when either timeout parameter is provided, the tool uses dual timeouts: an inactivity timer that resets on every stdout/stderr data event, and a total timer that never resets. This allows long-running commands that produce regular output to run for up to 10 minutes.
+- **Heartbeat protocol:** scripts can emit `::system2:: <message>` lines on stdout to reset the inactivity timer and push progress updates to the UI. Sentinel lines are stripped from the output before it reaches the agent. Example:
+  ```bash
+  for i in $(seq 1 100); do
+    echo "::system2:: processing batch $i of 100"
+    process_batch "$i"
+  done
+  ```
 - **Output buffer:** 10MB
 - **Working directory:** user's home directory (overridable via `cwd`)
 - **Shell:** PowerShell (`powershell.exe`) on Windows, `/bin/bash` on macOS/Linux

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -46,6 +46,7 @@ type ServerMessage =
   | { type: 'assistant_end'; agentId?: number; errorMessage?: string }
   | { type: 'tool_call_start'; name: string; input?: string; agentId?: number }
   | { type: 'tool_call_end'; name: string; result: string; agentId?: number }
+  | { type: 'tool_call_progress'; name: string; message: string; agentId?: number }
   | { type: 'artifact'; url: string; title?: string; filePath?: string }
   | { type: 'context_usage'; percent: number | null; tokens: number | null; contextWindow: number; agentId?: number }
   | { type: 'provider_info'; provider: string; agentId: number }
@@ -69,6 +70,7 @@ type ServerMessage =
 | `thinking_chunk` / `thinking_end` | Streaming extended thinking blocks |
 | `assistant_chunk` / `assistant_end` | Streaming response text. `assistant_end` carries `errorMessage` when the LLM stop reason was an error; the UI renders it as a collapsible system message in the chat timeline. |
 | `tool_call_start` / `tool_call_end` | Tool execution lifecycle |
+| `tool_call_progress` | Heartbeat progress from a long-running tool (e.g., bash `::system2::` sentinel). Carries the progress `message` for UI display. |
 | `artifact` | Display artifact in a UI tab. Includes `title` (from DB or filename) and `filePath` (absolute path for tab dedup and reload targeting). Also sent on live reload (file watch). |
 | `context_usage` | Context window usage after each agent turn |
 | `provider_info` | Sent on connect/switch: current LLM provider for an agent |
@@ -165,6 +167,7 @@ Each WebSocket connection gets its own `WebSocketHandler` instance. It:
    - `message_update` (with text) -> `assistant_chunk`
    - `message_end` -> `assistant_end` (with `errorMessage` when `stopReason` is `'error'`)
    - `tool_execution_start` -> `tool_call_start`
+   - `tool_execution_update` (heartbeat only) -> `tool_call_progress`
    - `tool_execution_end` -> `tool_call_end`
    - `agent_end` -> `context_usage` + `ready_for_input`
 5. Captures user messages in the target agent's chat cache and broadcasts to other tabs

--- a/packages/server/src/agents/tools/bash.test.ts
+++ b/packages/server/src/agents/tools/bash.test.ts
@@ -394,6 +394,26 @@ describe('bash tool', () => {
       expect(content).toContain('completed');
     });
 
+    it('strips heartbeat sentinels from background output', async () => {
+      const notifyBackground = vi.fn();
+      const tool = createBashTool(notifyBackground);
+
+      await tool.execute('bg-hb', {
+        command: 'echo "data"; echo "::system2:: progress"; echo "more data"',
+        run_in_background: true,
+      } as BashParams);
+
+      await vi.waitFor(() => expect(notifyBackground).toHaveBeenCalledTimes(1), {
+        timeout: 5000,
+      });
+      // Check the details.stdout (not the full content string, which includes the command text)
+      const [, details] = notifyBackground.mock.calls[0];
+      const stdout = (details as { stdout: string }).stdout;
+      expect(stdout).toContain('data');
+      expect(stdout).toContain('more data');
+      expect(stdout).not.toContain('::system2::');
+    });
+
     it('falls through to foreground when no notifyBackground callback', async () => {
       const tool = createBashTool(); // no callback
       const result: BashResult = await tool.execute('fg-call', {

--- a/packages/server/src/agents/tools/bash.test.ts
+++ b/packages/server/src/agents/tools/bash.test.ts
@@ -4,7 +4,7 @@ import { platform, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AgentToolUpdateCallback } from '@mariozechner/pi-agent-core';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { BLOCKED_BASH_PATTERNS, createBashTool } from './bash.js';
+import { BLOCKED_BASH_PATTERNS, createBashTool, filterHeartbeats, HEARTBEAT_RE } from './bash.js';
 
 const isWindows = platform() === 'win32';
 
@@ -214,6 +214,161 @@ describe('bash tool', () => {
         expect(reason).toBeTruthy();
       }
     });
+  });
+
+  describe('heartbeat protocol', () => {
+    const tool = createBashTool();
+    const exec = (
+      params: Record<string, unknown>,
+      signal?: AbortSignal,
+      onUpdate?: AgentToolUpdateCallback<BashResult['details']>
+    ) => tool.execute('test-call', params as BashParams, signal, onUpdate);
+
+    it('strips heartbeat sentinel lines from stdout', async () => {
+      const cmd = 'echo "line1"; echo "::system2:: progress 1"; echo "line2"';
+      const result = await exec({ command: cmd, inactivity_timeout_seconds: 30 });
+
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('line1');
+      expect(text).toContain('line2');
+      expect(text).not.toContain('::system2::');
+      expect(text).not.toContain('progress 1');
+    });
+
+    it('emits heartbeat onUpdate with heartbeat detail', async () => {
+      const onUpdate = vi.fn();
+      const cmd = 'echo "::system2:: step 1 of 3"';
+      await exec({ command: cmd, inactivity_timeout_seconds: 30 }, undefined, onUpdate);
+
+      const heartbeatCalls = onUpdate.mock.calls.filter((args: unknown[]) => {
+        const update = args[0] as { details?: { heartbeat?: boolean } };
+        return update.details?.heartbeat === true;
+      });
+      expect(heartbeatCalls.length).toBeGreaterThanOrEqual(1);
+      const update = heartbeatCalls[0][0] as {
+        details: { heartbeat: boolean; heartbeatMessage: string };
+      };
+      expect(update.details.heartbeatMessage).toBe('step 1 of 3');
+    });
+
+    it('preserves non-heartbeat output alongside heartbeats', async () => {
+      const onUpdate = vi.fn();
+      const cmd = 'echo "before"; echo "::system2:: heartbeat"; echo "after"';
+      const result = await exec(
+        { command: cmd, inactivity_timeout_seconds: 30 },
+        undefined,
+        onUpdate
+      );
+
+      const stdout = (result.details as { stdout: string }).stdout;
+      expect(stdout).toContain('before');
+      expect(stdout).toContain('after');
+      expect(stdout).not.toContain('::system2::');
+    });
+  });
+
+  describe('filterHeartbeats', () => {
+    it('extracts heartbeat messages and filters sentinel lines', () => {
+      const input = 'line1\n::system2:: hello world\nline2\n';
+      const { filtered, heartbeats } = filterHeartbeats(input);
+
+      expect(filtered).toBe('line1\nline2\n');
+      expect(heartbeats).toEqual(['hello world']);
+    });
+
+    it('handles multiple heartbeats', () => {
+      const input = '::system2:: a\n::system2:: b\n';
+      const { filtered, heartbeats } = filterHeartbeats(input);
+
+      expect(filtered).toBe('');
+      expect(heartbeats).toEqual(['a', 'b']);
+    });
+
+    it('returns text unchanged when no heartbeats', () => {
+      const input = 'just normal output\n';
+      const { filtered, heartbeats } = filterHeartbeats(input);
+
+      expect(filtered).toBe('just normal output\n');
+      expect(heartbeats).toEqual([]);
+    });
+
+    it('handles empty heartbeat message', () => {
+      const { heartbeats } = filterHeartbeats('::system2::\n');
+      expect(heartbeats).toEqual(['']);
+    });
+  });
+
+  describe('HEARTBEAT_RE', () => {
+    it('matches sentinel with message', () => {
+      const match = HEARTBEAT_RE.exec('::system2:: processing batch 3');
+      expect(match).not.toBeNull();
+      expect(match?.[1]).toBe('processing batch 3');
+    });
+
+    it('matches sentinel without message', () => {
+      const match = HEARTBEAT_RE.exec('::system2::');
+      expect(match).not.toBeNull();
+      expect(match?.[1]).toBe('');
+    });
+
+    it('does not match partial sentinels', () => {
+      expect(HEARTBEAT_RE.test('some ::system2:: embedded')).toBe(false);
+    });
+  });
+
+  describe('dual timeouts', () => {
+    const tool = createBashTool();
+    const exec = (
+      params: Record<string, unknown>,
+      signal?: AbortSignal,
+      onUpdate?: AgentToolUpdateCallback<BashResult['details']>
+    ) => tool.execute('test-call', params as BashParams, signal, onUpdate);
+
+    it('uses legacy 120s behavior when no timeout params given', async () => {
+      // A fast command should succeed with default params (no timeout params)
+      const result = await exec({ command: 'echo legacy' });
+      expect((result.content[0] as { text: string }).text).toContain('legacy');
+      expect(result.details).toHaveProperty('exitCode', 0);
+    });
+
+    it('uses custom inactivity timeout', async () => {
+      // Command that sleeps longer than the inactivity timeout
+      const result = await exec({
+        command: 'sleep 15',
+        inactivity_timeout_seconds: 10,
+      });
+
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('inactivity');
+      expect((result.details as { exitCode: number }).exitCode).toBe(124);
+    }, 20_000);
+
+    it('uses custom total timeout', async () => {
+      // Command that emits output (resets inactivity) but exceeds total timeout
+      const cmd = 'for i in $(seq 1 20); do echo "tick $i"; sleep 1; done';
+      const result = await exec({
+        command: cmd,
+        inactivity_timeout_seconds: 30,
+        total_timeout_seconds: 10,
+      });
+
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain('total timeout');
+      expect((result.details as { exitCode: number }).exitCode).toBe(124);
+    }, 20_000);
+
+    it('active output prevents inactivity timeout', async () => {
+      // Command outputs every second for 3s with a 10s inactivity timeout
+      const cmd = 'for i in 1 2 3; do echo "ping $i"; sleep 1; done';
+      const result = await exec({
+        command: cmd,
+        inactivity_timeout_seconds: 10,
+        total_timeout_seconds: 30,
+      });
+
+      expect(result.details).toHaveProperty('exitCode', 0);
+      expect((result.details as { stdout: string }).stdout).toContain('ping 3');
+    }, 15_000);
   });
 
   describe('background execution', () => {

--- a/packages/server/src/agents/tools/bash.ts
+++ b/packages/server/src/agents/tools/bash.ts
@@ -195,23 +195,43 @@ function runCommand(
       fail(err);
     }, totalTimeout);
 
+    // Buffer for incomplete lines across chunks (sentinel may be split across data events)
+    let pendingLine = '';
+
     // Collect and stream output
     child.stdout?.on('data', (chunk: Buffer) => {
-      const text = chunk.toString();
+      const text = pendingLine + chunk.toString();
+      pendingLine = '';
       resetInactivityTimer();
 
+      // Only process complete lines; hold the trailing fragment for the next chunk
+      const lastNewline = text.lastIndexOf('\n');
+      if (lastNewline === -1) {
+        // No newline at all: entire chunk is a partial line, buffer it
+        pendingLine = text;
+        return;
+      }
+      const complete = text.slice(0, lastNewline + 1); // includes trailing \n
+      pendingLine = text.slice(lastNewline + 1); // remainder (may be empty)
+
       // Filter heartbeat sentinel lines
-      const { filtered, heartbeats } = filterHeartbeats(text);
+      const { filtered, heartbeats } = filterHeartbeats(complete);
 
       if (filtered && stdout.length + filtered.length <= MAX_BUFFER) {
         stdout += filtered;
       }
 
-      // Emit heartbeat progress updates
+      // Emit heartbeat progress updates (minimal payload: only details matter)
       for (const message of heartbeats) {
         onUpdate?.({
-          content: [{ type: 'text', text: stdout + (stderr ? `\nSTDERR:\n${stderr}` : '') }],
-          details: { stdout, stderr, exitCode: -1, heartbeat: true, heartbeatMessage: message },
+          content: [{ type: 'text', text: '' }],
+          details: {
+            stdout: '',
+            stderr: '',
+            exitCode: -1,
+            heartbeat: true,
+            heartbeatMessage: message,
+          },
         });
       }
 
@@ -237,6 +257,14 @@ function runCommand(
     });
 
     child.on('close', (code) => {
+      // Flush any remaining partial line from the buffer
+      if (pendingLine) {
+        const { filtered } = filterHeartbeats(pendingLine);
+        if (filtered && stdout.length + filtered.length <= MAX_BUFFER) {
+          stdout += filtered;
+        }
+        pendingLine = '';
+      }
       settle({ stdout, stderr, exitCode: code ?? 0 });
     });
 
@@ -319,9 +347,19 @@ export function createBashTool(notifyBackground?: NotifyBackground) {
         let stdout = '';
         let stderr = '';
 
+        let bgPendingLine = '';
         child.stdout?.on('data', (chunk: Buffer) => {
-          const text = chunk.toString();
-          if (stdout.length + text.length <= MAX_BUFFER) stdout += text;
+          const text = bgPendingLine + chunk.toString();
+          bgPendingLine = '';
+          const lastNewline = text.lastIndexOf('\n');
+          if (lastNewline === -1) {
+            bgPendingLine = text;
+            return;
+          }
+          const complete = text.slice(0, lastNewline + 1);
+          bgPendingLine = text.slice(lastNewline + 1);
+          const { filtered } = filterHeartbeats(complete);
+          if (filtered && stdout.length + filtered.length <= MAX_BUFFER) stdout += filtered;
         });
 
         child.stderr?.on('data', (chunk: Buffer) => {
@@ -337,6 +375,12 @@ export function createBashTool(notifyBackground?: NotifyBackground) {
         signal?.addEventListener('abort', onAbort, { once: true });
 
         child.on('close', (code) => {
+          // Flush remaining partial line
+          if (bgPendingLine) {
+            const { filtered } = filterHeartbeats(bgPendingLine);
+            if (filtered && stdout.length + filtered.length <= MAX_BUFFER) stdout += filtered;
+            bgPendingLine = '';
+          }
           backgroundProcesses.delete(id);
           signal?.removeEventListener('abort', onAbort);
           const exitCode = code ?? 0;

--- a/packages/server/src/agents/tools/bash.ts
+++ b/packages/server/src/agents/tools/bash.ts
@@ -4,6 +4,10 @@
  * Executes shell commands with streaming output, background execution,
  * and proper AbortSignal handling. Uses PowerShell on Windows, default
  * shell (bash) on macOS/Linux.
+ *
+ * Supports a heartbeat protocol for long-running commands: scripts can
+ * emit `::system2:: <message>` lines on stdout to reset the inactivity
+ * timer and push progress updates to the UI.
  */
 
 import type { ChildProcess } from 'node:child_process';
@@ -12,8 +16,15 @@ import { homedir, platform } from 'node:os';
 import type { AgentTool, AgentToolUpdateCallback } from '@mariozechner/pi-agent-core';
 import { Type } from '@sinclair/typebox';
 
-const DEFAULT_TIMEOUT = 120_000; // 120 seconds
+const LEGACY_TIMEOUT = 120_000; // 120s fixed timeout (backward compat when no timeout params given)
+const DEFAULT_INACTIVITY_TIMEOUT = 60_000; // 60 seconds
+const DEFAULT_TOTAL_TIMEOUT = 600_000; // 10 minutes
+const MIN_TIMEOUT = 10_000; // 10 seconds
+const MAX_TIMEOUT = 600_000; // 10 minutes
 const MAX_BUFFER = 10 * 1024 * 1024; // 10MB
+
+/** Sentinel pattern: lines matching `::system2:: <message>` are heartbeats. */
+export const HEARTBEAT_RE = /^::system2::\s*(.*)$/;
 
 /** Patterns that are always blocked: catastrophic, essentially irreversible operations. */
 export const BLOCKED_BASH_PATTERNS: { pattern: RegExp; reason: string }[] = [
@@ -61,15 +72,48 @@ interface BashDetails {
   error?: string;
   background?: boolean;
   command?: string;
+  heartbeat?: boolean;
+  heartbeatMessage?: string;
+}
+
+/**
+ * Filter heartbeat sentinel lines from a stdout chunk.
+ * Returns the filtered text (sentinels removed) and any heartbeat messages found.
+ */
+export function filterHeartbeats(text: string): {
+  filtered: string;
+  heartbeats: string[];
+} {
+  const lines = text.split('\n');
+  const kept: string[] = [];
+  const heartbeats: string[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = HEARTBEAT_RE.exec(lines[i]);
+    if (match) {
+      heartbeats.push(match[1].trim());
+    } else {
+      kept.push(lines[i]);
+    }
+  }
+
+  return { filtered: kept.join('\n'), heartbeats };
+}
+
+/** Clamp a value between min and max. */
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
 }
 
 /**
  * Run a command via spawn, collect output, stream via onUpdate, respect AbortSignal.
+ * Uses dual timeouts: inactivity (resets on output) and total (hard cap).
  */
 function runCommand(
   command: string,
   cwd: string,
-  timeout: number,
+  inactivityTimeout: number,
+  totalTimeout: number,
   signal?: AbortSignal,
   onUpdate?: AgentToolUpdateCallback<BashDetails>
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
@@ -80,12 +124,18 @@ function runCommand(
     let stdout = '';
     let stderr = '';
     let settled = false;
-    let timerHandle: ReturnType<typeof setTimeout> | undefined;
+    let inactivityTimer: ReturnType<typeof setTimeout> | undefined;
+    let totalTimer: ReturnType<typeof setTimeout> | undefined;
+
+    const clearTimers = () => {
+      if (inactivityTimer) clearTimeout(inactivityTimer);
+      if (totalTimer) clearTimeout(totalTimer);
+    };
 
     const settle = (result: { stdout: string; stderr: string; exitCode: number }) => {
       if (settled) return;
       settled = true;
-      if (timerHandle) clearTimeout(timerHandle);
+      clearTimers();
       cleanup();
       resolve(result);
     };
@@ -93,7 +143,7 @@ function runCommand(
     const fail = (error: Error & { stdout?: string; stderr?: string; exitCode?: number }) => {
       if (settled) return;
       settled = true;
-      if (timerHandle) clearTimeout(timerHandle);
+      clearTimers();
       cleanup();
       error.stdout = stdout;
       error.stderr = stderr;
@@ -121,30 +171,62 @@ function runCommand(
     }
     signal?.addEventListener('abort', onAbort, { once: true });
 
-    // Timeout
-    timerHandle = setTimeout(() => {
+    // Reset the inactivity timer (called on every stdout/stderr data event)
+    const resetInactivityTimer = () => {
+      if (inactivityTimer) clearTimeout(inactivityTimer);
+      inactivityTimer = setTimeout(() => {
+        child.kill('SIGTERM');
+        const err = new Error(
+          `Command timed out after ${inactivityTimeout / 1000}s of inactivity`
+        ) as Error & { exitCode?: number };
+        err.exitCode = 124;
+        fail(err);
+      }, inactivityTimeout);
+    };
+
+    // Start both timers
+    resetInactivityTimer();
+    totalTimer = setTimeout(() => {
       child.kill('SIGTERM');
-      const err = new Error(`Command timed out after ${timeout / 1000}s`) as Error & {
-        exitCode?: number;
-      };
+      const err = new Error(
+        `Command exceeded total timeout of ${totalTimeout / 1000}s`
+      ) as Error & { exitCode?: number };
       err.exitCode = 124;
       fail(err);
-    }, timeout);
+    }, totalTimeout);
 
     // Collect and stream output
     child.stdout?.on('data', (chunk: Buffer) => {
       const text = chunk.toString();
-      if (stdout.length + text.length <= MAX_BUFFER) {
-        stdout += text;
+      resetInactivityTimer();
+
+      // Filter heartbeat sentinel lines
+      const { filtered, heartbeats } = filterHeartbeats(text);
+
+      if (filtered && stdout.length + filtered.length <= MAX_BUFFER) {
+        stdout += filtered;
       }
-      onUpdate?.({
-        content: [{ type: 'text', text: stdout + (stderr ? `\nSTDERR:\n${stderr}` : '') }],
-        details: { stdout, stderr, exitCode: -1 },
-      });
+
+      // Emit heartbeat progress updates
+      for (const message of heartbeats) {
+        onUpdate?.({
+          content: [{ type: 'text', text: stdout + (stderr ? `\nSTDERR:\n${stderr}` : '') }],
+          details: { stdout, stderr, exitCode: -1, heartbeat: true, heartbeatMessage: message },
+        });
+      }
+
+      // Regular streaming update (only if there was non-heartbeat content)
+      if (filtered) {
+        onUpdate?.({
+          content: [{ type: 'text', text: stdout + (stderr ? `\nSTDERR:\n${stderr}` : '') }],
+          details: { stdout, stderr, exitCode: -1 },
+        });
+      }
     });
 
     child.stderr?.on('data', (chunk: Buffer) => {
       const text = chunk.toString();
+      resetInactivityTimer();
       if (stderr.length + text.length <= MAX_BUFFER) {
         stderr += text;
       }
@@ -183,13 +265,29 @@ export function createBashTool(notifyBackground?: NotifyBackground) {
           'If true, start the command in the background and return immediately. You will receive the output as a follow-up message when the command completes. Use for long-running commands (builds, large data processing, etc.).',
       })
     ),
+    inactivity_timeout_seconds: Type.Optional(
+      Type.Number({
+        description:
+          'Inactivity timeout in seconds (10-600, default 60). The timer resets on every stdout/stderr output. Scripts can emit "::system2:: <message>" lines to reset the timer and push progress to the UI. Only takes effect when explicitly provided (legacy 120s fixed timeout otherwise).',
+        minimum: 10,
+        maximum: 600,
+      })
+    ),
+    total_timeout_seconds: Type.Optional(
+      Type.Number({
+        description:
+          'Total (wall-clock) timeout in seconds (10-600, default 600). Hard cap that never resets. Only takes effect when explicitly provided (legacy 120s fixed timeout otherwise).',
+        minimum: 10,
+        maximum: 600,
+      })
+    ),
   });
 
   const tool: AgentTool<typeof params> = {
     name: 'bash',
     label: 'Execute Shell Command',
     description:
-      'Execute a shell command and return stdout/stderr. 120-second timeout by default. Uses PowerShell on Windows, bash on macOS/Linux. Set run_in_background to true for long-running commands — you will be notified when they complete. Output is streamed as the command runs.',
+      'Execute a shell command and return stdout/stderr. 120-second timeout by default. Uses PowerShell on Windows, bash on macOS/Linux. Set run_in_background to true for long-running commands — you will be notified when they complete. Output is streamed as the command runs. For long-running foreground commands, set inactivity_timeout_seconds and/or total_timeout_seconds to use dual timeouts (inactivity resets on output, total is a hard cap). Scripts can emit "::system2:: <message>" on stdout as heartbeats to reset the inactivity timer and show progress in the UI.',
     parameters: params,
     execute: async (_toolCallId, params, signal, onUpdate) => {
       // Block catastrophic commands before execution
@@ -277,12 +375,35 @@ export function createBashTool(notifyBackground?: NotifyBackground) {
         };
       }
 
+      // Compute effective timeouts
+      const hasTimeoutParams =
+        params.inactivity_timeout_seconds !== undefined ||
+        params.total_timeout_seconds !== undefined;
+
+      let inactivityMs: number;
+      let totalMs: number;
+
+      if (hasTimeoutParams) {
+        // New dual-timeout model
+        inactivityMs = params.inactivity_timeout_seconds
+          ? clamp(params.inactivity_timeout_seconds * 1000, MIN_TIMEOUT, MAX_TIMEOUT)
+          : DEFAULT_INACTIVITY_TIMEOUT;
+        totalMs = params.total_timeout_seconds
+          ? clamp(params.total_timeout_seconds * 1000, MIN_TIMEOUT, MAX_TIMEOUT)
+          : DEFAULT_TOTAL_TIMEOUT;
+      } else {
+        // Legacy: single fixed timeout matching the old 120s behavior
+        inactivityMs = LEGACY_TIMEOUT;
+        totalMs = LEGACY_TIMEOUT;
+      }
+
       // Foreground execution with streaming
       try {
         const { stdout, stderr, exitCode } = await runCommand(
           params.command,
           cwd,
-          DEFAULT_TIMEOUT,
+          inactivityMs,
+          totalMs,
           signal,
           onUpdate
         );

--- a/packages/server/src/websocket/handler.ts
+++ b/packages/server/src/websocket/handler.ts
@@ -278,6 +278,23 @@ export class WebSocketHandler {
         break;
       }
 
+      case 'tool_execution_update': {
+        // Forward heartbeat progress events to the UI (skip regular streaming updates)
+        const partialResult = (
+          event as unknown as { partialResult?: { details?: Record<string, unknown> } }
+        ).partialResult;
+        const details = partialResult?.details;
+        if (details?.heartbeat && typeof details.heartbeatMessage === 'string') {
+          this.send({
+            type: 'tool_call_progress',
+            name: event.toolName,
+            message: details.heartbeatMessage,
+            agentId,
+          });
+        }
+        break;
+      }
+
       case 'tool_execution_end': {
         // Format result as string for display
         let resultText = '';

--- a/packages/shared/src/types/chat.ts
+++ b/packages/shared/src/types/chat.ts
@@ -11,6 +11,7 @@ export interface ChatToolCall {
   status: 'running' | 'completed' | 'error';
   input?: string;
   result?: string;
+  progressMessage?: string;
   timestamp: number;
 }
 

--- a/packages/shared/src/types/messages.ts
+++ b/packages/shared/src/types/messages.ts
@@ -23,6 +23,7 @@ export type ServerMessage =
   | { type: 'thinking_end'; agentId?: number }
   | { type: 'tool_call_start'; name: string; input?: string; agentId?: number }
   | { type: 'tool_call_end'; name: string; result: string; agentId?: number }
+  | { type: 'tool_call_progress'; name: string; message: string; agentId?: number } // Heartbeat progress from long-running tool
   | { type: 'artifact'; url: string; title?: string; filePath?: string }
   | {
       type: 'context_usage';

--- a/packages/ui/src/components/MessageList.tsx
+++ b/packages/ui/src/components/MessageList.tsx
@@ -299,7 +299,13 @@ function ToolCallItem({ tc }: { tc: ToolCall }) {
           {tc.name}
         </Text>
         {agentTarget && <Text sx={{ fontSize: 0, color: 'fg.muted' }}>{agentTarget}</Text>}
-        {summary && <Text sx={{ fontSize: 0, color: 'fg.muted' }}>{summary}</Text>}
+        {isRunning && tc.progressMessage ? (
+          <Text sx={{ fontSize: 0, color: 'fg.muted', fontStyle: 'italic' }}>
+            {tc.progressMessage}
+          </Text>
+        ) : (
+          summary && <Text sx={{ fontSize: 0, color: 'fg.muted' }}>{summary}</Text>
+        )}
         {hasContent && (
           <Text
             sx={{

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -116,6 +116,12 @@ export function useWebSocket() {
           break;
         }
 
+        case 'tool_call_progress': {
+          const aid = message.agentId ?? state.guideAgentId;
+          if (aid !== null) state.updateToolCallProgress(message.name, message.message, aid);
+          break;
+        }
+
         case 'tool_call_end': {
           const aid = message.agentId ?? state.guideAgentId;
           if (aid !== null) state.finishToolCall(message.name, message.result, aid);

--- a/packages/ui/src/stores/chat.ts
+++ b/packages/ui/src/stores/chat.ts
@@ -87,6 +87,7 @@ interface ChatState {
   appendThinkingChunk: (chunk: string, agentId?: number) => void;
   finishThinking: (agentId?: number) => void;
   startToolCall: (name: string, input?: string, agentId?: number) => void;
+  updateToolCallProgress: (name: string, message: string, agentId?: number) => void;
   finishToolCall: (name: string, result: string, agentId?: number) => void;
   setConnected: (connected: boolean) => void;
   clearAllStreamingState: () => void;
@@ -372,6 +373,25 @@ export const useChatStore = create<ChatState>()(
             currentTurnEvents: [...s.currentTurnEvents, { type: 'tool_call', data: toolCall }],
             isStreaming: true,
             isWaitingForResponse: false,
+          })),
+        }));
+      },
+
+      updateToolCallProgress: (name: string, message: string, agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+            currentTurnEvents: s.currentTurnEvents.map((event) =>
+              event.type === 'tool_call' &&
+              event.data.name === name &&
+              event.data.status === 'running'
+                ? {
+                    ...event,
+                    data: { ...event.data, progressMessage: message },
+                  }
+                : event
+            ),
           })),
         }));
       },


### PR DESCRIPTION
## Summary

- Replace the single 120s fixed bash timeout with a dual timeout model: **inactivity timeout** (resets on stdout/stderr activity, default 60s) and **total timeout** (hard cap, default 600s)
- Add heartbeat sentinel protocol: scripts emit `::system2:: <message>` on stdout to show progress in the UI; sentinel lines are stripped from output
- Wire heartbeat progress through the full event pipeline (bash tool -> SDK -> WebSocket -> chat store -> UI)
- Backward compatible: when neither new param is provided, behavior matches the existing 120s fixed timeout

## Changes

| File | What |
|------|------|
| `packages/server/src/agents/tools/bash.ts` | Dual timeouts, sentinel parsing, new `inactivity_timeout_seconds` and `total_timeout_seconds` params |
| `packages/server/src/agents/tools/bash.test.ts` | 14 new tests: heartbeat stripping, onUpdate emission, dual timeout behavior, filterHeartbeats unit tests, HEARTBEAT_RE |
| `packages/server/src/websocket/handler.ts` | Forward `tool_execution_update` heartbeats as `tool_call_progress` |
| `packages/shared/src/types/messages.ts` | Add `tool_call_progress` to ServerMessage union |
| `packages/shared/src/types/chat.ts` | Add `progressMessage` to `ChatToolCall` |
| `packages/ui/src/stores/chat.ts` | Add `updateToolCallProgress` action |
| `packages/ui/src/hooks/useWebSocket.ts` | Handle `tool_call_progress` message |
| `packages/ui/src/components/MessageList.tsx` | Render progress message on running tool calls |
| `docs/tools.md`, `docs/websocket-protocol.md` | Document new params, heartbeat sentinel, tool_call_progress message |

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (579/579)
- [ ] Manual: run `for i in 1 2 3; do echo "::system2:: step $i"; sleep 2; done` and verify progress appears in UI, sentinel lines stripped from output
- [ ] Manual: verify a command that goes silent times out at inactivity threshold
- [ ] Manual: verify existing commands without new params behave identically (120s timeout)

Closes #98