### PR TITLE
fix: prevent delivery promises from hanging during provider failover

### DIFF
--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -1530,7 +1530,7 @@ describe('AgentHost', () => {
         null,
         [],
         '429 rate limited, switched to anthropic',
-        'on google, switching to anthropic'
+        'on google, switching to anthropic\n\nError 429: rate limit exceeded'
       );
     });
 
@@ -1576,7 +1576,7 @@ describe('AgentHost', () => {
         null,
         [],
         '429 rate limited, rotating to next key',
-        'on google, rotating to next key'
+        'on google, rotating to next key\n\nError 429: rate limit exceeded'
       );
     });
 
@@ -1620,7 +1620,7 @@ describe('AgentHost', () => {
       const pushed = internal._chatCache.push.mock.calls[0][0];
       expect(pushed.role).toBe('system');
       expect(pushed.content).toBe(
-        '401 auth error, all providers unavailable\n\non cerebras, all providers unavailable'
+        '401 auth error, all providers unavailable\n\non cerebras, all providers unavailable\n\nError 401: Unauthorized'
       );
     });
   });
@@ -1749,7 +1749,7 @@ describe('AgentHost', () => {
         null,
         [],
         '400 client error, switched to google',
-        'on anthropic, switching to google'
+        'on anthropic, switching to google\n\nError 400: credit balance too low'
       );
     });
 
@@ -1801,7 +1801,7 @@ describe('AgentHost', () => {
       // Should show error details in the exhausted message
       const pushed = internal._chatCache.push.mock.calls[0][0];
       expect(pushed.content).toBe(
-        '400 client error, all providers unavailable\n\non anthropic, all providers unavailable'
+        '400 client error, all providers unavailable\n\non anthropic, all providers unavailable\n\nError 400: credit balance too low'
       );
     });
   });

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -1462,6 +1462,63 @@ describe('AgentHost', () => {
       expect(pushed.content).toBe('a'.repeat(100));
     });
 
