### PR TITLE
fix: upgrade Gemini models and improve onboarding reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 System2 is a multi-agent system for data engineering, analysis, and statistical reasoning. It adapts to your existing data stack or builds one from scratch. You talk to the Guide. It spawns a team that plans, builds pipelines, analyzes data, catches statistical fallacies, and delivers interactive output you can inspect end to end.
 
-Named for [Kahneman's](https://en.wikipedia.org/wiki/Thinking,_Fast_and_Slow) slow, deliberate mode of reasoning, System2 is the bicycle for your analytical mind.
+Named for Kahneman's slow, deliberate mode of reasoning, System2 is the bicycle for your analytical mind.
 
 It exists to help people think more clearly about complex questions and empower everyone, regardless of skill, to acquire and interpret data, and share rigorous analysis grounded in evidence and methods they can inspect.
 

--- a/README.md
+++ b/README.md
@@ -48,18 +48,17 @@ The Guide adapts to what you already have: if you have an existing database, orc
 
 </details>
 
-```bash
-system2 status           # check if the server is running
-system2 stop             # graceful shutdown
-```
+### Managing and updating
 
-### Updating
-
-Pull the latest released version:
+Once the server is running, you can check on it, stop it, or upgrade System2 at any time:
 
 ```bash
-pnpm update -g system2
+system2 status           # check whether the server is running
+system2 stop             # shut down gracefully
+pnpm update -g system2   # upgrade System2 to the latest release
 ```
+
+When you are done for the day, run `system2 stop`. Agent work in progress is saved, and a backup is created automatically on the next start.
 
 ---
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -14,11 +14,11 @@ System2's agents are built on the [pi-coding-agent](https://github.com/badlogic/
 
 | Agent | Role | Lifecycle | Models |
 | --- | --- | --- | --- |
-| **Guide** | Primary user-facing agent. Helps brainstorm and plan, starts projects, interfaces with the multi-agent system, and relays updates. Users may also interact directly with other active agents; Guide mediation is preferred in most cases. | Singleton, persistent | claude-sonnet-4-6, gpt-4o, gemini-2.5-flash |
-| **Narrator** | Maintains long-term memory: appends project logs and daily summaries, writes project stories on completion. [Schedule-driven](scheduler.md). | Singleton, persistent | claude-haiku-4-5-20251001, gpt-4o-mini, gemini-2.5-flash-lite |
-| **Conductor** | Orchestrates and executes work within a project: breaks it into tasks, spawns specialist agents or executes directly, and coordinates with the Reviewer before reporting completion. | Per-project, ephemeral | claude-sonnet-4-6, gpt-4o, gemini-2.5-flash |
-| **Reviewer** | Reviews code before push, assesses data analysis for reasoning fallacies (Kahneman's System 2 lens), and evaluates statistical quality of findings. | Per-project, ephemeral | claude-sonnet-4-6, gpt-4o, gemini-2.5-flash |
-| **Worker** | Executes self-contained tasks assigned by the Conductor. Same execution tools, no orchestration. All instructions via `initial_message`. | Per-project, ephemeral | claude-haiku-4-5-20251001, gpt-4o-mini, gemini-2.5-flash-lite |
+| **Guide** | Primary user-facing agent. Helps brainstorm and plan, starts projects, interfaces with the multi-agent system, and relays updates. Users may also interact directly with other active agents; Guide mediation is preferred in most cases. | Singleton, persistent | claude-sonnet-4-6, gpt-4o, gemini-3.1-pro-preview |
+| **Narrator** | Maintains long-term memory: appends project logs and daily summaries, writes project stories on completion. [Schedule-driven](scheduler.md). | Singleton, persistent | claude-haiku-4-5-20251001, gpt-4o-mini, gemini-3.1-flash-lite-preview |
+| **Conductor** | Orchestrates and executes work within a project: breaks it into tasks, spawns specialist agents or executes directly, and coordinates with the Reviewer before reporting completion. | Per-project, ephemeral | claude-sonnet-4-6, gpt-4o, gemini-3.1-pro-preview |
+| **Reviewer** | Reviews code before push, assesses data analysis for reasoning fallacies (Kahneman's System 2 lens), and evaluates statistical quality of findings. | Per-project, ephemeral | claude-sonnet-4-6, gpt-4o, gemini-3-flash-preview |
+| **Worker** | Executes self-contained tasks assigned by the Conductor. Same execution tools, no orchestration. All instructions via `initial_message`. | Per-project, ephemeral | claude-haiku-4-5-20251001, gpt-4o-mini, gemini-3.1-flash-lite-preview |
 
 **Guide and Narrator** are singletons created at server startup. Their sessions persist indefinitely across restarts.
 
@@ -38,7 +38,7 @@ version: "1.0"
 models:
   anthropic: claude-sonnet-4-6
   openai: gpt-4o
-  google: gemini-2.5-flash
+  google: gemini-3.1-pro-preview
 ---
 # Guide System Prompt
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,7 +66,7 @@ compaction_depth = 5
 anthropic = "claude-opus-4-6"
 
 [agents.conductor.models]
-google = "gemini-2.5-pro"
+google = "gemini-3.1-pro-preview"
 
 # Service credentials
 [services.brave_search]
@@ -186,9 +186,9 @@ compaction_depth = 5
 [agents.guide.models]
 anthropic = "claude-opus-4-6"
 
-# Use Gemini 2.5 Pro for the Conductor on Google
+# Use Gemini 3.1 Pro for the Conductor on Google
 [agents.conductor.models]
-google = "gemini-2.5-pro"
+google = "gemini-3.1-pro-preview"
 ```
 
 ### How it works

--- a/src/cli/utils/config.ts
+++ b/src/cli/utils/config.ts
@@ -642,7 +642,9 @@ export function buildConfigToml(options: {
       '# Example 2: route a role through OpenRouter to a specific upstream (e.g. Vertex AI)'
     );
     lines.push('# [agents.conductor.models]');
-    lines.push('# openrouter = "google/gemini-2.5-pro" # model ID as listed on openrouter.ai');
+    lines.push(
+      '# openrouter = "google/gemini-3.1-pro-preview" # model ID as listed on openrouter.ai'
+    );
     lines.push('#');
     lines.push('# To control which upstream providers OpenRouter uses for a model prefix:');
     lines.push('# [llm.openrouter.routing]');

--- a/src/server/agents/library/conductor.md
+++ b/src/server/agents/library/conductor.md
@@ -7,11 +7,11 @@ compaction_depth: 8
 models:
   anthropic: claude-sonnet-4-6
   cerebras: zai-glm-4.7
-  google: gemini-2.5-flash
+  google: gemini-3.1-pro-preview
   groq: llama-3.3-70b-versatile
   mistral: mistral-large-latest
   openai: gpt-4o
-  openrouter: google/gemini-2.5-flash
+  openrouter: google/gemini-3.1-pro-preview
   xai: grok-2-latest
 ---
 

--- a/src/server/agents/library/guide.md
+++ b/src/server/agents/library/guide.md
@@ -7,11 +7,11 @@ compaction_depth: 10
 models:
   anthropic: claude-sonnet-4-6
   cerebras: zai-glm-4.7
-  google: gemini-2.5-flash
+  google: gemini-3.1-pro-preview
   groq: llama-3.3-70b-versatile
   mistral: mistral-large-latest
   openai: gpt-4o
-  openrouter: google/gemini-2.5-flash
+  openrouter: google/gemini-3.1-pro-preview
   xai: grok-2-latest
 ---
 

--- a/src/server/agents/library/narrator.md
+++ b/src/server/agents/library/narrator.md
@@ -7,11 +7,11 @@ compaction_depth: 2
 models:
   anthropic: claude-haiku-4-5-20251001
   cerebras: gpt-oss-120b
-  google: gemini-2.5-flash-lite
+  google: gemini-3.1-flash-lite-preview
   groq: llama-3.1-8b-instant
   mistral: mistral-small-latest
   openai: gpt-4o-mini
-  openrouter: google/gemini-2.5-flash-lite
+  openrouter: google/gemini-3.1-flash-lite-preview
   xai: grok-2-latest
 ---
 

--- a/src/server/agents/library/reviewer.md
+++ b/src/server/agents/library/reviewer.md
@@ -7,11 +7,11 @@ compaction_depth: 5
 models:
   anthropic: claude-sonnet-4-6
   cerebras: zai-glm-4.7
-  google: gemini-2.5-flash
+  google: gemini-3-flash-preview
   groq: llama-3.3-70b-versatile
   mistral: mistral-large-latest
   openai: gpt-4o
-  openrouter: google/gemini-2.5-flash
+  openrouter: google/gemini-3-flash-preview
   xai: grok-2-latest
 ---
 

--- a/src/server/agents/library/worker.md
+++ b/src/server/agents/library/worker.md
@@ -6,11 +6,11 @@ thinking_level: medium
 models:
   anthropic: claude-haiku-4-5-20251001
   cerebras: gpt-oss-120b
-  google: gemini-2.5-flash-lite
+  google: gemini-3.1-flash-lite-preview
   groq: llama-3.1-8b-instant
   mistral: mistral-small-latest
   openai: gpt-4o-mini
-  openrouter: google/gemini-2.5-flash-lite
+  openrouter: google/gemini-3.1-flash-lite-preview
   xai: grok-2-latest
 ---
 

--- a/src/server/agents/skills/airflow/SKILL.md
+++ b/src/server/agents/skills/airflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: airflow
 description: Use when building, debugging, scheduling, or testing data pipelines with Apache Airflow v3. Trigger on any code importing airflow, DAG definitions, operator usage, or user mentioning DAGs/tasks/operators/sensors/scheduling.
-roles: [conductor, reviewer, worker]
+roles: [guide, conductor, reviewer, worker]
 ---
 
 # Apache Airflow v3

--- a/src/server/agents/skills/prefect/SKILL.md
+++ b/src/server/agents/skills/prefect/SKILL.md
@@ -338,7 +338,8 @@ prefect version
 
 ```bash
 # Get state of a specific flow run via the REST API
-curl -s http://localhost:4200/api/flow_runs/<flow-run-id> | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['state']['type'], r['state'].get('message',''))"
+# Uses PREFECT_API_URL if set, otherwise defaults to the local server
+curl -s "${PREFECT_API_URL:-http://localhost:4200/api}/flow_runs/<flow-run-id>" | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['state']['type'], r['state'].get('message',''))"
 ```
 
 Use this instead of repeatedly running `prefect flow-run ls` and trying to parse truncated table output.

--- a/src/server/agents/skills/prefect/SKILL.md
+++ b/src/server/agents/skills/prefect/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: prefect
 description: Use when building, debugging, deploying, or testing data pipelines with Prefect v3. Trigger on any code importing prefect, prefect YAML config, or user mentioning Prefect flows/tasks/deployments/workers.
-roles: [conductor, reviewer, worker]
+roles: [guide, conductor, reviewer, worker]
 ---
 
 # Prefect v3 Data Pipelines
@@ -339,7 +339,7 @@ prefect version
 ```bash
 # Get state of a specific flow run via the REST API
 # Uses PREFECT_API_URL if set, otherwise defaults to the local server
-curl -s "${PREFECT_API_URL:-http://localhost:4200/api}/flow_runs/<flow-run-id>" | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['state']['type'], r['state'].get('message',''))"
+curl -sf "${PREFECT_API_URL:-http://localhost:4200/api}/flow_runs/<flow-run-id>" | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['state']['type'], r['state'].get('message',''))"
 ```
 
 Use this instead of repeatedly running `prefect flow-run ls` and trying to parse truncated table output.

--- a/src/server/agents/skills/prefect/SKILL.md
+++ b/src/server/agents/skills/prefect/SKILL.md
@@ -334,6 +334,15 @@ prefect config view
 prefect version
 ```
 
