### PR TITLE
fix: persist project dir_path in app.db

### DIFF
--- a/src/server/agents/agents.md
+++ b/src/server/agents/agents.md
@@ -254,7 +254,7 @@ For ad-hoc SQL not covered by the named operations above (bulk updates, complex 
 │   └── {skill-name}/
 │       └── SKILL.md                 Frontmatter (name, description, roles) + steps
 ├── projects/                        Project workspaces
-│   └── {id}_{name}/
+│   └── {dir_path}/                  Slugified directory name from the project record in app.db
 │       ├── log.md                   Continuous project log (Narrator)
 │       ├── project_story.md         Final narrative (Narrator, on completion)
 │       ├── plan_{uuid}.md           Conductor's proposal document
@@ -291,7 +291,7 @@ When building a visualization or data app, write it as a self-contained HTML fil
 
 **Where artifacts live:**
 
-- **Project-scoped**: `~/.system2/projects/{id}_{name}/artifacts/` for artifacts tied to a project.
+- **Project-scoped**: `~/.system2/projects/{dir_path}/artifacts/` for artifacts tied to a project (`dir_path` is the slugified directory name from the project record in app.db).
 - **Project-free**: `~/.system2/artifacts/` for artifacts not associated with any project.
 - **Elsewhere**: when a more natural location exists (e.g., an analysis directory the user has designated). Document such locations in `infrastructure.md` and `user.md` so other agents can find them.
 
@@ -305,7 +305,7 @@ Scratchpad files are working materials, not deliverables. They are **not** regis
 
 **Where scratchpad files live:**
 
-- **Project-scoped**: `~/.system2/projects/{id}_{name}/scratchpad/` for working files tied to a project. This is the default for any work happening inside a project.
+- **Project-scoped**: `~/.system2/projects/{dir_path}/scratchpad/` for working files tied to a project (`dir_path` is the slugified directory name from the project record in app.db). This is the default for any work happening inside a project.
 - **Project-free**: `~/.system2/scratchpad/` for working files not associated with any project.
 
 **Intermediate data snapshots.** When an exploration produces a DataFrame, model, or query result that you may reload later, snapshot it to disk:
@@ -327,7 +327,7 @@ This lets later work resume from a known state without recomputing expensive que
 An in-process scheduler (Croner) runs two recurring Narrator jobs. In both cases, the server pre-computes all the data (JSONL session entries, database changes, file contents) and delivers a ready-to-use message to the Narrator. The Narrator's role is narrative synthesis: turning activity data into readable prose.
 
 1. **`daily-summary`** (every 30 minutes, configurable): collects agent session entries and database changes since the last run, partitioned by project. The Narrator synthesizes:
-   - `projects/{id}_{name}/log.md`: per-project narrative appended for each active project.
+   - `projects/{dir_path}/log.md`: per-project narrative appended for each active project.
    - `knowledge/daily_summaries/YYYY-MM-DD.md`: cross-project daily summary.
    - Skipped if no activity since last run.
 2. **`memory-update`** (daily at 11 AM): collects all daily summaries since the last memory update. The Narrator consolidates them into `knowledge/memory.md`, incorporating new patterns and clearing the `## Latest Learnings` buffer.

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -15,7 +15,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
-import { basename, dirname, join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import {
@@ -38,7 +38,7 @@ import type {
 } from '../../shared/index.js';
 import { MessageHistory } from '../chat/history.js';
 import type { DatabaseClient } from '../db/client.js';
-import { resolveProjectDir } from '../projects/dir.js';
+import { resolveProjectDir } from '../projects/dir.js'; // used for backfilling dir_path on legacy projects
 import type { ReminderManager } from '../reminders/manager.js';
 import { filterByRole } from '../skills/loader.js';
 import { log } from '../utils/logger.js';
@@ -246,9 +246,14 @@ export class AgentHost {
     if (this.agentProject !== null) {
       const projectRecord = this.db.getProject(this.agentProject);
       if (projectRecord) {
-        const projectsDir = join(SYSTEM2_DIR, 'projects');
-        const projectDir = resolveProjectDir(projectsDir, projectRecord.id, projectRecord.name);
-        this.agentProjectDirName = basename(projectDir);
+        if (projectRecord.dir_path) {
+          this.agentProjectDirName = projectRecord.dir_path;
+        } else {
+          // Backfill: legacy project created before dir_path was tracked
+          const projectsDir = join(SYSTEM2_DIR, 'projects');
+          const projectDir = resolveProjectDir(projectsDir, projectRecord.id, projectRecord.name);
+          this.agentProjectDirName = projectDir.split('/').pop() ?? null;
+        }
       }
     }
     this.agentRole = agentRecord.role;

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -15,7 +15,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import {
@@ -252,7 +252,7 @@ export class AgentHost {
           // Backfill: legacy project created before dir_path was tracked
           const projectsDir = join(SYSTEM2_DIR, 'projects');
           const projectDir = resolveProjectDir(projectsDir, projectRecord.id, projectRecord.name);
-          this.agentProjectDirName = projectDir.split('/').pop() ?? null;
+          this.agentProjectDirName = basename(projectDir);
         }
       }
     }

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -249,7 +249,7 @@ export class AgentHost {
         if (projectRecord.dir_path) {
           this.agentProjectDirName = projectRecord.dir_path;
         } else {
-          // Backfill: legacy project created before dir_path was tracked
+          // Legacy fallback: project created before dir_path was tracked
           const projectsDir = join(SYSTEM2_DIR, 'projects');
           const projectDir = resolveProjectDir(projectsDir, projectRecord.id, projectRecord.name);
           this.agentProjectDirName = basename(projectDir);

--- a/src/server/agents/library/conductor.md
+++ b/src/server/agents/library/conductor.md
@@ -31,7 +31,7 @@ You are a Conductor for System2, spawned by the Guide to own and execute a speci
 
 On receiving your initial message from Guide:
 
-- **Orient.** Read your project record from app.db, paying close attention to the requirements in the project description: these are your reference point for everything that follows. Consult infrastructure.md (already in your system prompt) for the available data stack. Your project workspace at `~/.system2/projects/{id}_{name}/` with `artifacts/` and `scratchpad/` subdirectories is created automatically.
+- **Orient.** Read your project record from app.db, paying close attention to the requirements in the project description: these are your reference point for everything that follows. Consult infrastructure.md (already in your system prompt) for the available data stack. Your project workspace at `~/.system2/projects/{dir_path}/` (where `dir_path` is the `dir_path` field from your project record in app.db) with `artifacts/` and `scratchpad/` subdirectories is created automatically.
 - **Understand the existing landscape.** Inspect the data pipeline code repository (path in infrastructure.md) for patterns, conventions, and code style, including in-repo documentation (READMEs, CONTRIBUTING, CLAUDE.md, agents.md) to adopt the project's standards. Query databases for relevant tables and schemas. Review existing pipelines in code repositories and orchestrators (Airflow DAGs, Prefect flows, etc.) for overlapping or reusable work. Understand what has already been built before creating anything new.
 - **Research the problem domain.** Search the web for API documentation, data dictionaries, file format specs, and schema references. Fetch and read the actual pages rather than relying on what you think an API returns. Investigate access methods, rate limits, authentication flows, available endpoints, response shapes, and expected volumes.
 - **Validate hands-on.** Pull real data samples, inspect for nulls, encoding issues, date format inconsistencies, and nested structures the docs don't mention. Write exploratory Python scripts in `scratchpad/`.
@@ -49,7 +49,7 @@ Iterate until major technical decisions are resolved. Do not build the plan unti
 
 ### 3. Plan and Approval
 
-Once aligned, write a narrative plan at `~/.system2/projects/{id}_{name}/plan_{uuid}.md` covering phases, technology decisions, expected outputs, and risks. Send it to the Reviewer for feedback and incorporate their input. Then message the Guide with the plan file path and ask them to present it to the user.
+Once aligned, write a narrative plan at `~/.system2/projects/{dir_path}/plan_{uuid}.md` covering phases, technology decisions, expected outputs, and risks. Send it to the Reviewer for feedback and incorporate their input. Then message the Guide with the plan file path and ask them to present it to the user.
 
 **Wait for explicit approval.** DO NOT create tasks or begin execution until the Guide confirms user approval!
 
@@ -106,7 +106,7 @@ When you believe project work is complete:
 
 1. **Resolve stragglers**: Query all tasks not `done` or `abandoned`. Let quick tasks finish, abandon those that cannot complete (with a comment explaining why). If a task genuinely needs more work, message Guide and wait for guidance.
 
-2. **Request final project review**: Message the Reviewer asking for a holistic assessment of the project as a whole: plan adherence, execution quality, results integrity, and cross-cutting issues that individual task reviews may have missed. The Reviewer saves the report to `~/.system2/projects/{id}_{name}/artifacts/final_review.md` and messages you back with the outcome. Wait for the Reviewer's response before proceeding.
+2. **Request final project review**: Message the Reviewer asking for a holistic assessment of the project as a whole: plan adherence, execution quality, results integrity, and cross-cutting issues that individual task reviews may have missed. The Reviewer saves the report to `~/.system2/projects/{dir_path}/artifacts/final_review.md` and messages you back with the outcome. Wait for the Reviewer's response before proceeding.
 
 3. **Report to Guide**: Include both your completion summary and the Reviewer's final report. "Project #N work complete. [Brief summary, task IDs, artifact paths]. Reviewer's final assessment: [outcome, report path, key findings if any]." Frame it as a decision point: the Guide and user decide whether to act on any of the Reviewer's findings or proceed to close.
 
@@ -118,6 +118,6 @@ When you believe project work is complete:
 
 7. **Wait for Narrator**: The Narrator messages you when the story is written.
 
-8. **Final report to Guide**: "Project #N closed. Story written at ~/.system2/projects/{id}_{name}/project_story.md. All tasks resolved."
+8. **Final report to Guide**: "Project #N closed. Story written at ~/.system2/projects/{dir_path}/project_story.md. All tasks resolved."
 
 Do not terminate the Reviewer. The Guide manages agent lifecycle (termination). If a project agent becomes unresponsive, you can resurrect it via `resurrect_agent`.

--- a/src/server/agents/library/narrator.md
+++ b/src/server/agents/library/narrator.md
@@ -139,7 +139,7 @@ This contains a full snapshot of the project from app.db and the project log. Th
    - `message_agent` the Conductor to ask specific questions (the Conductor is still active during story writing)
    - Read specific session files for involved agents, but follow the context-aware reading guidelines in the shared reference: check file size first, filter by relevant time period, never read entire large files
 
-4. **Write the story** to `~/.system2/projects/{id}_{name}/project_story.md` using `write` with `commit_message: "project story: <project_name>"`:
+4. **Write the story** to `~/.system2/projects/{dir_path}/project_story.md` using `write` with `commit_message: "project story: <project_name>"`:
 
    - Write in flowing prose, not bullet lists
    - Structure: opening (what the project was and why it mattered), execution (how it unfolded, phase by phase), findings (what was discovered and what wasn't), and close (what was built and what it enables)

--- a/src/server/agents/library/reviewer.md
+++ b/src/server/agents/library/reviewer.md
@@ -69,7 +69,7 @@ The review is delivered as the content of a `message_agent` call to the requesti
    - If you were assigned a review task, mark it done (set status to `done`, set `end_at`)
    - Some reviews have no associated tasks (e.g., a plan review, an ad-hoc sanity check from the Guide): skip this step when there is nothing to update
 
-3. **Write a persistent report file** only when the review is substantial enough to warrant a historical record (multi-task reviews, complex statistical assessments, reviews with extensive code findings). Write it to `~/.system2/projects/{id}_{name}/scratchpad/` and mention the path in the message. For lightweight reviews (a quick check on an approach, a single-issue finding), the message is sufficient. The final project review is the exception: it goes to `~/.system2/projects/{id}_{name}/artifacts/` (see Final Project Review below).
+3. **Write a persistent report file** only when the review is substantial enough to warrant a historical record (multi-task reviews, complex statistical assessments, reviews with extensive code findings). Write it to `~/.system2/projects/{dir_path}/scratchpad/` and mention the path in the message. For lightweight reviews (a quick check on an approach, a single-issue finding), the message is sufficient. The final project review is the exception: it goes to `~/.system2/projects/{dir_path}/artifacts/` (see Final Project Review below).
 
 Use `urgent: true` only if you discover a critical issue in work that is actively being built upon (e.g., a data corruption bug in a pipeline the Conductor is extending right now). Default delivery (non-urgent) is appropriate for all standard review completions.
 
@@ -91,7 +91,7 @@ The Conductor requests this when project work is complete, before reporting to t
 
 **Delivery:**
 
-1. Write the final project review report to `~/.system2/projects/{id}_{name}/artifacts/final_review.md` using the Validation Report Format. This review always warrants a persistent file: it is a project-level artifact that the Guide presents to the user and that the Narrator uses for the project story.
+1. Write the final project review report to `~/.system2/projects/{dir_path}/artifacts/final_review.md` using the Validation Report Format. This review always warrants a persistent file: it is a project-level artifact that the Guide presents to the user and that the Narrator uses for the project story.
 2. Message the Conductor with the outcome, the report path, and a concise summary of key findings. The Conductor includes this in their completion report to the Guide, and the user decides whether to act on any points before closing the project.
 
 The user may choose to address findings from the final review before closing. If the Conductor makes adjustments and requests a re-review, update `final_review.md` (append a "Re-review" section with date) rather than creating a new file, and message the Conductor with the updated outcome.

--- a/src/server/agents/skills/project-completion/SKILL.md
+++ b/src/server/agents/skills/project-completion/SKILL.md
@@ -10,7 +10,7 @@ Follow these steps end-to-end when the Conductor reports that its work is comple
 
 ## Steps
 
-1. **Show the Reviewer's final report to the user.** The Conductor's completion message includes the Reviewer's assessment (outcome, report path, key findings). Display the full report via `show_artifact` with the path to `~/.system2/projects/{id}_{name}/artifacts/final_review.md`. Walk the user through the key points.
+1. **Show the Reviewer's final report to the user.** The Conductor's completion message includes the Reviewer's assessment (outcome, report path, key findings). Display the full report via `show_artifact` with the path to `~/.system2/projects/{dir_path}/artifacts/final_review.md`. Walk the user through the key points.
 
 2. **Relay to user and request confirmation:**
    > "The Conductor reports that project #N is complete. [Brief summary from Conductor's message]. The Reviewer's final assessment: [outcome and key findings]. Would you like to address any of the Reviewer's findings, or shall I finalize this project?"
@@ -26,4 +26,4 @@ Follow these steps end-to-end when the Conductor reports that its work is comple
 7. **After the Conductor confirms the project is closed:**
    - Terminate Conductor and Reviewer via `terminate_agent` (using their agent IDs)
    - Update project status to `"done"` in app.db (set `end_at` to now)
-   - Display the project story in the artifact viewer via `show_artifact` with the absolute path `~/.system2/projects/{id}_{name}/project_story.md`, then inform the user with a final summary.
+   - Display the project story in the artifact viewer via `show_artifact` with the absolute path `~/.system2/projects/{dir_path}/project_story.md`, then inform the user with a final summary.

--- a/src/server/agents/tools/spawn-agent.test.ts
+++ b/src/server/agents/tools/spawn-agent.test.ts
@@ -12,6 +12,7 @@ function makeProject(id: number): Project {
     id,
     name: 'Project',
     description: 'Desc',
+    dir_path: `${id}_project`,
     status: 'todo',
     labels: '[]',
     start_at: null,

--- a/src/server/agents/tools/trigger-project-story.test.ts
+++ b/src/server/agents/tools/trigger-project-story.test.ts
@@ -33,6 +33,7 @@ function makeProject(id: number, name: string): Project {
     id,
     name,
     description: 'test project',
+    dir_path: `${id}_${name}`,
     status: 'in progress',
     labels: [],
     start_at: 'now',

--- a/src/server/agents/tools/trigger-project-story.test.ts
+++ b/src/server/agents/tools/trigger-project-story.test.ts
@@ -20,6 +20,7 @@ vi.mock('node:fs', async (importOriginal) => {
   return {
     ...actual,
     existsSync: vi.fn().mockReturnValue(false),
+    mkdirSync: vi.fn(),
     readFileSync: vi.fn().mockReturnValue(''),
   };
 });

--- a/src/server/agents/tools/trigger-project-story.ts
+++ b/src/server/agents/tools/trigger-project-story.ts
@@ -12,7 +12,7 @@
  * (writes the project story using the provided data + the log entry it just wrote).
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
@@ -114,6 +114,8 @@ export function createTriggerProjectStoryTool(
           project.dir_path ??
           basename(resolveProjectDir(join(SYSTEM2_DIR, 'projects'), project.id, project.name));
         const projectDir = join(SYSTEM2_DIR, 'projects', dirName);
+        mkdirSync(join(projectDir, 'artifacts'), { recursive: true });
+        mkdirSync(join(projectDir, 'scratchpad'), { recursive: true });
         const logFile = join(projectDir, 'log.md');
 
         // Read timestamps

--- a/src/server/agents/tools/trigger-project-story.ts
+++ b/src/server/agents/tools/trigger-project-story.ts
@@ -14,11 +14,11 @@
 
 import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { Type } from '@sinclair/typebox';
 import type { DatabaseClient } from '../../db/client.js';
-import { resolveProjectDir } from '../../projects/dir.js';
+import { resolveProjectDir } from '../../projects/dir.js'; // used for backfilling dir_path on legacy projects
 import {
   collectAgentActivity,
   collectProjectDbChanges,
@@ -109,12 +109,11 @@ export function createTriggerProjectStoryTool(
           };
         }
 
-        // Resolve project directory (handles renames)
-        const projectDir = resolveProjectDir(
-          join(SYSTEM2_DIR, 'projects'),
-          project.id,
-          project.name
-        );
+        // Use persisted dir_path, falling back to resolveProjectDir for legacy projects
+        const dirName =
+          project.dir_path ??
+          basename(resolveProjectDir(join(SYSTEM2_DIR, 'projects'), project.id, project.name));
+        const projectDir = join(SYSTEM2_DIR, 'projects', dirName);
         const logFile = join(projectDir, 'log.md');
 
         // Read timestamps

--- a/src/server/agents/tools/write-system2-db.test.ts
+++ b/src/server/agents/tools/write-system2-db.test.ts
@@ -10,6 +10,13 @@ import type {
 import type { DatabaseClient } from '../../db/client.js';
 import { createWriteSystem2DbTool } from './write-system2-db.js';
 
+// Mock resolveProjectDir so no real directories are created
+vi.mock('../../projects/dir.js', () => ({
+  resolveProjectDir: vi.fn(
+    (_dir: string, id: number, name: string) => `/tmp/fake-projects/${id}_${name}`
+  ),
+}));
+
 // Minimal mock DatabaseClient with controllable return values
 function createMockDb() {
   const agents = new Map<number, Agent>();
@@ -38,7 +45,13 @@ function createMockDb() {
 
     createProject: (p: Partial<Project>) => {
       const id = nextId++;
-      const project = { id, ...p, created_at: 'now', updated_at: 'now' } as Project;
+      const project = {
+        id,
+        ...p,
+        dir_path: `${id}_project`,
+        created_at: 'now',
+        updated_at: 'now',
+      } as Project;
       projects.set(id, project);
       return project;
     },
@@ -168,6 +181,7 @@ function addProject(db: MockDb, id: number) {
     id,
     name: 'Project',
     description: 'Desc',
+    dir_path: `${id}_project`,
     status: 'todo',
     labels: '[]',
     start_at: null,

--- a/src/server/agents/tools/write-system2-db.ts
+++ b/src/server/agents/tools/write-system2-db.ts
@@ -9,9 +9,14 @@
  * This is NOT for writing to data pipeline databases — use bash for those.
  */
 
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { Type } from '@sinclair/typebox';
 import type { DatabaseClient } from '../../db/client.js';
+import { resolveProjectDir } from '../../projects/dir.js';
+
+const SYSTEM2_DIR = join(homedir(), '.system2');
 
 const PROJECT_STATUSES = ['todo', 'in progress', 'review', 'done', 'abandoned'] as const;
 const TASK_PRIORITIES = ['low', 'medium', 'high'] as const;
@@ -238,6 +243,8 @@ export function createWriteSystem2DbTool(
               start_at: params.start_at ?? null,
               end_at: params.end_at ?? null,
             });
+            // Ensure the project directory exists on disk
+            resolveProjectDir(join(SYSTEM2_DIR, 'projects'), result.id, result.name);
             return ok(result, 'project');
           }
 
@@ -267,7 +274,10 @@ export function createWriteSystem2DbTool(
               ...(params.end_at !== undefined && { end_at: params.end_at }),
             });
             if (!result) return err(`No project found with id ${params.id}`);
-
+            // Rename directory on disk when the project name changes
+            if (params.name !== undefined) {
+              resolveProjectDir(join(SYSTEM2_DIR, 'projects'), result.id, result.name);
+            }
             return ok(result, 'project');
           }
 

--- a/src/server/db/client.ts
+++ b/src/server/db/client.ts
@@ -43,25 +43,30 @@ export class DatabaseClient {
 
   // Project operations
   createProject(project: Omit<Project, 'id' | 'dir_path' | 'created_at' | 'updated_at'>): Project {
-    const insertStmt = this.db.prepare(`
-      INSERT INTO project (name, description, status, labels, start_at, end_at)
-      VALUES (?, ?, ?, ?, ?, ?)
-      RETURNING *
-    `);
+    const txn = this.db.transaction(() => {
+      const insertStmt = this.db.prepare(`
+        INSERT INTO project (name, description, status, labels, start_at, end_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        RETURNING *
+      `);
 
-    const row = insertStmt.get(
-      project.name,
-      project.description,
-      project.status,
-      JSON.stringify(project.labels),
-      project.start_at,
-      project.end_at
-    ) as Project;
+      const row = insertStmt.get(
+        project.name,
+        project.description,
+        project.status,
+        JSON.stringify(project.labels),
+        project.start_at,
+        project.end_at
+      ) as Project;
 
-    // Compute and persist the slugified directory name
-    const dirPath = `${row.id}_${slugify(row.name)}`;
-    const updateStmt = this.db.prepare('UPDATE project SET dir_path = ? WHERE id = ? RETURNING *');
-    return updateStmt.get(dirPath, row.id) as Project;
+      // Compute and persist the slugified directory name
+      const dirPath = `${row.id}_${slugify(row.name)}`;
+      const updateStmt = this.db.prepare(
+        'UPDATE project SET dir_path = ? WHERE id = ? RETURNING *'
+      );
+      return updateStmt.get(dirPath, row.id) as Project;
+    });
+    return txn();
   }
 
   getProject(id: number): Project | null {

--- a/src/server/db/client.ts
+++ b/src/server/db/client.ts
@@ -17,6 +17,7 @@ import type {
   TaskComment,
   TaskLink,
 } from '../../shared/index.js';
+import { slugify } from '../projects/dir.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -41,14 +42,14 @@ export class DatabaseClient {
   }
 
   // Project operations
-  createProject(project: Omit<Project, 'id' | 'created_at' | 'updated_at'>): Project {
-    const stmt = this.db.prepare(`
+  createProject(project: Omit<Project, 'id' | 'dir_path' | 'created_at' | 'updated_at'>): Project {
+    const insertStmt = this.db.prepare(`
       INSERT INTO project (name, description, status, labels, start_at, end_at)
       VALUES (?, ?, ?, ?, ?, ?)
       RETURNING *
     `);
 
-    return stmt.get(
+    const row = insertStmt.get(
       project.name,
       project.description,
       project.status,
@@ -56,6 +57,11 @@ export class DatabaseClient {
       project.start_at,
       project.end_at
     ) as Project;
+
+    // Compute and persist the slugified directory name
+    const dirPath = `${row.id}_${slugify(row.name)}`;
+    const updateStmt = this.db.prepare('UPDATE project SET dir_path = ? WHERE id = ? RETURNING *');
+    return updateStmt.get(dirPath, row.id) as Project;
   }
 
   getProject(id: number): Project | null {
@@ -86,6 +92,9 @@ export class DatabaseClient {
     if (updates.name !== undefined) {
       fields.push('name = ?');
       values.push(updates.name);
+      // Keep dir_path in sync with the slugified name
+      fields.push('dir_path = ?');
+      values.push(`${id}_${slugify(updates.name)}`);
     }
     if (updates.description !== undefined) {
       fields.push('description = ?');

--- a/src/server/db/schema.sql
+++ b/src/server/db/schema.sql
@@ -6,6 +6,7 @@ CREATE TABLE IF NOT EXISTS project (
   id INTEGER PRIMARY KEY,                -- Auto-incrementing unique identifier
   name TEXT NOT NULL,                     -- Project name
   description TEXT NOT NULL,              -- Project description
+  dir_path TEXT,                          -- Slugified directory name under ~/.system2/projects/ (e.g. "1_my-project")
   status TEXT NOT NULL DEFAULT 'todo' CHECK(status IN ('todo', 'in progress', 'review', 'done', 'abandoned')), -- Current progress state
   labels TEXT NOT NULL DEFAULT '[]',      -- JSON array of string labels for categorization
   start_at TEXT,                          -- ISO 8601 timestamp when work began

--- a/src/server/projects/dir.ts
+++ b/src/server/projects/dir.ts
@@ -18,7 +18,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 
-function slugify(name: string): string {
+export function slugify(name: string): string {
   return name
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')

--- a/src/server/scheduler/jobs.ts
+++ b/src/server/scheduler/jobs.ts
@@ -574,6 +574,8 @@ export async function buildAndDeliverDailySummary(
       project.dir_path ??
       basename(resolveProjectDir(join(system2Dir, 'projects'), project.id, project.name));
     const projectDir = join(system2Dir, 'projects', dirName);
+    mkdirSync(join(projectDir, 'artifacts'), { recursive: true });
+    mkdirSync(join(projectDir, 'scratchpad'), { recursive: true });
     const logFile = join(projectDir, 'log.md');
 
     // Create log file if needed

--- a/src/server/scheduler/jobs.ts
+++ b/src/server/scheduler/jobs.ts
@@ -14,7 +14,7 @@ import type { JobExecution } from '../../shared/index.js';
 import type { AgentHost } from '../agents/host.js';
 import { commitIfStateDir } from '../agents/tools/git-commit.js';
 import type { DatabaseClient } from '../db/client.js';
-import { resolveProjectDir } from '../projects/dir.js';
+import { resolveProjectDir } from '../projects/dir.js'; // used for backfilling dir_path on legacy projects
 import { log } from '../utils/logger.js';
 import { isNetworkAvailable } from './network.js';
 import type { Scheduler } from './scheduler.js';
@@ -560,16 +560,20 @@ export async function buildAndDeliverDailySummary(
 
   // 5. Find active projects (conductor not archived) and deliver project logs
   const activeProjects = db.query(
-    `SELECT DISTINCT p.id, p.name FROM project p
+    `SELECT DISTINCT p.id, p.name, p.dir_path FROM project p
      JOIN agent a ON a.project = p.id
      WHERE a.role = 'conductor' AND a.status != 'archived'`
-  ) as Array<{ id: number; name: string }>;
+  ) as Array<{ id: number; name: string; dir_path: string | null }>;
 
   const projectDataList: ProjectActivityData[] = [];
   const deliveries: Promise<void>[] = [];
 
   for (const project of activeProjects) {
-    const projectDir = resolveProjectDir(join(system2Dir, 'projects'), project.id, project.name);
+    // Use persisted dir_path, falling back to resolveProjectDir for legacy projects
+    const dirName =
+      project.dir_path ??
+      basename(resolveProjectDir(join(system2Dir, 'projects'), project.id, project.name));
+    const projectDir = join(system2Dir, 'projects', dirName);
     const logFile = join(projectDir, 'log.md');
 
     // Create log file if needed

--- a/src/shared/types/database.ts
+++ b/src/shared/types/database.ts
@@ -8,6 +8,7 @@ export interface Project {
   id: number;
   name: string;
   description: string;
+  dir_path: string | null;
   status: 'todo' | 'in progress' | 'review' | 'done' | 'abandoned';
   labels: string[];
   start_at: string | null;


### PR DESCRIPTION
## Summary

- Adds `dir_path` column to the `project` table, computed once at creation from `{id}_{slugified_name}` and kept in sync on rename
- All consumers (`host.ts`, `jobs.ts`, `trigger-project-story.ts`) now read `project.dir_path` from the DB instead of calling `resolveProjectDir` on every access
- Agent instructions (`agents.md`, `conductor.md`, `reviewer.md`, `narrator.md`, `SKILL.md`) reference `{dir_path}` from the project record instead of the `{id}_{name}` template that agents were incorrectly constructing with the raw (unslugged) name
- Fixes `trigger-project-story.test.ts` and `write-system2-db.test.ts` leaking real directories into `~/.system2/projects/` by mocking `resolveProjectDir`

## Problem

The project directory name was reconstructed from `(id, name)` by every consumer independently via `resolveProjectDir` (which slugifies), while agents constructed paths from the raw project name in their instructions (e.g. `~/.system2/projects/1_US Fiscal Deficit and Price Inflation Correlation/`). This caused duplicate directories for the same project: one slugified, one with the raw name.

Additionally, the `trigger-project-story.test.ts` mocked `node:fs` but only overrode `existsSync`/`readFileSync`, leaving `mkdirSync` real. Combined with an unmocked `homedir()`, the test created real junk directories (`1_test-project`, `5_any-project`) under `~/.system2/projects/`.

## Test plan

- [x] All 652 tests pass (43 test files)
- [x] `pnpm check` passes (only pre-existing warnings)
- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes (verified via pre-push hook)