### PR TITLE
feat: support more file types in artifact viewer

### DIFF
--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -74,9 +74,10 @@ The tool technically accepts any file path, not just registered artifacts. This 
 **Rendering by file type:**
 
 - `.html`, `.htm`: rendered in a sandboxed iframe (best experience for dashboards and interactive content)
-- `.md`: rendered as styled markdown (via react-markdown)
-- Images, PDFs: rendered natively by the browser in the iframe
-- Plain text (`.txt`, `.csv`, `.py`, etc.): displayed as raw text in the iframe (readable but unstyled, no syntax highlighting)
+- `.md`, `.markdown`: rendered as styled markdown (via react-markdown)
+- `.toml`, `.yaml`, `.yml`, `.json`, `.jsonl`, `.xml`, `.csv`, `.txt`, `.log`, `.sql`, `.py`, `.sh`, `.css`, `.ts`, `.tsx`, `.js`, `.jsx`: rendered as monospaced text in a styled code block
+- `.pdf`: rendered in a native browser iframe (scrollable, no dark mode filter)
+- `.png`, `.jpg`, `.jpeg`, `.gif`, `.svg`, `.webp`, `.avif`, `.ico`, `.bmp`: rendered as an inline image
 - Multiple artifacts can be open simultaneously in tabs
 
 **Live reload:** when `show_artifact` is called, the server starts an `fs.watch` on the file. Any modification triggers an automatic UI refresh of the corresponding tab (cache-busted URL). Only one artifact is watched at a time; showing a new artifact closes the previous watcher.

--- a/src/ui/components/ArtifactViewer.tsx
+++ b/src/ui/components/ArtifactViewer.tsx
@@ -15,6 +15,72 @@ import { useAccentColors } from '../theme/useAccentColors';
 import { KanbanBoard } from './KanbanBoard';
 import { ParticlesBackground } from './ParticlesBackground';
 