+**Checking flow run state programmatically** (preferred over parsing CLI tables):
+
+```bash
+# Get state of a specific flow run via the REST API
+curl -s http://localhost:4200/api/flow_runs/<flow-run-id> | python3 -c "import sys,json; r=json.load(sys.stdin); print(r['state']['type'], r['state'].get('message',''))"
+```
+
+Use this instead of repeatedly running `prefect flow-run ls` and trying to parse truncated table output.
+
 **Flow run stuck in "Pending"**: no worker polling the work pool, or the work pool is paused. Check `prefect work-pool ls` and `prefect worker ls`.
 
 **Flow run stuck in "Running"**: worker may have crashed without reporting. Check worker logs. Runs exceeding `timeout_seconds` are eventually marked as failed.

--- a/src/server/agents/skills/system2-onboarding/SKILL.md
+++ b/src/server/agents/skills/system2-onboarding/SKILL.md
@@ -137,7 +137,7 @@ npm install --prefix ~/.system2 @google-cloud/bigquery # BigQuery
 # SQLite: no install needed (built-in)
 ```
 
-**Write a config entry** to `~/.system2/config.toml` for each database in the data stack (generally one). Use the `edit` tool with `append: true` to add a `[databases.<name>]` section. NEVER use the `write` tool on config.toml as it replaces the entire file and will destroy existing sections (LLM keys, services, operational settings). Passwords can be included directly in config.toml. Examples:
+**Write a config entry** to `~/.system2/config.toml` for each database in the data stack (generally one). Use the `edit` tool to insert a `[databases.<name>]` section immediately after the commented-out `[databases.mydb]` example block, keeping database entries grouped together. Do NOT use `append: true` (it dumps entries at the bottom, far from the databases section header). NEVER use the `write` tool on config.toml as it replaces the entire file and will destroy existing sections (LLM keys, services, operational settings). Use the database name directly as the section key (e.g. `[databases.lens]`), not prefixed with `system2_` or any other namespace. Passwords can be included directly in config.toml. Examples:
 
 ```toml
 [databases.my_postgres]
