### PR TITLE
feat: warn in write tool output when overwriting existing file

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -84,7 +84,7 @@ Edit a file by replacing an exact string match, or append content to a file.
 
 ### `write`
 
-Write or create files on the filesystem. Overwrites the entire file.
+Create a new file or write to an empty file. **Refuses to overwrite** an existing file that already contains data.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -92,7 +92,7 @@ Write or create files on the filesystem. Overwrites the entire file.
 | `content` | string | File content to write |
 | `commit_message` | string? | If provided and path is inside `~/.system2/`, git-commits the file with this message |
 
-Auto-creates parent directories if they don't exist. Use for creating new files or complete rewrites. For modifying specific parts of an existing file, prefer `edit`. For appending content, use `edit` with `append: true`. For operations where none of the above fit, use `bash`.
+Auto-creates parent directories if they don't exist. If the target file already exists and has content, the tool returns an error with a preview of the existing content and suggests using `edit` instead, or deleting the file first (`bash`: `rm <path>`) for intentional full replacement. For modifying specific parts of an existing file, use `edit`. For appending content, use `edit` with `append: true`. For operations where none of the above fit, use `bash`.
 
 **Auto-commit (`edit` and `write`):** When `commit_message` is provided, the tool runs `git add <file> && git commit -m <message>` in `~/.system2/` after the file operation. Git failure is non-fatal: the file change still succeeds. This is the primary mechanism for version-tracking knowledge and project files.
 

