### PR TITLE
fix: unify knowledge file commits via commitIfStateDir

### DIFF
--- a/2026-03-15.md
+++ b/2026-03-15.md
@@ -1,4 +1,0 @@
----
-last_narrator_update_ts: 2026-03-15T14:00:00.000Z
----
-# Daily Summary

--- a/2026-04-14.md
+++ b/2026-04-14.md
@@ -1,4 +1,0 @@
----
-last_narrator_update_ts: 2026-04-14T16:41:08.065Z
----
-# Daily Summary — 2026-04-14

--- a/log.md
+++ b/log.md
@@ -1,5 +1,0 @@
----
-last_narrator_update_ts: 2026-03-15T14:00:00.000Z
-project_id: 1
-project_name: TestProject
----

--- a/memory.md
+++ b/memory.md
@@ -1,3 +1,0 @@
----
-last_narrator_update_ts: 2026-04-14T16:41:08.108Z
----

--- a/packages/server/src/agents/tools/git-commit.test.ts
+++ b/packages/server/src/agents/tools/git-commit.test.ts
@@ -43,8 +43,11 @@ describe('commitIfStateDir', () => {
   }
 
   function initGitRepo(dir: string): void {
-    execSync('git init', { cwd: dir, env: gitEnv(), stdio: 'ignore' });
-    execSync('git commit --allow-empty -m "init"', { cwd: dir, env: gitEnv(), stdio: 'ignore' });
+    const opts = { cwd: dir, env: gitEnv(), stdio: 'ignore' as const };
+    execSync('git init', opts);
+    execSync('git config user.email "test@test.com"', opts);
+    execSync('git config user.name "Test"', opts);
+    execSync('git commit --allow-empty -m "init"', opts);
   }
 
   function commitCount(dir: string): number {

--- a/packages/server/src/agents/tools/git-commit.test.ts
+++ b/packages/server/src/agents/tools/git-commit.test.ts
@@ -93,10 +93,9 @@ describe('commitIfStateDir', () => {
     expect(lastMsg).toBe('cursor: infra.md');
   });
 
-  it('does not commit to the code repo even when run from it', () => {
+  it('does not commit to the code repo even when GIT_DIR points to it', () => {
     initGitRepo(system2Dir);
 
-    // Count commits in the actual code repo before
     const codeRepoRoot = execSync('git rev-parse --show-toplevel', {
       env: gitEnv(),
       encoding: 'utf-8',
@@ -105,7 +104,17 @@ describe('commitIfStateDir', () => {
 
     const filePath = join(system2Dir, 'knowledge', 'test.md');
     writeFileSync(filePath, 'should only go to system2 repo');
-    commitIfStateDir(filePath, 'cursor: test.md');
+
+    // Simulate the bug: parent process sets GIT_DIR / GIT_WORK_TREE
+    // to the code repo (this is what git hooks and dev servers do).
+    process.env.GIT_DIR = join(codeRepoRoot, '.git');
+    process.env.GIT_WORK_TREE = codeRepoRoot;
+    try {
+      commitIfStateDir(filePath, 'cursor: test.md');
+    } finally {
+      delete process.env.GIT_DIR;
+      delete process.env.GIT_WORK_TREE;
+    }
 
     // Code repo commit count must not change
     expect(commitCount(codeRepoRoot)).toBe(beforeCount);

--- a/packages/server/src/agents/tools/git-commit.test.ts
+++ b/packages/server/src/agents/tools/git-commit.test.ts
@@ -1,0 +1,113 @@
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock homedir() so commitIfStateDir targets our temp directory
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof import('node:os')>('node:os');
+  return { ...actual, homedir: vi.fn() };
+});
+
+import { homedir } from 'node:os';
+import { commitIfStateDir } from './git-commit.js';
+
+const mockHomedir = vi.mocked(homedir);
+
+describe('commitIfStateDir', () => {
+  let fakeHome: string;
+  let system2Dir: string;
+
+  beforeEach(() => {
+    fakeHome = join(
+      tmpdir(),
+      `git-commit-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+    );
+    system2Dir = join(fakeHome, '.system2');
+    mkdirSync(join(system2Dir, 'knowledge'), { recursive: true });
+    mockHomedir.mockReturnValue(fakeHome);
+  });
+
+  afterEach(() => {
+    if (existsSync(fakeHome)) {
+      rmSync(fakeHome, { recursive: true, force: true });
+    }
+  });
+
+  function initGitRepo(dir: string): void {
+    execSync('git init', { cwd: dir, stdio: 'ignore' });
+    execSync('git commit --allow-empty -m "init"', { cwd: dir, stdio: 'ignore' });
+  }
+
+  function commitCount(dir: string): number {
+    return Number(execSync('git rev-list --all --count', { cwd: dir, encoding: 'utf-8' }).trim());
+  }
+
+  it('skips when filePath is outside ~/.system2/', () => {
+    initGitRepo(system2Dir);
+    const outsidePath = join(fakeHome, 'other', 'file.md');
+    mkdirSync(join(fakeHome, 'other'), { recursive: true });
+    writeFileSync(outsidePath, 'data');
+
+    commitIfStateDir(outsidePath, 'should not commit');
+
+    expect(commitCount(system2Dir)).toBe(1); // only the init commit
+  });
+
+  it('skips when ~/.system2/.git does not exist', () => {
+    // No git init — .git doesn't exist
+    const filePath = join(system2Dir, 'knowledge', 'test.md');
+    writeFileSync(filePath, 'data');
+
+    commitIfStateDir(filePath, 'should not commit');
+
+    expect(existsSync(join(system2Dir, '.git'))).toBe(false);
+  });
+
+  it('commits to ~/.system2 repo when path is valid', () => {
+    initGitRepo(system2Dir);
+    const filePath = join(system2Dir, 'knowledge', 'infra.md');
+    writeFileSync(filePath, 'infrastructure data');
+
+    commitIfStateDir(filePath, 'cursor: infra.md');
+
+    expect(commitCount(system2Dir)).toBe(2); // init + our commit
+    const lastMsg = execSync('git log -1 --format=%s', {
+      cwd: system2Dir,
+      encoding: 'utf-8',
+    }).trim();
+    expect(lastMsg).toBe('cursor: infra.md');
+  });
+
+  it('does not commit to the code repo even when run from it', () => {
+    initGitRepo(system2Dir);
+
+    // Count commits in the actual code repo before
+    const codeRepoRoot = execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
+    const beforeCount = commitCount(codeRepoRoot);
+
+    const filePath = join(system2Dir, 'knowledge', 'test.md');
+    writeFileSync(filePath, 'should only go to system2 repo');
+    commitIfStateDir(filePath, 'cursor: test.md');
+
+    // Code repo commit count must not change
+    expect(commitCount(codeRepoRoot)).toBe(beforeCount);
+    // system2 repo must have the new commit
+    expect(commitCount(system2Dir)).toBe(2);
+  });
+
+  it('is a no-op when file has no changes', () => {
+    initGitRepo(system2Dir);
+    const filePath = join(system2Dir, 'knowledge', 'stable.md');
+    writeFileSync(filePath, 'unchanged');
+
+    // First commit
+    commitIfStateDir(filePath, 'first');
+    expect(commitCount(system2Dir)).toBe(2);
+
+    // Second call with same content — should not create a new commit
+    commitIfStateDir(filePath, 'second');
+    expect(commitCount(system2Dir)).toBe(2);
+  });
+});

--- a/packages/server/src/agents/tools/git-commit.test.ts
+++ b/packages/server/src/agents/tools/git-commit.test.ts
@@ -35,13 +35,22 @@ describe('commitIfStateDir', () => {
     }
   });
 
+  // Strip GIT_DIR / GIT_WORK_TREE so test helpers target the temp repo,
+  // not the code repo (git hooks set these in the environment).
+  function gitEnv() {
+    const { GIT_DIR, GIT_WORK_TREE, ...clean } = process.env;
+    return clean;
+  }
+
   function initGitRepo(dir: string): void {
-    execSync('git init', { cwd: dir, stdio: 'ignore' });
-    execSync('git commit --allow-empty -m "init"', { cwd: dir, stdio: 'ignore' });
+    execSync('git init', { cwd: dir, env: gitEnv(), stdio: 'ignore' });
+    execSync('git commit --allow-empty -m "init"', { cwd: dir, env: gitEnv(), stdio: 'ignore' });
   }
 
   function commitCount(dir: string): number {
-    return Number(execSync('git rev-list --all --count', { cwd: dir, encoding: 'utf-8' }).trim());
+    return Number(
+      execSync('git rev-list --all --count', { cwd: dir, env: gitEnv(), encoding: 'utf-8' }).trim()
+    );
   }
 
   it('skips when filePath is outside ~/.system2/', () => {
@@ -75,6 +84,7 @@ describe('commitIfStateDir', () => {
     expect(commitCount(system2Dir)).toBe(2); // init + our commit
     const lastMsg = execSync('git log -1 --format=%s', {
       cwd: system2Dir,
+      env: gitEnv(),
       encoding: 'utf-8',
     }).trim();
     expect(lastMsg).toBe('cursor: infra.md');
@@ -84,7 +94,10 @@ describe('commitIfStateDir', () => {
     initGitRepo(system2Dir);
 
     // Count commits in the actual code repo before
-    const codeRepoRoot = execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
+    const codeRepoRoot = execSync('git rev-parse --show-toplevel', {
+      env: gitEnv(),
+      encoding: 'utf-8',
+    }).trim();
     const beforeCount = commitCount(codeRepoRoot);
 
     const filePath = join(system2Dir, 'knowledge', 'test.md');

--- a/packages/server/src/agents/tools/git-commit.ts
+++ b/packages/server/src/agents/tools/git-commit.ts
@@ -16,19 +16,18 @@ import { join } from 'node:path';
  */
 export function commitIfStateDir(filePath: string, message: string): void {
   const system2Dir = join(homedir(), '.system2');
-  if (!filePath.startsWith(system2Dir) || !existsSync(join(system2Dir, '.git'))) {
+  if (!filePath.startsWith(`${system2Dir}/`) || !existsSync(join(system2Dir, '.git'))) {
     return;
   }
 
   // Strip GIT_DIR / GIT_WORK_TREE so git targets the ~/.system2 repo,
   // not whatever repo the parent process (dev server, git hook, etc.) uses.
   const { GIT_DIR, GIT_WORK_TREE, ...cleanEnv } = process.env;
+  const execOpts = { cwd: system2Dir, env: cleanEnv, stdio: 'ignore' as const, timeout: 10000 };
 
   try {
-    execSync(
-      `git add ${JSON.stringify(filePath)} && git diff --cached --quiet || git commit -m ${JSON.stringify(message)}`,
-      { cwd: system2Dir, env: cleanEnv, stdio: 'ignore', timeout: 10000 }
-    );
+    execSync(`git add ${JSON.stringify(filePath)}`, execOpts);
+    execSync(`git diff --cached --quiet || git commit -m ${JSON.stringify(message)}`, execOpts);
   } catch {
     // Git commit failure is non-fatal — the file operation already succeeded
   }

--- a/packages/server/src/agents/tools/git-commit.ts
+++ b/packages/server/src/agents/tools/git-commit.ts
@@ -20,10 +20,14 @@ export function commitIfStateDir(filePath: string, message: string): void {
     return;
   }
 
+  // Strip GIT_DIR / GIT_WORK_TREE so git targets the ~/.system2 repo,
+  // not whatever repo the parent process (dev server, git hook, etc.) uses.
+  const { GIT_DIR, GIT_WORK_TREE, ...cleanEnv } = process.env;
+
   try {
     execSync(
       `git add ${JSON.stringify(filePath)} && git diff --cached --quiet || git commit -m ${JSON.stringify(message)}`,
-      { cwd: system2Dir, stdio: 'ignore', timeout: 10000 }
+      { cwd: system2Dir, env: cleanEnv, stdio: 'ignore', timeout: 10000 }
     );
   } catch {
     // Git commit failure is non-fatal — the file operation already succeeded

--- a/packages/server/src/scheduler/jobs.ts
+++ b/packages/server/src/scheduler/jobs.ts
@@ -8,11 +8,11 @@
  * sender: 0 is a sentinel for system-generated messages (no agent sender).
  */
 
-import { execFileSync } from 'node:child_process';
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { basename, dirname, join } from 'node:path';
+import { basename, join } from 'node:path';
 import type { JobExecution } from '@dscarabelli/shared';
 import type { AgentHost } from '../agents/host.js';
+import { commitIfStateDir } from '../agents/tools/git-commit.js';
 import type { DatabaseClient } from '../db/client.js';
 import { resolveProjectDir } from '../projects/dir.js';
 import { log } from '../utils/logger.js';
@@ -75,36 +75,6 @@ export function writeFrontmatterField(filePath: string, field: string, value: st
   }
 
   writeFileSync(filePath, lines.join('\n'), 'utf-8');
-}
-
-/**
- * Git-commit a single knowledge file after a cursor update.
- * Best-effort: the cursor is durable in the filesystem regardless; the git
- * commit provides version-tracking. Silently no-ops outside a git repo (tests).
- */
-function commitKnowledgeFile(filePath: string, message: string): void {
-  const dir = dirname(filePath);
-  const file = basename(filePath);
-  try {
-    execFileSync('git', ['-C', dir, 'add', file], { stdio: 'pipe', timeout: 5000 });
-  } catch {
-    return; // Not in a git repo or file unchanged
-  }
-  try {
-    execFileSync('git', ['-C', dir, 'commit', '-m', message], { stdio: 'pipe', timeout: 5000 });
-  } catch (err) {
-    // Commit failed (lock contention, nothing to commit, etc.): unstage to
-    // prevent the file from leaking into a subsequent unrelated commit.
-    try {
-      execFileSync('git', ['-C', dir, 'reset', 'HEAD', file], { stdio: 'ignore', timeout: 5000 });
-    } catch {
-      // reset failed too; log below covers it
-    }
-    const stderr = (err as { stderr?: Buffer })?.stderr?.toString().trim();
-    if (stderr && !stderr.includes('nothing to commit')) {
-      log.info(`[Scheduler] commitKnowledgeFile: git commit failed for ${file}: ${stderr}`);
-    }
-  }
 }
 
 /**
@@ -496,11 +466,11 @@ function advanceFrontmatterCursors(
   newRunTs: string
 ): void {
   writeFrontmatterField(dailySummaryPath, 'last_narrator_update_ts', newRunTs);
-  commitKnowledgeFile(dailySummaryPath, `cursor: ${basename(dailySummaryPath)}`);
+  commitIfStateDir(dailySummaryPath, `cursor: ${basename(dailySummaryPath)}`);
   for (const pd of projectDataList) {
     if (pd.logFile) {
       writeFrontmatterField(pd.logFile, 'last_narrator_update_ts', newRunTs);
-      commitKnowledgeFile(pd.logFile, `cursor: ${pd.projectName} log`);
+      commitIfStateDir(pd.logFile, `cursor: ${pd.projectName} log`);
     }
   }
 }
@@ -948,5 +918,5 @@ ${messageParts.join('\n\n')}`;
 
   // Server-side cursor advancement for memory.md
   writeFrontmatterField(memoryFile, 'last_narrator_update_ts', newRunTs);
-  commitKnowledgeFile(memoryFile, 'cursor: memory.md');
+  commitIfStateDir(memoryFile, 'cursor: memory.md');
 }


### PR DESCRIPTION
## Summary

- **Root cause**: inherited `GIT_DIR`/`GIT_WORK_TREE` env vars from the parent process (dev server, git hooks) override git's repo detection even when `cwd:` is set, causing Narrator knowledge-file commits to land in the code repo instead of `~/.system2`
- Removes the duplicate `commitKnowledgeFile` helper from `jobs.ts` and routes all three call sites through the shared `commitIfStateDir` helper (already used by write/edit tools)
- Strips `GIT_DIR`/`GIT_WORK_TREE` from the env in `commitIfStateDir` so commits always target the `~/.system2` repo
- Deletes four stray knowledge files (`2026-03-15.md`, `2026-04-14.md`, `log.md`, `memory.md`) that were erroneously committed to the code repo root
- Adds 5 tests for `commitIfStateDir` covering skip conditions, valid commits, code-repo isolation, and idempotency

Fixes #122

## Test plan

- [x] All 648 tests pass (`pnpm test`)
- [x] Lint and format pass (`pnpm check`)
- [x] TypeScript compiles (`pnpm typecheck`)
- [x] Build succeeds (`pnpm build`)
- [x] Pre-push hooks pass (confirms the GIT_DIR fix works when git sets env vars)