@@ -258,6 +258,8 @@ The scaffold ships with Prefect and Airflow support out of the box. If the user 
 
 **If Prefect (default):**
 
+Load the `prefect` skill before proceeding. It contains the canonical CLI reference, deployment patterns, and debugging procedures. Use it throughout the Prefect setup steps below.
+
 Start the server (persistent runs, UI, scheduling). See the [Prefect server docs](https://docs.prefect.io/v3/manage/self-host) for details:
 ```bash
 prefect server start                                        # keep running in background
@@ -284,6 +286,8 @@ prefect deployment ls                         # list deployments and schedules
 Prefect Cloud (managed, no local server): `prefect cloud login` (browser auth).
 
 **If Airflow (only if the user chose Airflow over Prefect):**
+
+Load the `airflow` skill before proceeding. It contains the canonical CLI reference, DAG patterns, and debugging procedures. Use it throughout the Airflow setup steps below.
 
 Astronomer is the recommended way to run Airflow 3 locally: it handles all Docker setup. Requirements: Docker Desktop (macOS/Windows) or Docker Engine (Linux) running.
 

--- a/src/server/agents/skills/system2-onboarding/SKILL.md
+++ b/src/server/agents/skills/system2-onboarding/SKILL.md
@@ -137,7 +137,7 @@ npm install --prefix ~/.system2 @google-cloud/bigquery # BigQuery
 # SQLite: no install needed (built-in)
 ```
 
-**Write a config entry** to `~/.system2/config.toml` for each database in the data stack (generally one). Use the `edit` tool to insert a `[databases.<name>]` section immediately after the commented-out `[databases.mydb]` example block, keeping database entries grouped together. Do NOT use `append: true` (it dumps entries at the bottom, far from the databases section header). NEVER use the `write` tool on config.toml as it replaces the entire file and will destroy existing sections (LLM keys, services, operational settings). Use the database name directly as the section key (e.g. `[databases.lens]`), not prefixed with `system2_` or any other namespace. Passwords can be included directly in config.toml. Examples:
+**Write a config entry** to `~/.system2/config.toml` for each database in the data stack (generally one). Use the `edit` tool to insert a `[databases.<name>]` section immediately after the commented-out `[databases.mydb]` example block, keeping database entries grouped together. Do NOT use `append: true` (it dumps entries at the bottom, far from the databases section header). NEVER use the `write` tool on config.toml as it replaces the entire file and will destroy existing sections (LLM keys, services, operational settings). Use the database name directly as the section key (e.g. `[databases.lens]`), not prefixed with `system2_` or any other namespace. Note: the name `system2` is reserved for the built-in app database; never create a `[databases.system2]` section (it will be silently ignored). Passwords can be included directly in config.toml. Examples:
 
 ```toml
 [databases.my_postgres]

--- a/src/server/agents/skills/system2-onboarding/SKILL.md
+++ b/src/server/agents/skills/system2-onboarding/SKILL.md
@@ -137,7 +137,7 @@ npm install --prefix ~/.system2 @google-cloud/bigquery # BigQuery
 # SQLite: no install needed (built-in)
 ```
 
-**Write a config entry** to `~/.system2/config.toml` for each database in the data stack (generally one). Use the `edit` tool to insert a `[databases.<name>]` section immediately after the commented-out `[databases.mydb]` example block, keeping database entries grouped together. Do NOT use `append: true` (it dumps entries at the bottom, far from the databases section header). NEVER use the `write` tool on config.toml as it replaces the entire file and will destroy existing sections (LLM keys, services, operational settings). Use the database name directly as the section key (e.g. `[databases.lens]`), not prefixed with `system2_` or any other namespace. Note: the name `system2` is reserved for the built-in app database; never create a `[databases.system2]` section (it will be silently ignored). Passwords can be included directly in config.toml. Examples:
+**Write a config entry** to `~/.system2/config.toml` for each database in the data stack (generally one). These entries are used by System2's server for read-only querying: agents use them via the `query_database` tool, and HTML dashboard artifacts query through them. Pipelines manage their own database connections independently. Because System2 only reads, use a read-only database user (not the pipeline's write user). Read `~/.system2/config.toml` first, then use the `edit` tool to insert a `[databases.<name>]` section immediately after the commented-out `[databases.mydb]` example block, keeping database entries grouped together. Do NOT use `append: true` (it dumps entries at the bottom, far from the databases section header). NEVER use the `write` tool on config.toml as it replaces the entire file and will destroy existing sections (LLM keys, services, operational settings). Use the database name directly as the section key (e.g. `[databases.lens]`), not prefixed with `system2_` or any other namespace. Note: the name `system2` is reserved for the built-in app database; never create a `[databases.system2]` section (it will be silently ignored). Passwords can be included directly in config.toml. Examples:
 
 ```toml
 [databases.my_postgres]
@@ -362,7 +362,12 @@ Run the example pipeline to confirm the full stack works end-to-end. Inform the 
 
 #### 7h. Save to infrastructure.md
 
-Read once again the `infrastructure.md` and make sure that all data stack details are accurately recorded and their use explained: database type and version, database names,orchestrator choice, repository path, data pipelines environment path.
+Read `infrastructure.md` once more and verify all data stack details are accurately recorded:
+
+- **Databases**: For each database, fill in the JSON block with fields appropriate to the type (engine, version, deployment; host/port for on-premise databases; account/project for cloud services like Snowflake or BigQuery). Add a **Roles** section listing every database role created during setup, its purpose, auth mechanism, and where the credential lives. At minimum there should be a read-only role (used by System2 for queries and dashboards, credentials in config.toml) and a pipeline write role (used by ETL code, credentials in the pipeline repo's `.env` or equivalent). Never paste actual passwords.
+- **Orchestrator**: name, deployment mode, UI URL, flows/DAGs location.
+- **Code repositories**: path, remote URL, purpose.
+- **Data pipelines environment**: venv path.
 
 ### 8. Agent instruction files
 

--- a/src/server/agents/skills/system2-onboarding/SKILL.md
+++ b/src/server/agents/skills/system2-onboarding/SKILL.md
@@ -22,7 +22,7 @@ If the session is interrupted partway through, the next Guide session should re-
 
 ## Preamble
 
-The knowledge files in `~/.system2/knowledge/` are seeded with structural templates. **Always read the entire file before editing it** so you see what is already populated and do not overwrite existing content. Preserve the template's section headings and structure. Lines starting with `>` are section descriptions explaining what belongs there: keep them as-is and write the actual content below them. Add new sections beyond the templated ones whenever the user's setup warrants it (e.g. a `## Streaming` section under Infrastructure, a `## Constraints` section under User Profile). Likewise, the JSON blocks in `infrastructure.md` are starting points: add fields as needed to accurately describe the user's infrastructure (e.g. `tunnel`, `read_replica`, `tls`, `package_manager`). The schemas are illustrative, not rigid.
+The knowledge files in `~/.system2/knowledge/` are seeded with structural templates. **Always read the entire file before every edit** so you see what is already populated, what the exact current text is, and where to place new content. Never guess at file contents; a failed `edit` (old_string not found) means you did not read first. Preserve the template's section headings and structure. Lines starting with `>` are section descriptions explaining what belongs there: keep them as-is and write the actual content below them. Place content in the correct template section using `edit` with a precise `old_string`; do not use `append: true` on knowledge files (it dumps content at the bottom, outside the template structure). Do not use `write` to overwrite the file; use targeted `edit` calls. Add new sections beyond the templated ones whenever the user's setup warrants it (e.g. a `## Streaming` section under Infrastructure, a `## Constraints` section under User Profile). Likewise, the JSON blocks in `infrastructure.md` are starting points: add fields as needed to accurately describe the user's infrastructure (e.g. `tunnel`, `read_replica`, `tls`, `package_manager`). The schemas are illustrative, not rigid.
 
 **Handling credentials.** Many users will already have credentials configured in standard locations (e.g. `~/.pgpass` already exists, AWS is already set up via `aws configure`, GitHub via `gh auth login`). In those cases, simply point the `credentials` field in `infrastructure.md` at the existing file and move on. If the user instead shares a secret directly during the conversation, never write it to `infrastructure.md` or any other file under `~/.system2/knowledge/` (those files are git-tracked). Write the secret to the system's native credential location (creating the file with `chmod 600` if it does not already exist), then record the *path* to that location in the JSON block under a `credentials` field. Use the canonical native location for each system:
 
