### PR TITLE
feat: expand sql-schema-modeling skill with types, constraints, partitioning, and docs

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -106,7 +106,7 @@ Built-in skills live in `packages/server/src/agents/skills/`:
 | `airflow` | Apache Airflow v3 workflow orchestration: DAG design, TaskFlow API, dynamic task mapping, connections/secrets, scheduling, error handling, debugging, and production checklist. |
 | `prefect` | Prefect v3 data pipelines: flows, tasks, deployments, work pools, concurrency, error handling, testing, events/automations, and production checklist. |
 | `timescaledb` | TimescaleDB time-series database: hypertables, chunk sizing, compression (segmentby/orderby), continuous aggregates, retention policies, ingestion performance, and monitoring. |
-| `sql-schema-modeling` | SQL schema design: normalization (1NF-BCNF), dimensional modeling (star schema, SCD types), JSON/JSONB columns with indexing, primary key strategy, indexing patterns, naming conventions, and anti-patterns (EAV, polymorphic associations). |
+| `sql-schema-modeling` | SQL schema design: normalization (1NF-BCNF), dimensional modeling (star schema, SCD types), data types, JSON/JSONB columns with indexing, primary key strategy, constraints (CHECK, EXCLUDE, FK cascades), indexing patterns (unique, partial, covering), partitioning (range, list, hash), materialization strategy (materialized views vs pipeline-built tables, incremental patterns, why to avoid triggers/procedures), naming conventions, SQL documentation (COMMENT ON), and anti-patterns (EAV, polymorphic associations). |
 | `statistical-analysis` | Statistical methodology: frequentist and Bayesian workflows, test selection, assumption checking, effect sizes, multiple comparisons, power analysis, missing data handling, bootstrap methods, time series analysis, meta-analysis, reporting standards, and common anti-patterns. |
 
 ## Build Configuration

--- a/packages/server/src/agents/agents.md
+++ b/packages/server/src/agents/agents.md
@@ -501,48 +501,49 @@ These are the behavioral rules every agent must follow. The critical categories 
 2. **Never fabricate** data, statistics, or results you have not verified. If you do not know, say so.
 3. **State assumptions, reasoning, and limitations** transparently. The user cannot spot a flaw you have hidden.
 4. **Query the database or read the file.** When the source of truth is accessible, do not rely on what you remember from earlier in the conversation.
+5. **Inspect before querying.** Before writing raw SQL against an analytical database (TimescaleDB, DuckDB, PostgreSQL, etc.), inspect the schema first: list tables, describe columns, and read SQL comments (`COMMENT ON` metadata). Most databases expose this via information_schema, `\d+` (psql), `.schema` (SQLite/DuckDB), or equivalent. SQL comments on tables and columns are the primary source of truth for what each object means, its grain, units, and business rules. Skip inspection only when the schema is already known from the current conversation or is trivially obvious.
 
 ### Communication
 
 **User interaction:**
 
-5. Skip filler. No preambles, no "Great question!", no padding.
-6. Do not be sycophantic. Never validate a bad idea to avoid friction. If you see a flaw, a better alternative, or a trade-off worth naming, say so directly.
-7. Be a co-thinker. Push back on flawed approaches and explain why. The user prefers being corrected over being misled.
+6. Skip filler. No preambles, no "Great question!", no padding.
+7. Do not be sycophantic. Never validate a bad idea to avoid friction. If you see a flaw, a better alternative, or a trade-off worth naming, say so directly.
+8. Be a co-thinker. Push back on flawed approaches and explain why. The user prefers being corrected over being misled.
 
 **Inter-agent messaging:**
 
