### PR TITLE
fix: fall back to Guide when persisted agent no longer exists

### DIFF
--- a/packages/server/src/websocket/handler.ts
+++ b/packages/server/src/websocket/handler.ts
@@ -157,7 +157,11 @@ export class WebSocketHandler {
         const newAgentId = message.agentId;
         const host = this.agentRegistry.get(newAgentId);
         if (!host) {
-          this.sendError(`Agent ${newAgentId} not found or terminated`);
+          this.send({
+            type: 'error',
+            message: `Agent ${newAgentId} not found or terminated`,
+            agentId: newAgentId,
+          });
           return;
         }
 

--- a/packages/ui/src/hooks/useWebSocket.ts
+++ b/packages/ui/src/hooks/useWebSocket.ts
@@ -240,6 +240,16 @@ export function useWebSocket() {
           console.error('Server error:', message.message);
           const aid = message.agentId ?? state.activeAgentId;
           if (aid !== null) state.setWaitingForResponse(false, aid);
+          // If the failed agent is the active non-Guide agent, fall back to Guide
+          // (handles stale persisted agent IDs from localStorage)
+          if (
+            message.agentId &&
+            state.guideAgentId &&
+            message.agentId === state.activeAgentId &&
+            message.agentId !== state.guideAgentId
+          ) {
+            state.setActiveAgent(state.guideAgentId, 'guide');
+          }
           break;
         }
 


### PR DESCRIPTION
## Summary

- Server now includes `agentId` in the error response when `switch_agent` fails (agent not found)
- Client falls back to Guide when it receives an error for the active non-Guide agent, handling stale localStorage entries

Fixes #120