### PR TITLE
chore: add issue templates, funding, and discussions setup

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: diegoscarabelli

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug Report
+about: Report a bug to help us improve System2
+title: "[BUG] "
+labels: bug
+assignees: ""
+---
+
+## Bug Description
+
+A clear and concise description of the bug.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Run command '...'
+3. See error
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual Behavior
+
+A clear and concise description of what actually happened.
+
+## Environment
+
+- **OS**: [e.g., Ubuntu 22.04, macOS 15.0]
+- **Node.js Version**: [e.g., 22.0.0]
+- **pnpm Version**: [e.g., 9.0.0]
+- **Browser** (if UI-related): [e.g., Chrome 130, Safari 18]
+
+## Logs/Error Messages
+
+```
+Paste relevant logs or error messages here
+```
+
+## Additional Context
+
+Add any other context about the problem here (screenshots, configuration files, etc.).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/diegoscarabelli/system2/tree/main/docs
+    about: Read the project documentation
+  - name: Ask a Question
+    url: https://github.com/diegoscarabelli/system2/discussions
+    about: Ask questions and discuss ideas with the community

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,29 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement for System2
+title: "[FEATURE] "
+labels: enhancement
+assignees: ""
+---
+
+## Problem Description
+
+A clear and concise description of the problem this feature would solve.
+
+**Example:** I'm always frustrated when [...]
+
+## Proposed Solution
+
+A clear and concise description of what you want to happen.
+
+## Alternatives Considered
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+## Use Case
+
+Describe how this feature would be used and who would benefit from it.
+
+## Additional Context
+
+Add any other context, screenshots, or examples about the feature request here.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ System2 is a multi-agent system for data engineering, analysis, and statistical 
 
 Named for [Kahneman's](https://en.wikipedia.org/wiki/Thinking,_Fast_and_Slow) slow, deliberate mode of reasoning, System2 is the bicycle for your analytical mind.
 
-It exists to help people think more clearly about complex questions and empower everyone, regardless of skill, to acquire, interpret, and share rigorous analysis grounded in evidence and methods they can inspect.
+It exists to help people think more clearly about complex questions and empower everyone, regardless of skill, to acquire and interpret data, and share rigorous analysis grounded in evidence and methods they can inspect.
 
 <!-- TODO: screenshot/GIF of the full UI: chat panel on the right, artifact viewer with a dashboard on the left, activity bar visible -->
 

--- a/src/server/db/adapters/sqlite.test.ts
+++ b/src/server/db/adapters/sqlite.test.ts
@@ -9,6 +9,7 @@ import { createAdapter } from './sqlite.js';
 describe('SQLite adapter', () => {
   let tempDir: string;
   let dbPath: string;
+  let activeAdapter: Awaited<ReturnType<typeof createAdapter>> | undefined;
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-test-'));
@@ -24,7 +25,11 @@ describe('SQLite adapter', () => {
     seedDb.close();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    if (activeAdapter?.connected) {
+      await activeAdapter.disconnect();
+    }
+    activeAdapter = undefined;
     rmSync(tempDir, { recursive: true, force: true });
   });
 
@@ -33,43 +38,43 @@ describe('SQLite adapter', () => {
   }
 
   it('connects and queries SELECT 1 as val', async () => {
-    const adapter = createAdapter(makeConfig());
+    activeAdapter = createAdapter(makeConfig());
 
-    await adapter.connect();
-    const rows = await adapter.query('SELECT 1 as val');
+    await activeAdapter.connect();
+    const rows = await activeAdapter.query('SELECT 1 as val');
 
     expect(rows).toEqual([{ val: 1 }]);
   });
 
   it('respects max_rows cap', async () => {
-    const adapter = createAdapter(makeConfig({ max_rows: 5 }));
+    activeAdapter = createAdapter(makeConfig({ max_rows: 5 }));
 
-    await adapter.connect();
-    const rows = await adapter.query('SELECT * FROM items');
+    await activeAdapter.connect();
+    const rows = await activeAdapter.query('SELECT * FROM items');
 
     expect(rows).toHaveLength(5);
   });
 
   it('disconnect sets connected to false', async () => {
-    const adapter = createAdapter(makeConfig());
+    activeAdapter = createAdapter(makeConfig());
 
-    await adapter.connect();
-    expect(adapter.connected).toBe(true);
+    await activeAdapter.connect();
+    expect(activeAdapter.connected).toBe(true);
 
-    await adapter.disconnect();
-    expect(adapter.connected).toBe(false);
+    await activeAdapter.disconnect();
+    expect(activeAdapter.connected).toBe(false);
   });
 
   it('auto-reconnects when querying after disconnect', async () => {
-    const adapter = createAdapter(makeConfig());
+    activeAdapter = createAdapter(makeConfig());
 
-    await adapter.connect();
-    await adapter.disconnect();
-    expect(adapter.connected).toBe(false);
+    await activeAdapter.connect();
+    await activeAdapter.disconnect();
+    expect(activeAdapter.connected).toBe(false);
 
     // query() should re-open the database transparently
-    const rows = await adapter.query('SELECT 1 as val');
+    const rows = await activeAdapter.query('SELECT 1 as val');
     expect(rows).toEqual([{ val: 1 }]);
-    expect(adapter.connected).toBe(true);
+    expect(activeAdapter.connected).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Add bug report and feature request issue templates (adapted from openetl)
- Add `config.yml` to disable blank issues and link to docs/discussions
- Add `FUNDING.yml` pointing to GitHub Sponsors
- Discussions already enabled via API

Closes #N/A (repo setup)

## Test plan

- [ ] Verify issue templates appear when creating a new issue
- [ ] Verify "Sponsor" button appears on repo page (requires GitHub Sponsors enrollment)
- [ ] Verify Discussions tab is visible