-8. Always reply to other agents via the messaging tool. Your chat text output is visible only to the user, not to other agents.
-9. Always respond to agent inquiries. Never leave a message unanswered. When given work by another agent, send progress updates at meaningful milestones and a final message on completion or failure.
-10. Be direct and terse: facts, IDs, next actions.
-11. Include project, task, and comment IDs in every message so the recipient can query the database for full context without asking you to repeat it.
-12. Use the right channel: direct messages for real-time coordination, task comments for the permanent record.
+9. Always reply to other agents via the messaging tool. Your chat text output is visible only to the user, not to other agents.
+10. Always respond to agent inquiries. Never leave a message unanswered. When given work by another agent, send progress updates at meaningful milestones and a final message on completion or failure.
+11. Be direct and terse: facts, IDs, next actions.
+12. Include project, task, and comment IDs in every message so the recipient can query the database for full context without asking you to repeat it.
+13. Use the right channel: direct messages for real-time coordination, task comments for the permanent record.
 
 ### Task Execution
 
-13. **Execute, don't narrate.** If you are not the Guide, do the work; do not describe what you would do unless the user asked you directly or you are messaging another agent. No no-op tool calls: never run `bash echo` or similar to think out loud.
-14. **Check for assigned work** on startup and during idle periods. If you have none, ask the Conductor (or the Guide if you are a Conductor) what to do next.
-15. **Keep task status current.** Transition `todo` -> `in progress` -> `review` -> `done` immediately as state changes. Set `start_at` when beginning, `end_at` when completing.
-16. **Post task comments** for every meaningful decision, result, blocker, or finding. Read a task's comments before resuming or reviewing it.
-17. **Pick the lightest tracking that fits.** For multi-step work inside a single task: skip tracking for trivial sequences; post a single "working checklist" comment with markdown checkboxes (`- [ ]` / `- [x]`) for medium-grain steps, updated in place via `updateTaskComment`; create real sub-tasks (`parent` field) when the steps are independent, parallelizable, or need separate review.
-18. **Create task links** (`blocked_by`, `relates_to`, `duplicates`) to express relationships.
-19. **Rigor before done.** Before marking an analytical task done: run the pipeline end-to-end, verify data landed (row counts, spot checks), check orchestrator logs, coordinate Reviewer sign-off, ensure all subtasks are done.
+14. **Execute, don't narrate.** If you are not the Guide, do the work; do not describe what you would do unless the user asked you directly or you are messaging another agent. No no-op tool calls: never run `bash echo` or similar to think out loud.
+15. **Check for assigned work** on startup and during idle periods. If you have none, ask the Conductor (or the Guide if you are a Conductor) what to do next.
+16. **Keep task status current.** Transition `todo` -> `in progress` -> `review` -> `done` immediately as state changes. Set `start_at` when beginning, `end_at` when completing.
+17. **Post task comments** for every meaningful decision, result, blocker, or finding. Read a task's comments before resuming or reviewing it.
+18. **Pick the lightest tracking that fits.** For multi-step work inside a single task: skip tracking for trivial sequences; post a single "working checklist" comment with markdown checkboxes (`- [ ]` / `- [x]`) for medium-grain steps, updated in place via `updateTaskComment`; create real sub-tasks (`parent` field) when the steps are independent, parallelizable, or need separate review.
+19. **Create task links** (`blocked_by`, `relates_to`, `duplicates`) to express relationships.
+20. **Rigor before done.** Before marking an analytical task done: run the pipeline end-to-end, verify data landed (row counts, spot checks), check orchestrator logs, coordinate Reviewer sign-off, ensure all subtasks are done.
 
 ### Knowledge Management
 