+function CodeArtifact({ url }: { url: string }) {
+  const [content, setContent] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setContent(null);
+    setError(null);
+    fetch(url, { signal: controller.signal })
+      .then((res) => {
+        if (!res.ok) throw new Error(`Failed to load: ${res.status}`);
+        return res.text();
+      })
+      .then(setContent)
+      .catch((err) => {
+        if (err.name !== 'AbortError') setError(err.message);
+      });
+    return () => controller.abort();
+  }, [url]);
+
+  if (error) {
+    return (
+      <Box sx={{ p: 4, color: 'danger.fg' }}>
+        <Text>{error}</Text>
+      </Box>
+    );
+  }
+
+  if (content === null) {
+    return (
+      <Box sx={{ p: 4, color: 'fg.muted' }}>
+        <Text>Loading…</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      sx={{
+        p: 3,
+        height: '100%',
+        overflow: 'auto',
+      }}
+    >
+      <Box
+        as="pre"
+        sx={{
+          m: 0,
+          p: 3,
+          fontFamily: 'mono',
+          fontSize: 0,
+          lineHeight: 1.5,
+          color: 'fg.default',
+          backgroundColor: 'neutral.muted',
+          borderRadius: 2,
+          overflow: 'auto',
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+        }}
+      >
+        {content}
+      </Box>
+    </Box>
+  );
+}
+
 function MarkdownArtifact({ url }: { url: string }) {
   const [content, setContent] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -286,6 +352,10 @@ export function ArtifactViewer() {
                 <KanbanBoard />
               ) : /\.(?:md|markdown)$/i.test(activeTab.filePath) ? (
                 <MarkdownArtifact url={activeTab.url} />
+              ) : /\.(?:toml|ya?ml|jsonl?|xml|csv|txt|log|sql|py|sh|css|ts|tsx|js|jsx)$/i.test(
+                  activeTab.filePath
+                ) ? (
+                <CodeArtifact url={activeTab.url} />
               ) : /\.html?$/i.test(activeTab.filePath) ? (
                 <iframe
                   ref={iframeRef}
@@ -301,6 +371,32 @@ export function ArtifactViewer() {
                     filter: isLight ? 'none' : 'invert(1) hue-rotate(180deg)',
                   }}
                 />
+              ) : /\.pdf$/i.test(activeTab.filePath) ? (
+                <iframe
+                  src={activeTab.url}
+                  title={activeTab.title}
+                  style={{
+                    width: '100%',
+                    height: '100%',
+                    border: 'none',
+                  }}
+                />
+              ) : /\.(?:png|jpe?g|gif|svg|webp|avif|ico|bmp)$/i.test(activeTab.filePath) ? (
+                <Box
+                  sx={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    height: '100%',
+                    p: 3,
+                  }}
+                >
+                  <img
+                    src={activeTab.url}
+                    alt={activeTab.title}
+                    style={{ maxWidth: '100%', maxHeight: '100%', objectFit: 'contain' }}
+                  />
+                </Box>
               ) : (
                 <Box
                   sx={{

--- a/src/ui/components/ArtifactViewer.tsx
+++ b/src/ui/components/ArtifactViewer.tsx
@@ -15,7 +15,9 @@ import { useAccentColors } from '../theme/useAccentColors';
 import { KanbanBoard } from './KanbanBoard';
 import { ParticlesBackground } from './ParticlesBackground';
 
-function CodeArtifact({ url }: { url: string }) {
+const MAX_PREVIEW_BYTES = 5 * 1024 * 1024; // 5 MB
+
+function useFetchText(url: string) {
   const [content, setContent] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -26,14 +28,30 @@ function CodeArtifact({ url }: { url: string }) {
     fetch(url, { signal: controller.signal })
       .then((res) => {
         if (!res.ok) throw new Error(`Failed to load: ${res.status}`);
+        const length = res.headers.get('content-length');
+        if (length && Number(length) > MAX_PREVIEW_BYTES) {
+          throw new Error('File too large to preview');
+        }
         return res.text();
       })
-      .then(setContent)
+      .then((text) => {
+        if (text.length > MAX_PREVIEW_BYTES) {
+          setContent(`${text.slice(0, MAX_PREVIEW_BYTES)}\n\n… (truncated, file exceeds 5 MB)`);
+        } else {
+          setContent(text);
+        }
+      })
       .catch((err) => {
         if (err.name !== 'AbortError') setError(err.message);
       });
     return () => controller.abort();
   }, [url]);
+
+  return { content, error };
+}
+
+function CodeArtifact({ url }: { url: string }) {
+  const { content, error } = useFetchText(url);
 
   if (error) {
     return (
@@ -53,53 +71,27 @@ function CodeArtifact({ url }: { url: string }) {
 
   return (
     <Box
+      as="pre"
       sx={{
+        m: 0,
         p: 3,
-        height: '100%',
+        fontFamily: 'mono',
+        fontSize: 0,
+        lineHeight: 1.5,
+        color: 'fg.default',
+        backgroundColor: 'neutral.muted',
+        borderRadius: 2,
         overflow: 'auto',
+        whiteSpace: 'pre',
       }}
     >
-      <Box
-        as="pre"
-        sx={{
-          m: 0,
-          p: 3,
-          fontFamily: 'mono',
-          fontSize: 0,
-          lineHeight: 1.5,
-          color: 'fg.default',
-          backgroundColor: 'neutral.muted',
-          borderRadius: 2,
-          overflow: 'auto',
-          whiteSpace: 'pre-wrap',
-          wordBreak: 'break-word',
-        }}
-      >
-        {content}
-      </Box>
+      {content}
     </Box>
   );
 }
 
 function MarkdownArtifact({ url }: { url: string }) {
-  const [content, setContent] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    setContent(null);
-    setError(null);
-    fetch(url, { signal: controller.signal })
-      .then((res) => {
-        if (!res.ok) throw new Error(`Failed to load: ${res.status}`);
-        return res.text();
-      })
-      .then(setContent)
-      .catch((err) => {
-        if (err.name !== 'AbortError') setError(err.message);
-      });
-    return () => controller.abort();
-  }, [url]);
+  const { content, error } = useFetchText(url);
 
   if (error) {
     return (

--- a/src/ui/components/ArtifactViewer.tsx
+++ b/src/ui/components/ArtifactViewer.tsx
@@ -366,6 +366,7 @@ export function ArtifactViewer() {
               ) : /\.pdf$/i.test(activeTab.filePath) ? (
                 <iframe
                   src={activeTab.url}
+                  sandbox="allow-same-origin"
                   title={activeTab.title}
                   style={{
                     width: '100%',


### PR DESCRIPTION
## Summary

- Add `CodeArtifact` component for text-based formats (TOML, YAML, JSON, JSONL, XML, CSV, TXT, LOG, SQL, PY, SH, CSS, TS/TSX, JS/JSX) rendered as monospaced text in a styled code block
- Add PDF rendering via native browser iframe (scrollable, no dark mode filter)
- Add inline image display for common formats (PNG, JPEG, GIF, SVG, WebP, AVIF, ICO, BMP)
- Update docs to reflect the new supported file types

Previously only HTML and Markdown were viewable; all other types showed "Cannot preview this file type."