### PR TITLE
fix: prevent write tool from overwriting config.toml

### DIFF
--- a/src/server/agents/skills/system2-onboarding/SKILL.md
+++ b/src/server/agents/skills/system2-onboarding/SKILL.md
@@ -83,7 +83,7 @@ The knowledge files in `~/.system2/knowledge/` are seeded with structural templa
      # SQLite: no install needed (built-in)
      ```
 
-     **Write a config entry** to `~/.system2/config.toml` for each database. Use the `write` tool to append a `[databases.<name>]` section. Do NOT include passwords: they belong in native credential files or environment variables. Examples:
+     **Write a config entry** to `~/.system2/config.toml` for each database. Use the `edit` tool with `append: true` to add a `[databases.<name>]` section. NEVER use the `write` tool on config.toml as it replaces the entire file and will destroy existing sections (LLM keys, services, operational settings). Do NOT include passwords: they belong in native credential files or environment variables. Examples:
 
      ```toml
      [databases.my_postgres]

--- a/src/server/agents/tools/write.ts
+++ b/src/server/agents/tools/write.ts
@@ -31,7 +31,7 @@ export function createWriteTool() {
     name: 'write',
     label: 'Write File',
     description:
-      'Write content to a file. Creates parent directories if needed. Overwrites the entire file. Use this for creating new files or complete rewrites. For modifying specific parts of an existing file, prefer the `edit` tool. For appending content, use `edit` with `append: true`. For bulk replacements and similar operations, use `bash` with `sed`, `awk`, or similar.',
+      'Write content to a file. Creates parent directories if needed. WARNING: this tool REPLACES the entire file content. Any existing content not included in `content` will be permanently lost. Use this ONLY for creating new files or complete rewrites where you provide ALL content. To add a section to an existing file (e.g. adding a [databases.*] entry to config.toml), use the `edit` tool with `append: true` so you do not destroy existing sections. For modifying specific parts, use `edit`. For bulk replacements, use `bash` with `sed` or `awk`.',
     parameters: params,
     execute: async (_toolCallId, params, _signal, _onUpdate) => {
       try {


### PR DESCRIPTION
## Problem

During onboarding, the guide agent used the `write` tool to add a `[databases]` section to `config.toml`. Since `write` replaces the entire file, this destroyed the existing `[llm]`, `[services]`, and operational sections, leaving system2 unable to start ("has not been onboarded yet").

The onboarding skill instruction was contradictory: it said "Use the `write` tool to append", but the write tool overwrites, it does not append.

## Fix

**Write tool description** (`write.ts`): Added a prominent WARNING that the tool replaces entire file content, with config.toml called out as a specific example of when to use `edit` with `append: true` instead.

**Onboarding skill** (`SKILL.md`): Changed "Use the `write` tool to append" to "Use the `edit` tool with `append: true`" and added an explicit "NEVER use the `write` tool on config.toml" warning explaining the destructive consequence.