### PR TITLE
fix: resolve Windows CI test failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ System2's home directory is `~/.system2/`. It holds all system state: configurat
 ├── server.pid                       PID file when server is running (gitignored)
 ├── sessions/                        Agent conversations as JSONL (gitignored)
 ├── skills/                          User-created workflow instructions
-└── venv/                            Shared Python environment (notebooks, data libraries)
+└── venv/                            Shared Python environment (notebooks, data libraries) (gitignored)
 ```
 
 Agents run in a shell and can work with any directory on your machine. For data engineering work, they typically create and manage code in external repositories (e.g. `~/repos/system2_data_pipelines`), keeping pipeline code separate from the System2 home directory.

--- a/src/server/agents/tools/bash.test.ts
+++ b/src/server/agents/tools/bash.test.ts
@@ -333,8 +333,9 @@ describe('bash tool', () => {
 
     it('uses custom inactivity timeout', async () => {
       // Command that sleeps longer than the inactivity timeout
+      const sleepCmd = isWindows ? 'Start-Sleep -Seconds 15' : 'sleep 15';
       const result = await exec({
-        command: 'sleep 15',
+        command: sleepCmd,
         inactivity_timeout_seconds: 10,
       });
 
@@ -345,7 +346,9 @@ describe('bash tool', () => {
 
     it('uses custom total timeout', async () => {
       // Command that emits output (resets inactivity) but exceeds total timeout
-      const cmd = 'for i in $(seq 1 20); do echo "tick $i"; sleep 1; done';
+      const cmd = isWindows
+        ? '1..20 | ForEach-Object { Write-Output "tick $_"; Start-Sleep -Seconds 1 }'
+        : 'for i in $(seq 1 20); do echo "tick $i"; sleep 1; done';
       const result = await exec({
         command: cmd,
         inactivity_timeout_seconds: 30,
@@ -359,7 +362,9 @@ describe('bash tool', () => {
 
     it('active output prevents inactivity timeout', async () => {
       // Command outputs every second for 3s with a 10s inactivity timeout
-      const cmd = 'for i in 1 2 3; do echo "ping $i"; sleep 1; done';
+      const cmd = isWindows
+        ? '1..3 | ForEach-Object { Write-Output "ping $_"; Start-Sleep -Seconds 1 }'
+        : 'for i in 1 2 3; do echo "ping $i"; sleep 1; done';
       const result = await exec({
         command: cmd,
         inactivity_timeout_seconds: 10,

--- a/src/server/agents/tools/bash.test.ts
+++ b/src/server/agents/tools/bash.test.ts
@@ -296,6 +296,14 @@ describe('bash tool', () => {
       const { heartbeats } = filterHeartbeats('::system2::\n');
       expect(heartbeats).toEqual(['']);
     });
+
+    it('normalizes \\r\\n line endings before filtering', () => {
+      const input = 'line1\r\n::system2:: win-heartbeat\r\nline2\r\n';
+      const { filtered, heartbeats } = filterHeartbeats(input);
+
+      expect(filtered).toBe('line1\nline2\n');
+      expect(heartbeats).toEqual(['win-heartbeat']);
+    });
   });
 
   describe('HEARTBEAT_RE', () => {

--- a/src/server/agents/tools/bash.ts
+++ b/src/server/agents/tools/bash.ts
@@ -84,7 +84,8 @@ export function filterHeartbeats(text: string): {
   filtered: string;
   heartbeats: string[];
 } {
-  const lines = text.split('\n');
+  // Normalize Windows \r\n to \n so the sentinel regex matches cleanly
+  const lines = text.replace(/\r\n/g, '\n').split('\n');
   const kept: string[] = [];
   const heartbeats: string[] = [];
 

--- a/src/server/agents/tools/git-commit.ts
+++ b/src/server/agents/tools/git-commit.ts
@@ -25,8 +25,12 @@ export function commitIfStateDir(filePath: string, message: string): void {
   const { GIT_DIR, GIT_WORK_TREE, ...cleanEnv } = process.env;
   const execOpts = { cwd: system2Dir, env: cleanEnv, stdio: 'ignore' as const, timeout: 10000 };
 
+  // Git accepts forward slashes on all platforms; avoid JSON.stringify
+  // double-escaping backslashes when the path is passed through cmd.exe.
+  const gitPath = filePath.replace(/\\/g, '/');
+
   try {
-    execSync(`git add ${JSON.stringify(filePath)}`, execOpts);
+    execSync(`git add "${gitPath}"`, execOpts);
     execSync(`git diff --cached --quiet || git commit -m ${JSON.stringify(message)}`, execOpts);
   } catch {
     // Git commit failure is non-fatal — the file operation already succeeded

--- a/src/server/agents/tools/git-commit.ts
+++ b/src/server/agents/tools/git-commit.ts
@@ -8,7 +8,7 @@
 import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { join } from 'node:path';
+import { join, sep } from 'node:path';
 
 /**
  * If filePath is inside ~/.system2/ and a git repo exists there,
@@ -16,7 +16,7 @@ import { join } from 'node:path';
  */
 export function commitIfStateDir(filePath: string, message: string): void {
   const system2Dir = join(homedir(), '.system2');
-  if (!filePath.startsWith(`${system2Dir}/`) || !existsSync(join(system2Dir, '.git'))) {
+  if (!filePath.startsWith(`${system2Dir}${sep}`) || !existsSync(join(system2Dir, '.git'))) {
     return;
   }
 

--- a/src/server/agents/tools/trigger-project-story.test.ts
+++ b/src/server/agents/tools/trigger-project-story.test.ts
@@ -237,7 +237,8 @@ describe('trigger_project_story tool', () => {
 
   it('includes existing story note when project_story.md exists', async () => {
     (existsSync as Mock).mockImplementation(
-      (p: string) => typeof p === 'string' && p.endsWith('artifacts/project_story.md')
+      (p: string) =>
+        typeof p === 'string' && p.replace(/\\/g, '/').endsWith('artifacts/project_story.md')
     );
     try {
       const conductor = makeAgent(2, 'conductor', 1);


### PR DESCRIPTION
## Summary

- Normalize `\r\n` to `\n` in `filterHeartbeats` so sentinel regex matches on Windows
- Replace bash-only `sleep`/`for` loops with PowerShell equivalents in timeout tests
- Normalize backslash paths in `trigger-project-story` test mock

## Test plan

- [ ] Windows CI passes (was failing before this PR)
- [ ] macOS and Ubuntu CI continue to pass