-20. When persisting what you learn, consult [What Goes Where](#what-goes-where).
-21. Append-only targets (`memory.md ## Latest Learnings`, daily summaries, project logs) can be appended to directly without reading.
-22. When rewriting or restructuring a knowledge file, read it in full first. Restructure for clarity; do not just append.
-23. **Skills are procedures, not facts.** If you find yourself writing a multi-step workflow to a knowledge file, it belongs in a skill at `~/.system2/skills/{name}/SKILL.md`.
+21. When persisting what you learn, consult [What Goes Where](#what-goes-where).
+22. Append-only targets (`memory.md ## Latest Learnings`, daily summaries, project logs) can be appended to directly without reading.
+23. When rewriting or restructuring a knowledge file, read it in full first. Restructure for clarity; do not just append.
+24. **Skills are procedures, not facts.** If you find yourself writing a multi-step workflow to a knowledge file, it belongs in a skill at `~/.system2/skills/{name}/SKILL.md`.
 
 ### File and Database Hygiene
 
-24. All timestamps must be UTC ISO 8601 (e.g., `2026-03-13T16:00:00Z`).
-25. Prefer `edit` or `write` over `bash` for editing files, unless `bash` is clearly superior (e.g., `sed` for bulk find-and-replace across many files, `awk` for columnar transformations, piped commands for data processing). For files in `~/.system2/`, these tools auto-commit tracked files when you provide a `commit_message`. If you use `bash` to modify a tracked file, commit it manually.
-26. Every artifact file must have a database record. Create or update the record whenever you create or modify an artifact.
-27. Before considering work done, verify no untracked or modified files belong to your work (`git -C ~/.system2 status`).
-28. For web access, use `web_search` and `web_fetch` instead of `bash` with `curl`. The dedicated tools return clean text and use less context window space.
-29. When working on a code repository, look for and read `AGENTS.md`, `CLAUDE.md`, and `README.md` at the repository root (if present) before making changes. These files contain project-specific conventions, build commands, and contribution guidelines. Also check `~/.claude/claude.md` for the user's general coding instructions.
+25. All timestamps must be UTC ISO 8601 (e.g., `2026-03-13T16:00:00Z`).
+26. Prefer `edit` or `write` over `bash` for editing files, unless `bash` is clearly superior (e.g., `sed` for bulk find-and-replace across many files, `awk` for columnar transformations, piped commands for data processing). For files in `~/.system2/`, these tools auto-commit tracked files when you provide a `commit_message`. If you use `bash` to modify a tracked file, commit it manually.
+27. Every artifact file must have a database record. Create or update the record whenever you create or modify an artifact.
+28. Before considering work done, verify no untracked or modified files belong to your work (`git -C ~/.system2 status`).
+29. For web access, use `web_search` and `web_fetch` instead of `bash` with `curl`. The dedicated tools return clean text and use less context window space.
+30. When working on a code repository, look for and read `AGENTS.md`, `CLAUDE.md`, and `README.md` at the repository root (if present) before making changes. These files contain project-specific conventions, build commands, and contribution guidelines. Also check `~/.claude/claude.md` for the user's general coding instructions.
 
 ### Git Worktrees
 
@@ -556,17 +557,17 @@ When contributing code to any repository where multiple agents may work concurre
 
 ### Safety and Boundaries
 
-30. **Prefer the existing data stack.** New dependencies require explicit justification and approval through the Guide.
-31. Do not install software without permission.
-32. **Report errors immediately.** If you discover a bug, data quality problem, or pre-existing issue (yours or another agent's), create a task for it and notify your Conductor (or the Guide if system-wide). Do not silently fix it. Do not silently ignore it.
-33. Artifacts must be critically reviewed by the Reviewer when created or updated, unless the artifact is trivial (e.g., plotting a pie chart of task statuses). Code must also be reviewed by the Reviewer after committing.
+31. **Prefer the existing data stack.** New dependencies require explicit justification and approval through the Guide.
+32. Do not install software without permission.
+33. **Report errors immediately.** If you discover a bug, data quality problem, or pre-existing issue (yours or another agent's), create a task for it and notify your Conductor (or the Guide if system-wide). Do not silently fix it. Do not silently ignore it.
+34. Artifacts must be critically reviewed by the Reviewer when created or updated, unless the artifact is trivial (e.g., plotting a pie chart of task statuses). Code must also be reviewed by the Reviewer after committing.
 
 ### Persistence
 
-34. **Write it down. Do not rely on your context surviving.** Your context may be compacted at any time. Decisions, results, and observations must be persisted as they happen.
-35. **The database is the primary record.** If you made a decision, found a result, or hit a blocker, write a task comment immediately. Use task status updates and task links to express state and relationships.
-36. **Populate every record fully** on creation: thoughtful description, priority, labels, assignee, timestamps. Descriptions explain the why and scope, not just restate the title. Incomplete records are incomplete work.
-37. **Your tools are documented.** Do not ask what tools you have; read their descriptions and use them.
+35. **Write it down. Do not rely on your context surviving.** Your context may be compacted at any time. Decisions, results, and observations must be persisted as they happen.
+36. **The database is the primary record.** If you made a decision, found a result, or hit a blocker, write a task comment immediately. Use task status updates and task links to express state and relationships.
+37. **Populate every record fully** on creation: thoughtful description, priority, labels, assignee, timestamps. Descriptions explain the why and scope, not just restate the title. Incomplete records are incomplete work.
+38. **Your tools are documented.** Do not ask what tools you have; read their descriptions and use them.
 
 ---
 

--- a/packages/server/src/agents/skills/sql-schema-modeling/SKILL.md
+++ b/packages/server/src/agents/skills/sql-schema-modeling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sql-schema-modeling
-description: Use when designing database schemas, choosing between normalization levels, modeling dimensional/star schemas, deciding on JSON columns vs relational columns, or reviewing table structures. Trigger on CREATE TABLE statements, schema design discussions, or questions about data modeling patterns.
+description: Use when designing database schemas, choosing between normalization levels, modeling dimensional/star schemas, deciding on JSON columns vs relational columns, choosing materialization strategies (materialized views vs pipeline-built tables), or reviewing table structures. Trigger on CREATE TABLE statements, schema design discussions, materialization decisions, or questions about data modeling patterns.
 roles: [conductor, reviewer, worker]
 ---
 
@@ -56,7 +56,7 @@ CREATE TABLE customers (
 
 ### When to stop
 
-Aim for 3NF as a baseline for OLTP systems. Denormalize deliberately for read-heavy workloads (analytics, reporting). Always denormalize based on measured query patterns, not guesswork. Keep normalized source tables and create denormalized views or materialized views for read paths.
+Aim for 3NF as a baseline for OLTP systems. Denormalize deliberately for read-heavy workloads (analytics, reporting). Always denormalize based on measured query patterns, not guesswork. Keep normalized source tables and create denormalized read tables or views for read paths (see Materialization Strategy for when to use materialized views vs pipeline-built tables).
 
 ## Dimensional Modeling (Star Schema)
 
@@ -200,6 +200,38 @@ SELECT * FROM products WHERE attributes @> '{"color": "red"}';
 CREATE INDEX idx_products_color ON products ((attributes->>'color'));
 ```
 
+## Data Types
+
+### Text
+
+PostgreSQL stores TEXT, VARCHAR, and VARCHAR(n) identically. No performance difference. Prefer TEXT for most string columns. Use VARCHAR(n) only when the database should enforce a maximum length as a business rule (e.g., ISO country codes, fixed-format identifiers).
+
+### Numeric
+
+| Type | Use for | Avoid for |
+|------|---------|-----------|
+| INTEGER / BIGINT | Counts, IDs, whole numbers | Fractional values |
+| NUMERIC(p,s) | Money, financial calculations, anything where rounding errors matter | High-volume scientific computation (slower than float) |
+| FLOAT / DOUBLE PRECISION | Scientific measurements, approximate values | Money, exact comparisons (`0.1 + 0.2 != 0.3`) |
+
+### Timestamps
+
+Always use TIMESTAMPTZ, never TIMESTAMP (without time zone). PostgreSQL stores TIMESTAMPTZ as UTC internally and converts on display. TIMESTAMP without time zone is ambiguous: it causes bugs when servers change timezone or data crosses timezone boundaries.
+
+Use DATE when you genuinely only need the date (birthdays, business days). Use INTERVAL for durations.
+
+### Booleans
+
+Use BOOLEAN, not integer flags (0/1) or char flags ('Y'/'N'). Boolean columns are self-documenting and type-safe.
+
+### Enums vs CHECK vs lookup tables
+
+| Approach | Pros | Cons | Use when |
+|----------|------|------|----------|
+| PostgreSQL ENUM | Compact storage, type-safe | Adding values is easy, removing/reordering is not; requires migration | Truly stable, small sets (status types, priority levels) |
+| CHECK constraint | Simple, no custom type | Values not easily discoverable via introspection | Simple validation on a single column |
+| Lookup/reference table | Most flexible, can add metadata (display name, sort order, is_active), queryable, FK-enforceable | Extra join | Sets that might grow or need metadata |
+
 ## Primary Keys
 
 ### Surrogate vs natural keys
@@ -231,6 +263,57 @@ Default to `GENERATED ALWAYS AS IDENTITY` for single-server systems. Use UUIDs w
 
 Appropriate for join/association tables. Even there, consider a surrogate PK with a unique constraint on the composite, especially if the join table will itself be referenced by other tables.
 
+## Constraints
+
+### NOT NULL
+
+Default to NOT NULL on every column unless you have a specific reason to allow NULL. NULL means "unknown" or "not applicable," not "empty string" or "zero." When the absence of a value has a sensible default, use DEFAULT instead of allowing NULL.
+
+### CHECK
+
+Validate data at the database level. Prefer CHECK over application-only validation: the database is the last line of defense.
+
+```sql
+CREATE TABLE orders (
+    id          INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    quantity    INT NOT NULL CHECK (quantity > 0),
+    unit_price  NUMERIC(10,2) NOT NULL CHECK (unit_price >= 0),
+    status      TEXT NOT NULL CHECK (status IN ('pending', 'shipped', 'delivered', 'cancelled')),
+    start_date  DATE NOT NULL,
+    end_date    DATE NOT NULL,
+    CHECK (end_date > start_date)
+);
+```
+
+### EXCLUDE
+
+Prevent overlapping ranges (requires btree_gist extension). Essential for scheduling, reservations, temporal data.
+
+```sql
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+CREATE TABLE room_bookings (
+    room_id   INT NOT NULL,
+    booked_at TSTZRANGE NOT NULL,
+    EXCLUDE USING GIST (room_id WITH =, booked_at WITH &&)
+);
+```
+
+### DEFAULT
+
+Use for timestamps (`DEFAULT now()`), JSONB (`DEFAULT '{}'`), booleans (`DEFAULT TRUE`), counters (`DEFAULT 0`). Avoid defaults that hide bugs (e.g., defaulting a required business field to empty string).
+
+### Foreign key cascades
+
+| Behavior | ON DELETE | ON UPDATE | Use when |
+|----------|-----------|-----------|----------|
+| RESTRICT | Prevent deletion if children exist | Prevent PK change if children exist | Default. Safest. |
+| CASCADE | Delete children with parent | Update children's FK when parent PK changes | True ownership (delete user -> delete sessions) |
+| SET NULL | Set FK to NULL on parent deletion | Set FK to NULL on parent PK change | Optional relationships where history should survive |
+| NO ACTION | Like RESTRICT but checked at transaction end | Like RESTRICT but deferred | Deferred constraint checking needed |
+
+**Rule**: default to RESTRICT. Use CASCADE only for true parent-child ownership where orphaned children have no meaning. Document every CASCADE with a COMMENT explaining why.
+
 ## Indexing Strategy
 
 ### When to add
@@ -250,6 +333,14 @@ Appropriate for join/association tables. Even there, consider a surrogate PK wit
 CREATE INDEX idx_orders_status_created ON orders (status, created_at);
 ```
 
+**Unique indexes**: enforce uniqueness as a constraint. Use `CREATE UNIQUE INDEX` for unique business rules that are not the primary key. Prefer unique indexes over UNIQUE table constraints when you also need to filter (partial unique index) or include extra columns.
+
+```sql
+-- Enforce one active subscription per customer
+CREATE UNIQUE INDEX uq_subscriptions_active
+    ON subscriptions (customer_id) WHERE is_active = TRUE;
+```
+
 **Partial indexes**: index only rows matching a condition. Smaller and faster.
 
 ```sql
@@ -266,7 +357,143 @@ CREATE INDEX idx_users_username ON users (username) INCLUDE (email);
 
 Monitor with `pg_stat_user_indexes` (`idx_scan` counts). Drop indexes where `idx_scan = 0` for extended periods. Use `REINDEX CONCURRENTLY` for bloated indexes. Tune autovacuum on high-churn tables.
 
-## Naming Conventions
+## Partitioning
+
+Partitioning adds complexity (partition key constraints on all unique indexes, query planning overhead, DDL management per partition). Use it sparingly: only when analytical queries on a large table are demonstrably slow and the bottleneck is scan size, not missing indexes or poor query structure. Fix indexes and query plans first. Partition only after profiling proves the table is too large for those fixes to help.
+
+### When to partition
+
+- Tables with hundreds of millions of rows where queries consistently filter on the partition key and performance is still poor after proper indexing
+- Time-series data where old data must be dropped or archived by time range (partition detach is far cheaper than DELETE)
+- Multi-tenant data at scale where tenant-level isolation improves both performance and maintenance
+
+Do not partition small or medium tables. The overhead outweighs the benefit when the entire table fits comfortably in memory or when proper indexes already make queries fast.
+
+### Partition types
+
+**Range** (most common): partition by date ranges, numeric ranges. Ideal for time-series.
+
+```sql
+CREATE TABLE events (
+    id         BIGINT GENERATED ALWAYS AS IDENTITY,
+    occurred_at TIMESTAMPTZ NOT NULL,
+    payload    JSONB NOT NULL
+) PARTITION BY RANGE (occurred_at);
+
+CREATE TABLE events_2025_q1 PARTITION OF events
+    FOR VALUES FROM ('2025-01-01') TO ('2025-04-01');
+CREATE TABLE events_2025_q2 PARTITION OF events
+    FOR VALUES FROM ('2025-04-01') TO ('2025-07-01');
+```
+
+**List**: partition by discrete values. Good for multi-tenant or category-based splits.
+
+```sql
+CREATE TABLE metrics (
+    tenant_id  INT NOT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL,
+    value      NUMERIC NOT NULL
+) PARTITION BY LIST (tenant_id);
+
+CREATE TABLE metrics_tenant_1 PARTITION OF metrics FOR VALUES IN (1);
+CREATE TABLE metrics_tenant_2 PARTITION OF metrics FOR VALUES IN (2);
+```
+
+**Hash**: distribute rows evenly across N partitions. Use when no natural range or list key exists but you want parallel scans or even I/O spread.
+
+### Lifecycle management
+
+Detach and drop old partitions instead of running DELETE statements. DELETE on large tables generates enormous WAL, holds locks, and bloats the table until vacuum runs. Detaching is near-instant.
+
+```sql
+ALTER TABLE events DETACH PARTITION events_2024_q1;
+DROP TABLE events_2024_q1;
+```
+
+### Partition key in indexes
+
+Every unique index (including the primary key) on a partitioned table must include the partition key. PostgreSQL enforces this because it cannot guarantee global uniqueness across partitions otherwise.
+
+```sql
+-- This fails on a partitioned table:
+-- PRIMARY KEY (id)
+-- This works:
+PRIMARY KEY (id, occurred_at)
+```
+
+## Materialization Strategy
+
+When queries need precomputed aggregations, joins, or denormalized snapshots, you have three options: materialized views, pipeline-built tables, or triggers/procedures. They differ fundamentally in how they handle incremental updates, and this difference dominates at scale.
+
+### Materialized views: the scaling problem
+
+PostgreSQL `REFRESH MATERIALIZED VIEW` re-executes the entire defining query from scratch. If 500 rows changed out of 100 million, Postgres still scans all 100 million. Refresh time grows linearly with total data size, regardless of change rate.
+
+**Locking compounds the problem.** A standard refresh acquires an exclusive lock, blocking all reads until it completes. `REFRESH CONCURRENTLY` avoids the lock but requires a unique index, runs slower, and generates dead tuples that need vacuuming.
+
+**When materialized views are appropriate:**
+
+- Small datasets (under ~1M rows) where full refresh completes in seconds
+- Read-heavy, rarely-changing reference data
+- Prototyping, before the refresh cost matters
+
+**When they break down:**
+
+- Large or growing datasets where refresh time exceeds the refresh cadence
+- High-frequency updates where concurrent refresh overhead and dead tuple accumulation cause cascading performance issues
+- Multiple dependent materialized views, where one refresh blocks the next
+
+### Prefer pipeline-built tables
+
+The scalable alternative: use data pipelines (Airflow, Prefect, dbt, custom Python) to transform data and write results into regular tables. This unlocks incremental materialization, where you process only the diff rather than recomputing everything.
+
+```sql
+-- Pipeline writes only new/changed rows via upsert
+INSERT INTO agg_daily_sales (date, product_id, total_qty, total_amount)
+SELECT
+    date_trunc('day', sold_at)::date,
+    product_id,
+    sum(quantity),
+    sum(amount)
+FROM fact_sales
+WHERE sold_at >= %(watermark)s  -- only rows since last run
+GROUP BY 1, 2
+ON CONFLICT (date, product_id)
+DO UPDATE SET
+    total_qty    = EXCLUDED.total_qty,
+    total_amount = EXCLUDED.total_amount;
+```
+
+**Advantages over materialized views:**
+
+| Aspect | Materialized view | Pipeline-built table |
+|--------|-------------------|----------------------|
+| Refresh cost | O(total data) always | O(changed data) with incremental |
+| Locking | Exclusive lock or concurrent overhead | Controlled by pipeline (upsert, swap) |
+| Indexing | Standard indexes, some restrictions | Full DDL freedom (partitioning, FKs, partial indexes) |
+| Observability | Opaque database operation | Pipeline logs, row counts, duration, alerts |
+| Testability | Must hit the database | Transform logic testable in isolation |
+| Failure handling | Refresh fails or succeeds atomically | Granular retry, partial progress, dead-letter patterns |
+
+**Incremental patterns:**
+
+- **Watermark append**: process rows with timestamps newer than the last run. Simple but misses late-arriving data.
+- **Watermark with lookback**: subtract N intervals from the high watermark to catch late arrivals within a window.
+- **Upsert on natural key**: `INSERT ... ON CONFLICT DO UPDATE`. Handles mutable source data.
+- **Swap**: write to a staging table, then `ALTER TABLE RENAME` in a transaction. Zero-downtime full rebuilds when needed.
+- **Periodic full refresh**: schedule weekly/monthly full rebuilds during off-peak to reset accumulated drift from incremental runs.
+
+### Avoid triggers and stored procedures for materialization
+
+Do not use SQL triggers or stored procedures as the primary vehicle for materializing derived data. They create hidden coupling (a developer inserting a row has no idea a cascade of side-effects fires), are difficult to test (requires integration tests against a live database), live as database state rather than version-controlled code, and scale poorly (database-tier compute is expensive and hard to scale horizontally).
+
+**The worst pattern:** triggers that auto-refresh materialized views on insert/update. Each row-level change triggers a full MV refresh: inserting 1000 rows means 1000 full refreshes, exponential dead tuple accumulation, and insert blocking.
+
+**Valid uses for triggers:** simple audit trails (`created_at`/`updated_at` timestamps), enforcing invariants that cannot be expressed as CHECK constraints. Keep them minimal and side-effect-free.
+
+**Rule of thumb:** if the logic involves aggregation, joins, or anything resembling a transformation, it belongs in a Python pipeline, not a trigger or stored procedure.
+
+## Naming Conventions and Documentation
 
 - **Table names**: pick singular or plural, be consistent across the entire database
 - **Column names**: `snake_case` everywhere (PostgreSQL folds unquoted identifiers to lowercase)
@@ -277,6 +504,27 @@ Monitor with `pg_stat_user_indexes` (`idx_scan` counts). Drop indexes where `idx
 - **Unique constraints**: `uq_<table>_<columns>`
 - Avoid abbreviations unless universally understood (`id`, `url`, `sku` are fine; `cust_addr` is not)
 - Never prefix with `tbl_` or `col_`
+
+### SQL comments (COMMENT ON)
+
+Document schemas, tables, and columns with `COMMENT ON`. These comments are stored in the database catalog, visible via `\d+` in psql, queryable from `pg_description`, and available to any tool that reads the catalog (ORMs, documentation generators, data catalogs). They are the single source of truth for what each object means.
+
+```sql
+COMMENT ON TABLE fact_sales IS 'One row per sale line item. Grain: one product sold in one transaction.';
+COMMENT ON COLUMN fact_sales.total_amount IS 'quantity * unit_price after discount. Additive across all dimensions.';
+COMMENT ON COLUMN dim_customer.customer_id IS 'Natural business key. Not unique in SCD Type 2: use customer_key for joins.';
+COMMENT ON INDEX idx_orders_status_created IS 'Covers active order queries filtered by status + date range.';
+```
+
+**What to document:**
+
+- Every table: its grain (what one row represents), its role (fact, dimension, staging, aggregate)
+- Columns where the name alone is ambiguous: units, business rules, whether it is additive, FK semantics
+- Non-obvious indexes: why they exist, which query patterns they serve
+- CASCADE foreign keys: why deletion cascades rather than restricts
+- Constraints with non-trivial logic: what business rule the CHECK or EXCLUDE enforces
+
+**When to write comments:** at table creation time, not retroactively. Treat `COMMENT ON` as part of the DDL, not optional documentation.
 
 ## Anti-Patterns
 

--- a/packages/server/src/agents/skills/sql-schema-modeling/SKILL.md
+++ b/packages/server/src/agents/skills/sql-schema-modeling/SKILL.md
@@ -216,9 +216,9 @@ PostgreSQL stores TEXT, VARCHAR, and VARCHAR(n) identically. No performance diff
 
 ### Timestamps
 
-Always use TIMESTAMPTZ, never TIMESTAMP (without time zone). PostgreSQL stores TIMESTAMPTZ as UTC internally and converts on display. TIMESTAMP without time zone is ambiguous: it causes bugs when servers change timezone or data crosses timezone boundaries.
+Prefer TIMESTAMPTZ for points-in-time (events, `created_at`, `updated_at`, audit logs, expiration times). PostgreSQL stores TIMESTAMPTZ as UTC internally and converts on display, which avoids bugs when servers change timezone or data crosses timezone boundaries.
 
-Use DATE when you genuinely only need the date (birthdays, business days). Use INTERVAL for durations.
+Use TIMESTAMP (without time zone) only for true local wall-clock datetimes that are not instants, such as a recurring local schedule or a store's local opening/closing time. Use DATE when you genuinely only need the date (birthdays, business days). Use INTERVAL for durations.
 
 ### Booleans
 
@@ -487,7 +487,7 @@ DO UPDATE SET
 
 Do not use SQL triggers or stored procedures as the primary vehicle for materializing derived data. They create hidden coupling (a developer inserting a row has no idea a cascade of side-effects fires), are difficult to test (requires integration tests against a live database), live as database state rather than version-controlled code, and scale poorly (database-tier compute is expensive and hard to scale horizontally).
 
-**The worst pattern:** triggers that auto-refresh materialized views on insert/update. Each row-level change triggers a full MV refresh: inserting 1000 rows means 1000 full refreshes, exponential dead tuple accumulation, and insert blocking.
+**The worst pattern:** triggers that auto-refresh materialized views on insert/update. Each row-level change triggers a full MV refresh: inserting 1000 rows means 1000 full refreshes, rapid dead tuple accumulation, heavy vacuum pressure, and insert blocking.
 
 **Valid uses for triggers:** simple audit trails (`created_at`/`updated_at` timestamps), enforcing invariants that cannot be expressed as CHECK constraints. Keep them minimal and side-effect-free.
 


### PR DESCRIPTION
## Summary

- Add Data Types, Constraints (CHECK, EXCLUDE, FK cascades), Unique Indexes, Partitioning (conservative: only after profiling), Materialization Strategy (MV scaling, pipeline-built tables, avoid triggers), and SQL documentation (COMMENT ON) sections to the sql-schema-modeling skill
- Add rule 5 "Inspect before querying" to agents.md requiring schema inspection and SQL comment reading before writing raw SQL against analytical databases
- Update docs/skills.md description to reflect new coverage

Closes #113