@@ -60,7 +60,7 @@ Tell the user you're going to take a quick look at their system, then run:
 - Check installed tools: `git --version`, `python3 --version`, `pip3 --version`, `docker --version`, `psql --version`
 - Detect the platform package manager (macOS: `brew`, Linux: `apt`/`dnf`/distro equivalent, Windows: `winget` or `choco`)
 - Share a brief summary of what you found with the user
-- Save findings to `~/.system2/knowledge/infrastructure.md`, following the instructions for editing knowledge files in the Preamble.
+- Save findings to `~/.system2/knowledge/infrastructure.md`: read the file first, then use `edit` to place content in the correct template section.
 
 ### 4. Inventory existing infrastructure
 
@@ -68,7 +68,7 @@ Before installing anything, understand what the user already has running.
 - Ask whether the user has remote machines (VPS, home server, cloud instances) where infrastructure runs or could run. If so, understand how to access them (SSH, Tailscale, etc.).
 - Inventory existing databases, orchestration tools, and visualization tools (asking the user and checking the system). For each, ask and understand where it is deployed (local, remote), how to connect, and what access level System2 can have.
 - Check for running services: `psql --version`, `prefect version`, `airflow version`, `docker ps`. Note what is already operational. If Airflow is already running locally, this affects the orchestrator recommendation in step 7.