+    it('stale sendCustomMessage catch is a no-op after session change', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as {
+        session: { sendCustomMessage: ReturnType<typeof vi.fn> };
+        _chatCache: null;
+        _sessionDir: string | null;
+        deliverySendCount: number;
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
+        }>;
+        handlePotentialError: ReturnType<typeof vi.fn>;
+        handleCompactionTracking: ReturnType<typeof vi.fn>;
+      };
+
+      // Create a session whose sendCustomMessage rejects after a tick
+      const sendError = new Error('session destroyed');
+      const oldSession = {
+        sendCustomMessage: vi.fn().mockRejectedValue(sendError),
+      };
+      internal.session = oldSession;
+      internal._chatCache = null;
+      internal._sessionDir = null;
+      internal.handlePotentialError = vi.fn().mockResolvedValue(undefined);
+      internal.handleCompactionTracking = vi.fn();
+
+      const details = { sender: 1, receiver: 2, timestamp: Date.now() };
+      // Don't await: we need the catch handler to fire after session swap
+      host.deliverMessage('msg1', details);
+
+      // deliverySendCount was incremented synchronously by deliverMessage
+      expect(internal.deliverySendCount).toBe(1);
+
+      // Simulate failover: swap session to a new object before the catch fires
+      const newSession = { sendCustomMessage: vi.fn() };
+      internal.session = newSession as typeof internal.session;
+
+      // Let the rejected promise's catch handler run
+      await new Promise((r) => setTimeout(r, 0));
+
+      // The catch handler should have been a no-op (session !== session guard).
+      // deliverySendCount should NOT have been decremented by the stale handler.
+      expect(internal.deliverySendCount).toBe(1);
+      // The delivery should still be in the queue (not spliced by the stale handler)
+      expect(internal.pendingDeliveries).toHaveLength(1);
+      expect(internal.pendingDeliveries[0].content).toBe('msg1');
+    });
+
     it('does not push to chatCache when _chatCache is null', () => {
       const host = new AgentHost({
         db: makeDbStub(),
@@ -1803,6 +1860,60 @@ describe('AgentHost', () => {
       expect(pushed.content).toBe(
         '400 client error, all providers unavailable\n\non anthropic, all providers unavailable\n\nError 400: credit balance too low'
       );
+    });
+
+    it('reinitializeWithProvider failure rejects all pending deliveries', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as {
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
+        }>;
+        deliverySendCount: number;
+        reinitializeWithProvider: (
+          provider: string,
+          prompt: string | null,
+          deliveries: unknown[],
+          reason?: string,
+          detail?: string
+        ) => Promise<void>;
+        isReinitializing: boolean;
+        _chatCache: { push: ReturnType<typeof vi.fn>; getMessages: ReturnType<typeof vi.fn> };
+        initialize: ReturnType<typeof vi.fn>;
+      };
+
+      // Mock initialize to throw (simulates reinit failure)
+      internal.initialize = vi.fn().mockRejectedValue(new Error('init failed'));
+      internal._chatCache = { push: vi.fn(), getMessages: vi.fn().mockReturnValue([]) };
+
+      const reject1 = vi.fn();
+      const reject2 = vi.fn();
+      const details = { sender: 0, receiver: 2, timestamp: Date.now() };
+      internal.pendingDeliveries = [
+        { content: 'msg-A', details, resolve: vi.fn(), reject: reject1 },
+        { content: 'msg-B', details, resolve: vi.fn(), reject: reject2 },
+      ];
+      internal.deliverySendCount = 2;
+
+      await internal.reinitializeWithProvider('google', null, [], 'test reason', 'test detail');
+
+      // Both deliveries should be rejected with the init error
+      expect(reject1).toHaveBeenCalledWith(expect.objectContaining({ message: 'init failed' }));
+      expect(reject2).toHaveBeenCalledWith(expect.objectContaining({ message: 'init failed' }));
+      // Queue and counter should be cleared
+      expect(internal.pendingDeliveries).toHaveLength(0);
+      expect(internal.deliverySendCount).toBe(0);
+      // isReinitializing should be reset (finally block)
+      expect(internal.isReinitializing).toBe(false);
     });
   });
 

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -608,8 +608,8 @@ export class AgentHost {
             : `${errorPrefix}, switched to ${nextProvider}`;
         const detail =
           nextProvider === this.currentProvider
-            ? `on ${this.currentProvider}, rotating to next key`
-            : `on ${this.currentProvider} (key already in cooldown), switching to ${nextProvider}`;
+            ? `on ${this.currentProvider}, rotating to next key\n\n${errorMessage}`
+            : `on ${this.currentProvider} (key already in cooldown), switching to ${nextProvider}\n\n${errorMessage}`;
         log.info(
           `[AgentHost] Key ${this.currentProvider}:${this.currentKeyIndex} already in cooldown`
         );
@@ -686,6 +686,7 @@ export class AgentHost {
               }
             )
             .catch((error) => {
+              if (this.session !== session) return;
               this.deliverySendCount = Math.max(0, this.deliverySendCount - 1);
               log.error('[AgentHost] Failed to resend delivery after retry:', error);
               const idx = this.pendingDeliveries.indexOf(d);
@@ -719,7 +720,7 @@ export class AgentHost {
         if (nextProvider) {
           if (nextProvider === this.currentProvider) {
             const reason = `${errorPrefix}, rotating to next key`;
-            const detail = `on ${this.currentProvider}, rotating to next key`;
+            const detail = `on ${this.currentProvider}, rotating to next key\n\n${errorMessage}`;
             log.info(`[AgentHost] Rotating to next key for ${this.currentProvider}`);
             await this.reinitializeWithProvider(
               nextProvider,
@@ -737,7 +738,7 @@ export class AgentHost {
             await this.compactForProvider(nextProvider);
 
             const reason = `${errorPrefix}, switched to ${nextProvider}`;
-            const detail = `on ${fromProvider}, switching to ${nextProvider}`;
+            const detail = `on ${fromProvider}, switching to ${nextProvider}\n\n${errorMessage}`;
             log.info(`[AgentHost] Failing over from ${fromProvider} to ${nextProvider}`);
             await this.reinitializeWithProvider(
               nextProvider,
@@ -752,7 +753,7 @@ export class AgentHost {
       }
 
       this.pushSystemMessage(
-        `${errorPrefix}, all providers unavailable\n\non ${this.currentProvider}, all providers unavailable`
+        `${errorPrefix}, all providers unavailable\n\non ${this.currentProvider}, all providers unavailable\n\n${errorMessage}`
       );
       log.info('[AgentHost] No fallback providers available, error will be surfaced to user');
 
@@ -949,6 +950,7 @@ export class AgentHost {
               }
             )
             .catch((error) => {
+              if (this.session !== session) return;
               this.deliverySendCount = Math.max(0, this.deliverySendCount - 1);
               log.error('[AgentHost] Failed to replay delivery after failover:', error);
               const idx = this.pendingDeliveries.indexOf(d);
@@ -963,6 +965,15 @@ export class AgentHost {
         const msg = error instanceof Error ? error.message : String(error);
         this.pushSystemMessage(`Failed to switch provider\n\n${msg}`);
       }
+      // Reject all pending deliveries so their promises don't hang forever
+      // (which would leave trackJobExecution stuck in "running" state).
+      const rejectError =
+        error instanceof Error ? error : new Error(`Reinitialize failed: ${String(error)}`);
+      for (const d of this.pendingDeliveries) {
+        d.reject(rejectError);
+      }
+      this.pendingDeliveries = [];
+      this.deliverySendCount = 0;
     } finally {
       this.isReinitializing = false;
     }
@@ -1252,6 +1263,11 @@ export class AgentHost {
         )
       )
       .catch((err) => {
+        // If the session changed (failover/reinit), this catch belongs to a
+        // stale send. The delivery was already captured in deliveriesToRetry
+        // and replayed on the new session — mutating state here would corrupt
+        // the new session's deliverySendCount / pendingDeliveries.
+        if (this.session !== session) return;
         this.deliverySendCount = Math.max(0, this.deliverySendCount - 1);
         log.error('[AgentHost] deliverMessage error:', err);
         // Send itself failed (session destroyed, etc.). The message never


### PR DESCRIPTION
## Summary

- Guard `sendCustomMessage` catch handlers with session identity checks so stale catches from old/destroyed sessions don't corrupt `deliverySendCount` / `pendingDeliveries` on the new session (root cause of cron jobs stuck in "running" after failover)
- Reject all pending delivery promises in `reinitializeWithProvider`'s catch block when failover itself fails, preventing indefinite hangs
- Append raw API `errorMessage` to failover chat detail strings so users see the actual error (e.g., "Provider finish_reason: error") instead of just the category label ("error")

## Test plan

- [x] All 662 existing tests pass
- [x] 5 updated test expectations verify raw error messages appear in failover detail strings
- [ ] Manual: trigger a provider error (e.g., invalid API key) and verify the chat message now shows the raw error string in the detail line
- [ ] Manual: trigger a failover during a cron job and verify the job transitions to "completed" (not stuck "running")