--- a/src/server/agents/library/guide.md
+++ b/src/server/agents/library/guide.md
@@ -124,6 +124,16 @@ All agents follow the knowledge management rules in agents.md (what goes where, 
 These are living documents. Update them whenever relevant information surfaces: during direct user interactions, when the user describes their environment or preferences, or when Conductor reports signal new facts about the data stack, tooling, or the user's working style and goals. After every update, check whether the document structure is still optimal. If sections have grown stale, overlapping, or poorly organized, restructure them. The goal is a document that is always accurate, concise, and easy for any agent to read at a glance.
 - **File size budget**: `infrastructure.md`, `user.md`, and `guide.md` each have a character budget (default: 20,000). When updating these files, actively remove outdated, redundant, or low-value content. If a file grows beyond the budget, the Narrator will condense it during the next memory-update run.
 
+## Recovery
+
+System2 automatically backs up `~/.system2/` on every server start (with a configurable cooldown, default 24 hours). Backups are stored at `~/.system2-auto-backup-YYYY-MM-DDTHH-MM-SS/` with a retention limit (default: 3 most recent). When the user encounters data loss, corruption, or an irreversible mistake affecting files in `~/.system2/` (knowledge files, config.toml, project data, artifacts), check for available backups and offer to restore the affected files:
+
+```bash
+ls -dt ~/.system2-auto-backup-* | head -3   # list available backups
+```
+
+Restore selectively: copy only the affected files from the backup, not the entire directory, to avoid overwriting newer valid state. Always confirm with the user before restoring.
+
 ## Additional Guidelines
 
 - **Ask, don't assume**: When a request is ambiguous or has meaningful options, ask a focused question before acting. Don't front-load a list of clarifications.

--- a/src/server/agents/tools/write.test.ts
+++ b/src/server/agents/tools/write.test.ts
@@ -51,17 +51,18 @@ describe('write tool', () => {
     expect(readFileSync(file, 'utf-8')).toBe('nested');
   });
 
-  it('overwrites an existing file', async () => {
+  it('writes to an existing empty file', async () => {
     const dir = trackDir(makeTmpDir());
-    const file = join(dir, 'existing.txt');
-    writeFileSync(file, 'old content');
+    const file = join(dir, 'empty.txt');
+    writeFileSync(file, '');
 
-    await exec({ path: file, content: 'new content' });
+    const result = await exec({ path: file, content: 'now has content' });
 
-    expect(readFileSync(file, 'utf-8')).toBe('new content');
+    expect((result.content[0] as { text: string }).text).toContain('Successfully wrote');
+    expect(readFileSync(file, 'utf-8')).toBe('now has content');
   });
 
-  it('warns when overwriting an existing file with content', async () => {
+  it('blocks overwriting an existing file with content', async () => {
     const dir = trackDir(makeTmpDir());
     const file = join(dir, 'existing.txt');
     writeFileSync(file, 'important existing content');
@@ -69,22 +70,27 @@ describe('write tool', () => {
     const result = await exec({ path: file, content: 'replacement' });
     const text = (result.content[0] as { text: string }).text;
 
-    expect(text).toContain('WARNING: Overwrote existing file');
+    // Should block the write
+    expect(text).toContain('Cannot write: file already exists with content');
     expect(text).toContain('important existing content');
-    expect(text).toContain('Use the `edit` tool');
+    expect(text).toContain('edit');
+    expect(text).toContain('delete it first');
+    // Original content should be preserved
+    expect(readFileSync(file, 'utf-8')).toBe('important existing content');
   });
 
-  it('does not warn when creating a new file', async () => {
+  it('includes file size in blocked overwrite message', async () => {
     const dir = trackDir(makeTmpDir());
-    const file = join(dir, 'brand-new.txt');
+    const file = join(dir, 'sized.txt');
+    writeFileSync(file, 'hello world');
 
-    const result = await exec({ path: file, content: 'fresh' });
+    const result = await exec({ path: file, content: 'replacement' });
     const text = (result.content[0] as { text: string }).text;
 
-    expect(text).not.toContain('WARNING');
+    expect(text).toContain('11 bytes');
   });
 
-  it('truncates long existing content in overwrite warning', async () => {
+  it('truncates long existing content in blocked overwrite preview', async () => {
     const dir = trackDir(makeTmpDir());
     const file = join(dir, 'big.txt');
     const longContent = 'x'.repeat(500);
@@ -93,9 +99,21 @@ describe('write tool', () => {
     const result = await exec({ path: file, content: 'short' });
     const text = (result.content[0] as { text: string }).text;
 
-    expect(text).toContain('WARNING: Overwrote existing file (500 bytes)');
+    expect(text).toContain('500 bytes');
     expect(text).toContain('...');
     // Preview should be truncated, not the full 500 chars
     expect(text.indexOf('x'.repeat(201))).toBe(-1);
+    // Original content should be preserved
+    expect(readFileSync(file, 'utf-8')).toBe(longContent);
+  });
+
+  it('sets blocked flag in details when overwrite is prevented', async () => {
+    const dir = trackDir(makeTmpDir());
+    const file = join(dir, 'flagged.txt');
+    writeFileSync(file, 'content');
+
+    const result = await exec({ path: file, content: 'replacement' });
+
+    expect((result.details as Record<string, unknown>).blocked).toBe(true);
   });
 });

--- a/src/server/agents/tools/write.test.ts
+++ b/src/server/agents/tools/write.test.ts
@@ -60,4 +60,42 @@ describe('write tool', () => {
 
     expect(readFileSync(file, 'utf-8')).toBe('new content');
   });
+
+  it('warns when overwriting an existing file with content', async () => {
+    const dir = trackDir(makeTmpDir());
+    const file = join(dir, 'existing.txt');
+    writeFileSync(file, 'important existing content');
+
+    const result = await exec({ path: file, content: 'replacement' });
+    const text = (result.content[0] as { text: string }).text;
+
+    expect(text).toContain('WARNING: Overwrote existing file');
+    expect(text).toContain('important existing content');
+    expect(text).toContain('Use the `edit` tool');
+  });
+
+  it('does not warn when creating a new file', async () => {
+    const dir = trackDir(makeTmpDir());
+    const file = join(dir, 'brand-new.txt');
+
+    const result = await exec({ path: file, content: 'fresh' });
+    const text = (result.content[0] as { text: string }).text;
+
+    expect(text).not.toContain('WARNING');
+  });
+
+  it('truncates long existing content in overwrite warning', async () => {
+    const dir = trackDir(makeTmpDir());
+    const file = join(dir, 'big.txt');
+    const longContent = 'x'.repeat(500);
+    writeFileSync(file, longContent);
+
+    const result = await exec({ path: file, content: 'short' });
+    const text = (result.content[0] as { text: string }).text;
+
+    expect(text).toContain('WARNING: Overwrote existing file (500 bytes)');
+    expect(text).toContain('...');
+    // Preview should be truncated, not the full 500 chars
+    expect(text.indexOf('x'.repeat(201))).toBe(-1);
+  });
 });

--- a/src/server/agents/tools/write.test.ts
+++ b/src/server/agents/tools/write.test.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { homedir, tmpdir } from 'node:os';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { createWriteTool, isSensitivePath } from './write.js';
+import { createWriteTool } from './write.js';
 
 function makeTmpDir(): string {
   const dir = join(tmpdir(), `system2-test-write-${randomUUID().slice(0, 8)}`);
@@ -117,40 +117,5 @@ describe('write tool', () => {
     const result = await exec({ path: file, content: 'replacement' });
 
     expect((result.details as Record<string, unknown>).blocked).toBe(true);
-  });
-
-  describe('isSensitivePath', () => {
-    it('returns true for files inside ~/.system2/', () => {
-      expect(isSensitivePath(join(homedir(), '.system2', 'config.toml'))).toBe(true);
-      expect(isSensitivePath(join(homedir(), '.system2', 'nested', 'file.txt'))).toBe(true);
-    });
-
-    it('returns false for files outside ~/.system2/', () => {
-      expect(isSensitivePath(join(tmpdir(), 'file.txt'))).toBe(false);
-      expect(isSensitivePath(join(homedir(), 'projects', 'config.toml'))).toBe(false);
-      expect(isSensitivePath(join(homedir(), '.system2-other', 'file.txt'))).toBe(false);
-    });
-  });
-
-  it('omits content preview for files in ~/.system2/', async () => {
-    // Create a temp file inside ~/.system2/ — the actual state directory — to
-    // avoid mocking node:os. The file is cleaned up in afterEach.
-    const stateDir = join(homedir(), '.system2');
-    mkdirSync(stateDir, { recursive: true });
-    const file = join(stateDir, `test-write-sensitive-${randomUUID().slice(0, 8)}.txt`);
-    const secretContent = 'key = "sk-ant-secret-value"';
-    writeFileSync(file, secretContent);
-    tmpDirs.push(file); // cleaned up by afterEach via rmSync
-
-    const result = await exec({ path: file, content: 'replacement' });
-    const text = (result.content[0] as { text: string }).text;
-
-    // Should still be blocked and report size
-    expect(text).toContain('Cannot write: file already exists with content');
-    // Should NOT include content preview to avoid leaking secrets
-    expect(text).not.toContain(secretContent);
-    expect(text).not.toContain('Existing content starts with');
-    // Original content should be preserved
-    expect(readFileSync(file, 'utf-8')).toBe(secretContent);
   });
 });

--- a/src/server/agents/tools/write.test.ts
+++ b/src/server/agents/tools/write.test.ts
@@ -1,9 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { createWriteTool } from './write.js';
+import { createWriteTool, isSensitivePath } from './write.js';
 
 function makeTmpDir(): string {
   const dir = join(tmpdir(), `system2-test-write-${randomUUID().slice(0, 8)}`);
@@ -101,8 +101,10 @@ describe('write tool', () => {
 
     expect(text).toContain('500 bytes');
     expect(text).toContain('...');
-    // Preview should be truncated, not the full 500 chars
-    expect(text.indexOf('x'.repeat(201))).toBe(-1);
+    // Preview should be capped at PREVIEW_BYTES (200), not the full 500 chars
+    const match = text.match(/x+/);
+    expect(match).not.toBeNull();
+    expect((match as RegExpMatchArray)[0].length).toBeLessThanOrEqual(200);
     // Original content should be preserved
     expect(readFileSync(file, 'utf-8')).toBe(longContent);
   });
@@ -115,5 +117,40 @@ describe('write tool', () => {
     const result = await exec({ path: file, content: 'replacement' });
 
     expect((result.details as Record<string, unknown>).blocked).toBe(true);
+  });
+
+  describe('isSensitivePath', () => {
+    it('returns true for files inside ~/.system2/', () => {
+      expect(isSensitivePath(join(homedir(), '.system2', 'config.toml'))).toBe(true);
+      expect(isSensitivePath(join(homedir(), '.system2', 'nested', 'file.txt'))).toBe(true);
+    });
+
+    it('returns false for files outside ~/.system2/', () => {
+      expect(isSensitivePath(join(tmpdir(), 'file.txt'))).toBe(false);
+      expect(isSensitivePath(join(homedir(), 'projects', 'config.toml'))).toBe(false);
+      expect(isSensitivePath(join(homedir(), '.system2-other', 'file.txt'))).toBe(false);
+    });
+  });
+
+  it('omits content preview for files in ~/.system2/', async () => {
+    // Create a temp file inside ~/.system2/ — the actual state directory — to
+    // avoid mocking node:os. The file is cleaned up in afterEach.
+    const stateDir = join(homedir(), '.system2');
+    mkdirSync(stateDir, { recursive: true });
+    const file = join(stateDir, `test-write-sensitive-${randomUUID().slice(0, 8)}.txt`);
+    const secretContent = 'key = "sk-ant-secret-value"';
+    writeFileSync(file, secretContent);
+    tmpDirs.push(file); // cleaned up by afterEach via rmSync
+
+    const result = await exec({ path: file, content: 'replacement' });
+    const text = (result.content[0] as { text: string }).text;
+
+    // Should still be blocked and report size
+    expect(text).toContain('Cannot write: file already exists with content');
+    // Should NOT include content preview to avoid leaking secrets
+    expect(text).not.toContain(secretContent);
+    expect(text).not.toContain('Existing content starts with');
+    // Original content should be preserved
+    expect(readFileSync(file, 'utf-8')).toBe(secretContent);
   });
 });

--- a/src/server/agents/tools/write.ts
+++ b/src/server/agents/tools/write.ts
@@ -71,7 +71,7 @@ export function createWriteTool() {
                   type: 'text',
                   text:
                     `Cannot write: file already exists with content (${stats.size} bytes). ` +
-                    `Use the \`edit\` tool to modify it, or delete it first (\`bash\`: \`rm ${params.path}\`) ` +
+                    `Use the \`edit\` tool to modify it, or delete it first (\`bash\`: \`rm "${params.path}"\`) ` +
                     `then retry this write.\n\nExisting content starts with:\n${preview}${suffix}`,
                 },
               ],

--- a/src/server/agents/tools/write.ts
+++ b/src/server/agents/tools/write.ts
@@ -6,15 +6,15 @@
  * existing file, delete it first (via bash `rm`), then write.
  */
 
-import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
+import { mkdir, open, stat, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { Type } from '@sinclair/typebox';
 import { commitIfStateDir } from './git-commit.js';
 import { resolvePath } from './resolve-path.js';
 
-/** Max characters of existing content to include in the blocked-overwrite preview. */
-const PREVIEW_CHARS = 200;
+/** Max bytes of existing content to include in the blocked-overwrite preview. */
+const PREVIEW_BYTES = 200;
 
 export function createWriteTool() {
   const params = Type.Object({
@@ -51,9 +51,17 @@ export function createWriteTool() {
         try {
           const stats = await stat(filePath);
           if (stats.isFile() && stats.size > 0) {
-            const existing = await readFile(filePath, 'utf-8');
-            const preview =
-              existing.length > PREVIEW_CHARS ? `${existing.slice(0, PREVIEW_CHARS)}...` : existing;
+            // Read only the first PREVIEW_BYTES to avoid loading large files
+            const bytesToRead = Math.min(stats.size, PREVIEW_BYTES);
+            const buf = Buffer.alloc(bytesToRead);
+            const fh = await open(filePath, 'r');
+            try {
+              await fh.read(buf, 0, bytesToRead, 0);
+            } finally {
+              await fh.close();
+            }
+            const preview = buf.toString('utf-8');
+            const truncated = stats.size > PREVIEW_BYTES ? `${preview}...` : preview;
             return {
               content: [
                 {
@@ -61,13 +69,14 @@ export function createWriteTool() {
                   text:
                     `Cannot write: file already exists with content (${stats.size} bytes). ` +
                     `Use the \`edit\` tool to modify it, or delete it first (\`bash\`: \`rm ${params.path}\`) ` +
-                    `then retry this write.\n\nExisting content starts with:\n${preview}`,
+                    `then retry this write.\n\nExisting content starts with:\n${truncated}`,
                 },
               ],
               details: { path: filePath, blocked: true, existingSize: stats.size },
             };
           }
-        } catch {
+        } catch (err: unknown) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
           // File doesn't exist, safe to write
         }
 

--- a/src/server/agents/tools/write.ts
+++ b/src/server/agents/tools/write.ts
@@ -56,14 +56,15 @@ export function createWriteTool() {
             const bytesToRead = Math.min(stats.size, PREVIEW_BYTES);
             const buf = Buffer.alloc(bytesToRead);
             const fh = await open(filePath, 'r');
+            let bytesRead = 0;
             try {
-              await fh.read(buf, 0, bytesToRead, 0);
+              ({ bytesRead } = await fh.read(buf, 0, bytesToRead, 0));
             } finally {
               await fh.close();
             }
             // StringDecoder handles incomplete multi-byte sequences at the boundary
             const decoder = new StringDecoder('utf8');
-            const preview = decoder.write(buf) + decoder.end();
+            const preview = decoder.write(buf.subarray(0, bytesRead)) + decoder.end();
             const suffix = stats.size > PREVIEW_BYTES ? '...' : '';
             return {
               content: [

--- a/src/server/agents/tools/write.ts
+++ b/src/server/agents/tools/write.ts
@@ -7,7 +7,9 @@
  */
 
 import { mkdir, open, stat, writeFile } from 'node:fs/promises';
-import { dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { dirname, join, resolve, sep } from 'node:path';
+import { StringDecoder } from 'node:string_decoder';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { Type } from '@sinclair/typebox';
 import { commitIfStateDir } from './git-commit.js';
@@ -15,6 +17,17 @@ import { resolvePath } from './resolve-path.js';
 
 /** Max bytes of existing content to include in the blocked-overwrite preview. */
 const PREVIEW_BYTES = 200;
+
+/**
+ * Returns true for files inside ~/.system2/ whose content may contain API keys
+ * or other credentials. Content previews are suppressed for these paths.
+ * Note: symlinks are not resolved; paths are assumed to be absolute and
+ * already normalized (as produced by resolvePath()).
+ */
+export function isSensitivePath(filePath: string): boolean {
+  const stateDir = join(homedir(), '.system2') + sep;
+  return resolve(filePath).startsWith(stateDir);
+}
 
 export function createWriteTool() {
   const params = Type.Object({
@@ -51,17 +64,23 @@ export function createWriteTool() {
         try {
           const stats = await stat(filePath);
           if (stats.isFile() && stats.size > 0) {
-            // Read only the first PREVIEW_BYTES to avoid loading large files
-            const bytesToRead = Math.min(stats.size, PREVIEW_BYTES);
-            const buf = Buffer.alloc(bytesToRead);
-            const fh = await open(filePath, 'r');
-            try {
-              await fh.read(buf, 0, bytesToRead, 0);
-            } finally {
-              await fh.close();
+            let previewSection = '';
+            if (!isSensitivePath(filePath)) {
+              // Read only the first PREVIEW_BYTES to avoid loading large files
+              const bytesToRead = Math.min(stats.size, PREVIEW_BYTES);
+              const buf = Buffer.alloc(bytesToRead);
+              const fh = await open(filePath, 'r');
+              try {
+                await fh.read(buf, 0, bytesToRead, 0);
+              } finally {
+                await fh.close();
+              }
+              // StringDecoder handles incomplete multi-byte sequences at the boundary
+              const decoder = new StringDecoder('utf8');
+              const preview = decoder.write(buf);
+              const suffix = stats.size > PREVIEW_BYTES ? '...' : '';
+              previewSection = `\n\nExisting content starts with:\n${preview}${suffix}`;
             }
-            const preview = buf.toString('utf-8');
-            const truncated = stats.size > PREVIEW_BYTES ? `${preview}...` : preview;
             return {
               content: [
                 {
@@ -69,7 +88,7 @@ export function createWriteTool() {
                   text:
                     `Cannot write: file already exists with content (${stats.size} bytes). ` +
                     `Use the \`edit\` tool to modify it, or delete it first (\`bash\`: \`rm ${params.path}\`) ` +
-                    `then retry this write.\n\nExisting content starts with:\n${truncated}`,
+                    `then retry this write.${previewSection}`,
                 },
               ],
               details: { path: filePath, blocked: true, existingSize: stats.size },

--- a/src/server/agents/tools/write.ts
+++ b/src/server/agents/tools/write.ts
@@ -34,7 +34,7 @@ export function createWriteTool() {
     name: 'write',
     label: 'Write File',
     description:
-      'Write content to a file. Creates parent directories if needed. WARNING: this tool REPLACES the entire file content. Any existing content not included in `content` will be permanently lost. Use this ONLY for creating new files or complete rewrites where you provide ALL content. To add a section to an existing file (e.g. adding a [databases.*] entry to config.toml), use the `edit` tool with `append: true` so you do not destroy existing sections. For modifying specific parts, use `edit`. For bulk replacements, use `bash` with `sed` or `awk`.',
+      'Write content to a file. Creates parent directories if needed. Best for creating new files or intentionally rewriting an existing file from scratch. WARNING: this tool REPLACES the entire file content. If the file already exists, read it first so you know what you are replacing and can preserve any content that should be kept. To add a section to an existing file (e.g. adding a [databases.<name>] entry to config.toml), use the `edit` tool with `append: true` so you do not destroy existing sections. For modifying specific parts, use `edit`. For bulk replacements, use `bash` with `sed` or `awk`.',
     parameters: params,
     execute: async (_toolCallId, params, _signal, _onUpdate) => {
       try {

--- a/src/server/agents/tools/write.ts
+++ b/src/server/agents/tools/write.ts
@@ -4,12 +4,15 @@
  * Writes content to files on the filesystem.
  */
 
-import { mkdir, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { Type } from '@sinclair/typebox';
 import { commitIfStateDir } from './git-commit.js';
 import { resolvePath } from './resolve-path.js';
+
+/** Max bytes of existing content to include in the overwrite warning. */
+const PREVIEW_BYTES = 200;
 
 export function createWriteTool() {
   const params = Type.Object({
@@ -37,6 +40,24 @@ export function createWriteTool() {
       try {
         const filePath = resolvePath(params.path);
 
+        // Check if we're about to overwrite an existing file
+        let overwriteWarning = '';
+        try {
+          const stats = await stat(filePath);
+          if (stats.isFile() && stats.size > 0) {
+            const existing = await readFile(filePath, 'utf-8');
+            const preview =
+              existing.length > PREVIEW_BYTES ? `${existing.slice(0, PREVIEW_BYTES)}...` : existing;
+            overwriteWarning =
+              `\n\nWARNING: Overwrote existing file (${stats.size} bytes). ` +
+              `Previous content started with:\n${preview}\n\n` +
+              'If this was unintentional, the existing content is now lost. ' +
+              'Use the `edit` tool to modify files without replacing them entirely.';
+          }
+        } catch {
+          // File doesn't exist, no warning needed
+        }
+
         const dir = dirname(filePath);
         await mkdir(dir, { recursive: true });
 
@@ -50,7 +71,7 @@ export function createWriteTool() {
           content: [
             {
               type: 'text',
-              text: `Successfully wrote ${params.content.length} bytes to ${params.path}`,
+              text: `Successfully wrote ${params.content.length} bytes to ${params.path}${overwriteWarning}`,
             },
           ],
           details: { path: filePath, size: params.content.length },

--- a/src/server/agents/tools/write.ts
+++ b/src/server/agents/tools/write.ts
@@ -77,7 +77,7 @@ export function createWriteTool() {
               }
               // StringDecoder handles incomplete multi-byte sequences at the boundary
               const decoder = new StringDecoder('utf8');
-              const preview = decoder.write(buf);
+              const preview = decoder.write(buf) + decoder.end();
               const suffix = stats.size > PREVIEW_BYTES ? '...' : '';
               previewSection = `\n\nExisting content starts with:\n${preview}${suffix}`;
             }

--- a/src/server/agents/tools/write.ts
+++ b/src/server/agents/tools/write.ts
@@ -2,6 +2,8 @@
  * Write Tool
  *
  * Writes content to files on the filesystem.
+ * Refuses to overwrite existing files that contain data. To replace an
+ * existing file, delete it first (via bash `rm`), then write.
  */
 
 import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
@@ -11,8 +13,8 @@ import { Type } from '@sinclair/typebox';
 import { commitIfStateDir } from './git-commit.js';
 import { resolvePath } from './resolve-path.js';
 
-/** Max bytes of existing content to include in the overwrite warning. */
-const PREVIEW_BYTES = 200;
+/** Max characters of existing content to include in the blocked-overwrite preview. */
+const PREVIEW_CHARS = 200;
 
 export function createWriteTool() {
   const params = Type.Object({
@@ -34,28 +36,39 @@ export function createWriteTool() {
     name: 'write',
     label: 'Write File',
     description:
-      'Write content to a file. Creates parent directories if needed. Best for creating new files or intentionally rewriting an existing file from scratch. WARNING: this tool REPLACES the entire file content. If the file already exists, read it first so you know what you are replacing and can preserve any content that should be kept. To add a section to an existing file (e.g. adding a [databases.<name>] entry to config.toml), use the `edit` tool with `append: true` so you do not destroy existing sections. For modifying specific parts, use `edit`. For bulk replacements, use `bash` with `sed` or `awk`.',
+      'Create a new file or write to an empty file. Creates parent directories if needed. ' +
+      'This tool REFUSES to overwrite an existing file that already contains data. ' +
+      'To modify part of a file, use the `edit` tool. ' +
+      'To append content (e.g. adding a [databases.<name>] entry to config.toml), use `edit` with `append: true`. ' +
+      'To intentionally replace a file entirely, delete it first with `bash` (`rm <path>`), then use this tool. ' +
+      'For bulk find-and-replace, use `bash` with `sed` or `awk`.',
     parameters: params,
     execute: async (_toolCallId, params, _signal, _onUpdate) => {
       try {
         const filePath = resolvePath(params.path);
 
-        // Check if we're about to overwrite an existing file
-        let overwriteWarning = '';
+        // Block overwriting existing files that contain data
         try {
           const stats = await stat(filePath);
           if (stats.isFile() && stats.size > 0) {
             const existing = await readFile(filePath, 'utf-8');
             const preview =
-              existing.length > PREVIEW_BYTES ? `${existing.slice(0, PREVIEW_BYTES)}...` : existing;
-            overwriteWarning =
-              `\n\nWARNING: Overwrote existing file (${stats.size} bytes). ` +
-              `Previous content started with:\n${preview}\n\n` +
-              'If this was unintentional, the existing content is now lost. ' +
-              'Use the `edit` tool to modify files without replacing them entirely.';
+              existing.length > PREVIEW_CHARS ? `${existing.slice(0, PREVIEW_CHARS)}...` : existing;
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text:
+                    `Cannot write: file already exists with content (${stats.size} bytes). ` +
+                    `Use the \`edit\` tool to modify it, or delete it first (\`bash\`: \`rm ${params.path}\`) ` +
+                    `then retry this write.\n\nExisting content starts with:\n${preview}`,
+                },
+              ],
+              details: { path: filePath, blocked: true, existingSize: stats.size },
+            };
           }
         } catch {
-          // File doesn't exist, no warning needed
+          // File doesn't exist, safe to write
         }
 
         const dir = dirname(filePath);
@@ -71,7 +84,7 @@ export function createWriteTool() {
           content: [
             {
               type: 'text',
-              text: `Successfully wrote ${params.content.length} bytes to ${params.path}${overwriteWarning}`,
+              text: `Successfully wrote ${params.content.length} bytes to ${params.path}`,
             },
           ],
           details: { path: filePath, size: params.content.length },

--- a/src/server/agents/tools/write.ts
+++ b/src/server/agents/tools/write.ts
@@ -7,8 +7,7 @@
  */
 
 import { mkdir, open, stat, writeFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
-import { dirname, join, resolve, sep } from 'node:path';
+import { dirname } from 'node:path';
 import { StringDecoder } from 'node:string_decoder';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { Type } from '@sinclair/typebox';
@@ -17,17 +16,6 @@ import { resolvePath } from './resolve-path.js';
 
 /** Max bytes of existing content to include in the blocked-overwrite preview. */
 const PREVIEW_BYTES = 200;
-
-/**
- * Returns true for files inside ~/.system2/ whose content may contain API keys
- * or other credentials. Content previews are suppressed for these paths.
- * Note: symlinks are not resolved; paths are assumed to be absolute and
- * already normalized (as produced by resolvePath()).
- */
-export function isSensitivePath(filePath: string): boolean {
-  const stateDir = join(homedir(), '.system2') + sep;
-  return resolve(filePath).startsWith(stateDir);
-}
 
 export function createWriteTool() {
   const params = Type.Object({
@@ -64,23 +52,19 @@ export function createWriteTool() {
         try {
           const stats = await stat(filePath);
           if (stats.isFile() && stats.size > 0) {
-            let previewSection = '';
-            if (!isSensitivePath(filePath)) {
-              // Read only the first PREVIEW_BYTES to avoid loading large files
-              const bytesToRead = Math.min(stats.size, PREVIEW_BYTES);
-              const buf = Buffer.alloc(bytesToRead);
-              const fh = await open(filePath, 'r');
-              try {
-                await fh.read(buf, 0, bytesToRead, 0);
-              } finally {
-                await fh.close();
-              }
-              // StringDecoder handles incomplete multi-byte sequences at the boundary
-              const decoder = new StringDecoder('utf8');
-              const preview = decoder.write(buf) + decoder.end();
-              const suffix = stats.size > PREVIEW_BYTES ? '...' : '';
-              previewSection = `\n\nExisting content starts with:\n${preview}${suffix}`;
+            // Read only the first PREVIEW_BYTES to avoid loading large files
+            const bytesToRead = Math.min(stats.size, PREVIEW_BYTES);
+            const buf = Buffer.alloc(bytesToRead);
+            const fh = await open(filePath, 'r');
+            try {
+              await fh.read(buf, 0, bytesToRead, 0);
+            } finally {
+              await fh.close();
             }
+            // StringDecoder handles incomplete multi-byte sequences at the boundary
+            const decoder = new StringDecoder('utf8');
+            const preview = decoder.write(buf) + decoder.end();
+            const suffix = stats.size > PREVIEW_BYTES ? '...' : '';
             return {
               content: [
                 {
@@ -88,7 +72,7 @@ export function createWriteTool() {
                   text:
                     `Cannot write: file already exists with content (${stats.size} bytes). ` +
                     `Use the \`edit\` tool to modify it, or delete it first (\`bash\`: \`rm ${params.path}\`) ` +
-                    `then retry this write.${previewSection}`,
+                    `then retry this write.\n\nExisting content starts with:\n${preview}${suffix}`,
                 },
               ],
               details: { path: filePath, blocked: true, existingSize: stats.size },


### PR DESCRIPTION
## Summary

- Write tool now **blocks overwrites** of existing files that contain data, instead of warning after the fact
- When blocked, returns the file size and a 200-char content preview, with guidance to use `edit` for modifications or `bash rm` + `write` for intentional full replacement
- Tool description updated to reflect the new contract: write = new/empty files only
- docs/tools.md updated to document the blocking behavior
- 7 tests covering: new file creation, parent directory creation, empty file write, overwrite blocking, size reporting, preview truncation, blocked flag in details

## Test plan

- [x] All 652 tests pass
- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [ ] Copilot review (3 rounds)