-- Save findings to `~/.system2/knowledge/infrastructure.md`, following the instructions for editing knowledge files in the Preamble.
+- Save findings to `~/.system2/knowledge/infrastructure.md`: read the file first, then use `edit` to place content in the correct template section.
 
 ### 5. GitHub and gh CLI
 
@@ -369,7 +369,7 @@ Read once again the `infrastructure.md` and make sure that all data stack detail
 Check for AI agent instruction files that may contain coding conventions or preferences:
 - Per-repo: `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md`
 - Global: `~/.claude/CLAUDE.md`, `~/.cursor/rules/`
-- Save findings to `~/.system2/knowledge/infrastructure.md`
+- Save findings to `~/.system2/knowledge/infrastructure.md`: read the file first, then use `edit` to place content in the correct template section.
 
 ### 9. Capture interaction preferences
 

--- a/src/server/knowledge/templates.ts
+++ b/src/server/knowledge/templates.ts
@@ -24,12 +24,13 @@ export const INFRASTRUCTURE_TEMPLATE = `# Infrastructure
 
 ## Databases
 
-> One subsection per database. Each starts with a JSON block describing connection details,
-> followed by prose covering schemas, tables of interest, retention, conventions, and quirks.
-> Add JSON fields as needed (e.g. \`tunnel\`, \`read_replica\`, \`tls\`). Use \`auth\` to
-> describe the mechanism (e.g. \`password\`, \`scram-sha-256\`, \`iam\`, \`peer\`), and
-> \`credentials\` to point at where the secret lives on disk (e.g. \`~/.pgpass\`, \`.env\`,
-> OS keychain entry name). Never paste the secret itself into this file: it is git-tracked.
+> One subsection per database. Each starts with a JSON block describing the database itself
+> (engine, version, deployment, and connection fields appropriate to the type: host/port for
+> on-premise, account/project for cloud services like Snowflake or BigQuery), followed by
+> prose covering what lives in it,
+> schemas, retention policies, conventions, and quirks. After the prose, list every database
+> role under a **Roles** heading with its purpose, auth mechanism, and where the credential
+> lives on disk. Never paste secrets into this file: it is git-tracked.
 
 > ### example_db
 >
@@ -40,14 +41,16 @@ export const INFRASTRUCTURE_TEMPLATE = `# Infrastructure
 >   "host": "localhost",
 >   "port": 5432,
 >   "database": "example",
->   "auth": "scram-sha-256",
->   "credentials": "~/.pgpass",
 >   "deployment": "local"
 > }
 > \`\`\`
 >
 > Prose describing what lives in this database, important schemas, retention policies,
 > gotchas, and how System2 typically queries it.
+>
+> **Roles:**
+> - \`read_only\` (password): read-only access for System2 queries and dashboards. Credentials in \`~/.system2/config.toml [databases.example]\`.
+> - \`app_writer\` (password): read-write access for ETL pipelines. Credentials in \`~/repos/my_pipelines/.env\`.
 
 ## Data Repositories
 


### PR DESCRIPTION
## Summary
- Upgrade Google/OpenRouter default models: Guide and Conductor to gemini-3.1-pro-preview, Reviewer to gemini-3-flash-preview, Worker and Narrator to gemini-3.1-flash-lite-preview
- Onboarding skill: instruct guide to load the `prefect` or `airflow` skill before setup steps (prevents CLI fumbling observed in first onboarding run)
- Onboarding skill: insert database config entries after the commented-out example block instead of appending to bottom of config.toml, and use plain names without `system2_` prefix
- Prefect skill: add REST API one-liner for programmatically checking flow run state (avoids parsing truncated CLI tables)
- Update docs/agents.md and docs/configuration.md to reflect new model defaults

## Test plan
- [ ] Verify `pnpm check`, `pnpm build`, `pnpm test` pass (pre-push hook confirms)
- [ ] Start system2 and confirm agents initialize with new model IDs
- [ ] Run a fresh onboarding to verify skill loading and config.toml placement