### PR TITLE
feat: replace fs.watch with mtime polling for artifact live reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.3] - 2026-04-22
 
 ### Changed
 
@@ -59,5 +59,5 @@ First published release.
 - Unify knowledge file commits via `commitIfStateDir` ([#125](https://github.com/diegoscarabelli/system2/pull/125))
 - Fall back to Guide when persisted agent no longer exists ([#122](https://github.com/diegoscarabelli/system2/pull/122))
 
-[Unreleased]: https://github.com/diegoscarabelli/system2/compare/v0.1.2...HEAD
+[0.1.3]: https://github.com/diegoscarabelli/system2/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/diegoscarabelli/system2/releases/tag/v0.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Replace unreliable `fs.watch` with mtime polling for artifact live reload ([#143](https://github.com/diegoscarabelli/system2/pull/143))
+  - New `GET /api/artifact-mtime` endpoint returns `{ mtimeMs }` via `fs.statSync`
+  - UI polls active artifact tab every 2 seconds, reloads on mtime change
+  - Tab switches now cache-bust iframe URLs for fresh content
+  - `show_artifact` WebSocket messages cache-bust when targeting an already-open tab
+
+### Removed
+
+- Remove `FSWatcher` and `watchArtifact()` from WebSocket handler (replaced by mtime polling) ([#143](https://github.com/diegoscarabelli/system2/pull/143))
+
+## [0.1.2] - 2026-04-22
+
+First published release.
+
+### Added
+
+- Multi-agent orchestration with Conductor, Narrator, Analyst, and Guide roles
+- React-based real-time chat UI with WebSocket communication
+- HTML artifact system with sandboxed iframes
+- postMessage query bridge for interactive dashboards ([#114](https://github.com/diegoscarabelli/system2/pull/114), [#142](https://github.com/diegoscarabelli/system2/pull/142))
+- Built-in skills: `live-dashboard`, `sql-schema-modeling`, `statistical-analysis`, `review` ([#108](https://github.com/diegoscarabelli/system2/pull/108), [#116](https://github.com/diegoscarabelli/system2/pull/116), [#119](https://github.com/diegoscarabelli/system2/pull/119), [#142](https://github.com/diegoscarabelli/system2/pull/142))
+- Git-tracked knowledge system with dynamic prompt injection
+- SQLite database (WAL mode) for artifacts, chat history, and agent state
+- Cron-based Narrator scheduler for automated summaries and memory updates
+- CLI: `system2 onboard`, `system2 start`, `system2 stop`, `system2 status` with update notifier ([#142](https://github.com/diegoscarabelli/system2/pull/142))
+- TimescaleDB/PostgreSQL integration for external analytics queries
+- WebSocket push notifications for real-time UI updates ([#104](https://github.com/diegoscarabelli/system2/pull/104))
+- Worker role for conductor-managed parallel execution ([#107](https://github.com/diegoscarabelli/system2/pull/107))
+- Heartbeat protocol and dual timeouts for bash tool ([#112](https://github.com/diegoscarabelli/system2/pull/112))
+- Timestamped logger module ([#111](https://github.com/diegoscarabelli/system2/pull/111))
+- Error state and retry button for push-triggered panel fetches ([#109](https://github.com/diegoscarabelli/system2/pull/109))
+- Guide welcome message on server startup ([#123](https://github.com/diegoscarabelli/system2/pull/123))
+- Support for markdown, code, PDF, and image file types in artifact viewer ([#128](https://github.com/diegoscarabelli/system2/pull/128))
+- Write tool warns when overwriting existing files ([#130](https://github.com/diegoscarabelli/system2/pull/130))
+- Per-role agent config overrides and OpenRouter Gemini defaults ([#118](https://github.com/diegoscarabelli/system2/pull/118))
+- LLM failover across providers (Anthropic, OpenRouter, OpenAI-compatible)
+
+### Fixed
+
+- Prevent delivery promises from hanging during provider failover ([#139](https://github.com/diegoscarabelli/system2/pull/139))
+- Upgrade Gemini models and improve onboarding reliability ([#140](https://github.com/diegoscarabelli/system2/pull/140))
+- Resolve Windows CI test failures ([#137](https://github.com/diegoscarabelli/system2/pull/137))
+- Conductor task granularity, narrator hardening, and context overflow recovery ([#134](https://github.com/diegoscarabelli/system2/pull/134))
+- Persist project `dir_path` in `app.db` ([#133](https://github.com/diegoscarabelli/system2/pull/133))
+- Improve inter-agent communication reliability ([#132](https://github.com/diegoscarabelli/system2/pull/132))
+- Prevent write tool from overwriting `config.toml` ([#129](https://github.com/diegoscarabelli/system2/pull/129))
+- Delivery send count race with `agent_end` ([#127](https://github.com/diegoscarabelli/system2/pull/127))
+- Unify knowledge file commits via `commitIfStateDir` ([#125](https://github.com/diegoscarabelli/system2/pull/125))
+- Fall back to Guide when persisted agent no longer exists ([#122](https://github.com/diegoscarabelli/system2/pull/122))
+
+[Unreleased]: https://github.com/diegoscarabelli/system2/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/diegoscarabelli/system2/releases/tag/v0.1.2

--- a/docs/artifacts.md
+++ b/docs/artifacts.md
@@ -9,7 +9,7 @@ Pipeline code, utility scripts, intermediate data files, and other working mater
 - `src/server/agents/tools/write-system2-db.ts`: CRUD operations (`createArtifact`, `updateArtifact`, `deleteArtifact`)
 - `src/server/db/client.ts`: database methods (`createArtifact`, `getArtifact`, `getArtifactByPath`, `updateArtifact`, `deleteArtifact`)
 - `src/server/server.ts`: HTTP endpoints (`/api/artifact`, `/api/artifacts`, `/api/query`)
-- `src/server/websocket/handler.ts`: WebSocket artifact events and file watching
+- `src/server/websocket/handler.ts`: WebSocket artifact events
 - `src/ui/components/ArtifactViewer.tsx`: tabbed viewer with iframe/markdown rendering
 - `src/ui/components/ArtifactCatalog.tsx`: browsable catalog panel
 - `src/ui/stores/artifact.ts`: Zustand store for tab state (persisted to localStorage)
@@ -80,7 +80,7 @@ The tool technically accepts any file path, not just registered artifacts. This 
 - `.png`, `.jpg`, `.jpeg`, `.gif`, `.svg`, `.webp`, `.avif`, `.ico`, `.bmp`: rendered as an inline image
 - Multiple artifacts can be open simultaneously in tabs
 
-**Live reload:** when `show_artifact` is called, the server starts an `fs.watch` on the file. Any modification triggers an automatic UI refresh of the corresponding tab (cache-busted URL). Only one artifact is watched at a time; showing a new artifact closes the previous watcher.
+**Live reload:** the UI polls the server for the active artifact's file modification time (`GET /api/artifact-mtime?path=...`) every 2 seconds. When `mtimeMs` changes, the tab reloads with a cache-busted URL. Switching tabs also triggers a reload, ensuring fresh content on every tab switch.
 
 ## Interactive Dashboards (postMessage Bridge)
 
@@ -135,7 +135,7 @@ When `show_artifact` completes successfully, the WebSocket handler emits an `art
 }
 ```
 
-The same message type is sent on live reload (with a cache-busting `&t=<timestamp>` appended to the URL).
+Live reload is handled by the UI polling `GET /api/artifact-mtime`, not by additional WebSocket messages.
 
 ## UI Components
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -166,8 +166,7 @@ Display an artifact file in the UI panel. **Guide-only**: the Guide is the only 
 - **DB metadata lookup:** queries the `artifact` table for title. If registered, the DB title is used as the tab label; otherwise, the filename is used.
 - **Unregistered files:** files not in the `artifact` table can still be shown; the filename is used as the tab label.
 - **Missing registered files:** if the file is registered but missing from disk, returns an error with the title and a hint to search for the filename.
-- **Live reload:** the server starts an `fs.watch` on the file; modifications trigger automatic UI refresh of the correct tab.
-- **Only one artifact watched at a time:** showing a new artifact closes the previous watcher.
+- **Live reload:** the UI polls the file's modification time every 2 seconds for the active tab. Switching tabs also triggers a reload.
 
 ### `web_fetch`
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -208,7 +208,8 @@ Key behaviors:
 
 - `openArtifact`: if a tab with the same `filePath` exists, activate it and update its URL; otherwise create a new tab
 - `closeTab`: remove tab, activate next/previous/null
-- `reloadTab`: find tab by `filePath`, update URL (for fs.watch cache-bust reloads)
+- `reloadTab`: find tab by `filePath`, update URL (used by mtime polling and show_artifact reload)
+- `setActiveTab`: activate tab with cache-busted URL (ensures fresh content on tab switch)
 - `openKanbanTab`: create (or activate existing) native kanban tab at position 0
 - `toggleKanbanTab`: close kanban tab if open, otherwise call `openKanbanTab` (used by activity bar button)
 - Tab dedup uses `filePath` with cache-bust query params stripped

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -71,7 +71,7 @@ type ServerMessage =
 | `assistant_chunk` / `assistant_end` | Streaming response text. `assistant_end` carries `errorMessage` when the LLM stop reason was an error; the UI renders it as a collapsible system message in the chat timeline. |
 | `tool_call_start` / `tool_call_end` | Tool execution lifecycle |
 | `tool_call_progress` | Heartbeat progress from a long-running tool (e.g., bash `::system2::` sentinel). Carries the progress `message` for UI display. |
-| `artifact` | Display artifact in a UI tab. Includes `title` (from DB or filename) and `filePath` (absolute path for tab dedup and reload targeting). Also sent on live reload (file watch). |
+| `artifact` | Display artifact in a UI tab. Includes `title` (from DB or filename) and `filePath` (absolute path for tab dedup). Sent when `show_artifact` completes. |
 | `context_usage` | Context window usage after each agent turn |
 | `provider_info` | Sent on connect/switch: current LLM provider for an agent |
 | `provider_change` | Sent on failover: provider switched. Includes `reason` (e.g., "503 server error, switched to anthropic") and `agentId` so the UI routes the system message to the correct agent chat |
@@ -196,7 +196,7 @@ Each WebSocket connection gets its own `WebSocketHandler` instance. It:
 5. Captures user messages in the target agent's chat cache and broadcasts to other tabs
 6. Handles `switch_agent` by adding a subscription (if not already subscribed) and sending the new agent's state
 7. Records non-Guide user messages in the `ConversationSummarizer` for Guide notification
-8. Watches artifact files for live reload (`fs.watch`)
+8. Emits `artifact` message when `show_artifact` completes (live reload is handled by UI polling)
 
 ## See Also
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diegoscarabelli/system2",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A multi-agent data platform for solo analysts",
   "author": "Diego Scarabelli",
   "license": "AGPL-3.0-only",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -191,6 +191,8 @@ export class Server {
 
     // Return file modification time for artifact live-reload polling
     this.app.get('/api/artifact-mtime', (req, res) => {
+      res.setHeader('Cache-Control', 'no-store');
+
       const resolved = resolveArtifactPath(req.query.path);
       if (!resolved) {
         res.status(400).json({ error: 'Missing or invalid path parameter' });
@@ -199,7 +201,6 @@ export class Server {
 
       try {
         const stat = statSync(resolved);
-        res.setHeader('Cache-Control', 'no-store');
         res.json({ mtimeMs: stat.mtimeMs });
       } catch {
         res.status(404).json({ error: 'File not found' });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -164,22 +164,19 @@ export class Server {
     this.app = express();
     this.app.use(express.json());
 
+    function resolveArtifactPath(raw: unknown): string | null {
+      if (!raw || typeof raw !== 'string') return null;
+      let resolved = raw;
+      if (resolved.startsWith('~/')) resolved = join(homedir(), resolved.slice(2));
+      resolved = normalize(resolved);
+      return isAbsolute(resolved) ? resolved : null;
+    }
+
     // Serve artifact files from anywhere on the filesystem
     this.app.get('/api/artifact', (req, res) => {
-      const filePath = req.query.path as string;
-      if (!filePath || typeof filePath !== 'string') {
-        res.status(400).json({ error: 'Missing path parameter' });
-        return;
-      }
-
-      let resolved = filePath;
-      if (resolved.startsWith('~/')) {
-        resolved = join(homedir(), resolved.slice(2));
-      }
-      resolved = normalize(resolved);
-
-      if (!isAbsolute(resolved)) {
-        res.status(400).json({ error: 'Path must be absolute' });
+      const resolved = resolveArtifactPath(req.query.path);
+      if (!resolved) {
+        res.status(400).json({ error: 'Missing or invalid path parameter' });
         return;
       }
 
@@ -194,25 +191,15 @@ export class Server {
 
     // Return file modification time for artifact live-reload polling
     this.app.get('/api/artifact-mtime', (req, res) => {
-      const filePath = req.query.path as string;
-      if (!filePath || typeof filePath !== 'string') {
-        res.status(400).json({ error: 'Missing path parameter' });
-        return;
-      }
-
-      let resolved = filePath;
-      if (resolved.startsWith('~/')) {
-        resolved = join(homedir(), resolved.slice(2));
-      }
-      resolved = normalize(resolved);
-
-      if (!isAbsolute(resolved)) {
-        res.status(400).json({ error: 'Path must be absolute' });
+      const resolved = resolveArtifactPath(req.query.path);
+      if (!resolved) {
+        res.status(400).json({ error: 'Missing or invalid path parameter' });
         return;
       }
 
       try {
         const stat = statSync(resolved);
+        res.setHeader('Cache-Control', 'no-store');
         res.json({ mtimeMs: stat.mtimeMs });
       } catch {
         res.status(404).json({ error: 'File not found' });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -4,7 +4,7 @@
  * HTTP + WebSocket server that hosts the Guide and Narrator agents and serves the UI.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join, normalize } from 'node:path';
@@ -190,6 +190,33 @@ export class Server {
 
       res.setHeader('Cache-Control', 'no-cache');
       res.sendFile(resolved);
+    });
+
+    // Return file modification time for artifact live-reload polling
+    this.app.get('/api/artifact-mtime', (req, res) => {
+      const filePath = req.query.path as string;
+      if (!filePath || typeof filePath !== 'string') {
+        res.status(400).json({ error: 'Missing path parameter' });
+        return;
+      }
+
+      let resolved = filePath;
+      if (resolved.startsWith('~/')) {
+        resolved = join(homedir(), resolved.slice(2));
+      }
+      resolved = normalize(resolved);
+
+      if (!isAbsolute(resolved)) {
+        res.status(400).json({ error: 'Path must be absolute' });
+        return;
+      }
+
+      try {
+        const stat = statSync(resolved);
+        res.json({ mtimeMs: stat.mtimeMs });
+      } catch {
+        res.status(404).json({ error: 'File not found' });
+      }
     });
 
     // List all registered artifacts for the catalog UI

--- a/src/server/websocket/handler.ts
+++ b/src/server/websocket/handler.ts
@@ -7,7 +7,6 @@
  * Assistant message history capture is handled centrally by Server.
  */
 
-import { type FSWatcher, watch } from 'node:fs';
 import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 import type { WebSocket, WebSocketServer } from 'ws';
 import type { ClientMessage, ServerMessage } from '../../shared/index.js';
@@ -24,8 +23,6 @@ export class WebSocketHandler {
   private activeAgentId: number;
   private subscriptions = new Map<number, () => void>();
   private thinkingAgents = new Set<number>();
-  private artifactWatcher?: FSWatcher;
-  private artifactUrl?: string;
   private summarizer?: ConversationSummarizer;
 
   constructor(
@@ -317,7 +314,7 @@ export class WebSocketHandler {
           agentId,
         });
 
-        // If show_artifact completed successfully, emit artifact message and watch
+        // If show_artifact completed successfully, emit artifact message
         if (event.toolName === 'show_artifact' && !event.isError) {
           const details = event.result?.details as
             | { url?: string; absolutePath?: string; title?: string }
@@ -330,7 +327,6 @@ export class WebSocketHandler {
               title: details.title,
               filePath: details.absolutePath,
             });
-            this.watchArtifact(details.url, details.absolutePath);
           } else {
             log.warn('[WebSocket] show_artifact missing details:', details);
           }
@@ -397,40 +393,7 @@ export class WebSocketHandler {
     this.send({ type: 'error', message });
   }
 
-  private watchArtifact(url: string, absolutePath: string): void {
-    // Stop previous watcher if any
-    if (this.artifactWatcher) {
-      this.artifactWatcher.close();
-    }
-
-    this.artifactUrl = url;
-    log.info('[WebSocket] Watching artifact:', absolutePath);
-
-    try {
-      this.artifactWatcher = watch(absolutePath, (eventType, filename) => {
-        log.info('[WebSocket] fs.watch event:', eventType, filename);
-        if (eventType === 'change') {
-          // Cache-bust so the iframe actually reloads (use & since URL already has ?path=)
-          const separator = this.artifactUrl?.includes('?') ? '&' : '?';
-          const bustUrl = `${this.artifactUrl}${separator}t=${Date.now()}`;
-          log.info('[WebSocket] Sending artifact reload:', bustUrl);
-          this.send({ type: 'artifact', url: bustUrl, filePath: absolutePath });
-        }
-      });
-
-      this.artifactWatcher.on('error', (err) => {
-        log.error('[WebSocket] Watcher error:', err);
-      });
-    } catch (error) {
-      log.error('[WebSocket] Failed to watch artifact:', error);
-    }
-  }
-
   private cleanup(): void {
-    if (this.artifactWatcher) {
-      this.artifactWatcher.close();
-      this.artifactWatcher = undefined;
-    }
     for (const unsub of this.subscriptions.values()) {
       unsub();
     }

--- a/src/ui/components/ArtifactViewer.tsx
+++ b/src/ui/components/ArtifactViewer.tsx
@@ -9,6 +9,7 @@ import { XIcon } from '@primer/octicons-react';
 import { Box, IconButton, Text } from '@primer/react';
 import { useEffect, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
+import { useArtifactMtimePoll } from '../hooks/useArtifactMtimePoll';
 import { handleQueryMessage } from '../query-bridge';
 import { useArtifactStore } from '../stores/artifact';
 import { useThemeStore } from '../stores/theme';
@@ -194,6 +195,9 @@ export function ArtifactViewer() {
   const isLight = colorMode === 'light';
 
   const activeTab = tabs.find((t) => t.id === activeTabId);
+
+  // Poll for file changes on the active artifact tab
+  useArtifactMtimePoll(activeTab?.type === 'iframe' ? activeTab.filePath : null);
 
   // Resize iframe to its content height so the parent container handles scrolling.
   // Uses ResizeObserver on the iframe body to track dynamic content changes

--- a/src/ui/hooks/useArtifactMtimePoll.test.ts
+++ b/src/ui/hooks/useArtifactMtimePoll.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { useArtifactStore } from '../stores/artifact';
+
+const ARTIFACT_PATH = '/home/user/dashboard.html';
+
+describe('useArtifactMtimePoll (store integration)', () => {
+  beforeEach(() => {
+    useArtifactStore.setState({
+      tabs: [
+        {
+          id: 'tab-1',
+          type: 'iframe',
+          url: `/api/artifact?path=${encodeURIComponent(ARTIFACT_PATH)}`,
+          filePath: ARTIFACT_PATH,
+          title: 'dashboard.html',
+        },
+      ],
+      activeTabId: 'tab-1',
+    });
+  });
+
+  afterEach(() => {
+    useArtifactStore.setState({
+      tabs: [],
+      activeTabId: null,
+      catalogOpen: false,
+      agentsOpen: false,
+      cronJobsOpen: false,
+      kanbanOpen: false,
+    });
+  });
+
+  it('reloadTab updates the URL for a matching tab', () => {
+    const store = useArtifactStore.getState();
+    store.reloadTab(ARTIFACT_PATH, '/api/artifact?path=%2Fhome%2Fuser%2Fdashboard.html&t=123');
+
+    const tab = useArtifactStore.getState().tabs.find((t) => t.filePath === ARTIFACT_PATH);
+    expect(tab?.url).toContain('&t=123');
+  });
+
+  it('reloadTab does not affect other tabs', () => {
+    useArtifactStore.setState({
+      tabs: [
+        ...useArtifactStore.getState().tabs,
+        {
+          id: 'tab-2',
+          type: 'iframe',
+          url: '/api/artifact?path=%2Fother.html',
+          filePath: '/other.html',
+          title: 'other.html',
+        },
+      ],
+    });
+
+    useArtifactStore.getState().reloadTab(ARTIFACT_PATH, '/api/artifact?path=x&t=999');
+
+    const other = useArtifactStore.getState().tabs.find((t) => t.filePath === '/other.html');
+    expect(other?.url).toBe('/api/artifact?path=%2Fother.html');
+  });
+});

--- a/src/ui/hooks/useArtifactMtimePoll.ts
+++ b/src/ui/hooks/useArtifactMtimePoll.ts
@@ -28,16 +28,19 @@ export function useArtifactMtimePoll(filePath: string | null): void {
           signal: controller.signal,
           cache: 'no-store',
         });
-        if (!res.ok || controller.signal.aborted) return;
-        const data = (await res.json()) as { mtimeMs: number };
         if (controller.signal.aborted) return;
 
-        if (lastMtime.current === null) {
-          lastMtime.current = data.mtimeMs;
-        } else if (data.mtimeMs !== lastMtime.current) {
-          lastMtime.current = data.mtimeMs;
-          const freshUrl = `/api/artifact?path=${encodeURIComponent(filePath)}&t=${Date.now()}`;
-          useArtifactStore.getState().reloadTab(filePath, freshUrl);
+        if (res.ok) {
+          const data = (await res.json()) as { mtimeMs: number };
+          if (controller.signal.aborted) return;
+
+          if (lastMtime.current === null) {
+            lastMtime.current = data.mtimeMs;
+          } else if (data.mtimeMs !== lastMtime.current) {
+            lastMtime.current = data.mtimeMs;
+            const freshUrl = `/api/artifact?path=${encodeURIComponent(filePath)}&t=${Date.now()}`;
+            useArtifactStore.getState().reloadTab(filePath, freshUrl);
+          }
         }
       } catch {
         // Network or abort error, skip this tick

--- a/src/ui/hooks/useArtifactMtimePoll.ts
+++ b/src/ui/hooks/useArtifactMtimePoll.ts
@@ -15,37 +15,44 @@ export function useArtifactMtimePoll(filePath: string | null): void {
   const lastMtime = useRef<number | null>(null);
 
   useEffect(() => {
-    // Reset mtime when the active file changes
     lastMtime.current = null;
 
     if (!filePath) return;
 
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
     const poll = async () => {
       try {
-        const res = await fetch(`/api/artifact-mtime?path=${encodeURIComponent(filePath)}`);
-        if (!res.ok) return;
+        const res = await fetch(`/api/artifact-mtime?path=${encodeURIComponent(filePath)}`, {
+          signal: controller.signal,
+          cache: 'no-store',
+        });
+        if (!res.ok || controller.signal.aborted) return;
         const data = (await res.json()) as { mtimeMs: number };
+        if (controller.signal.aborted) return;
 
         if (lastMtime.current === null) {
-          // First poll: store baseline, don't reload
           lastMtime.current = data.mtimeMs;
-          return;
-        }
-
-        if (data.mtimeMs !== lastMtime.current) {
+        } else if (data.mtimeMs !== lastMtime.current) {
           lastMtime.current = data.mtimeMs;
           const freshUrl = `/api/artifact?path=${encodeURIComponent(filePath)}&t=${Date.now()}`;
           useArtifactStore.getState().reloadTab(filePath, freshUrl);
         }
       } catch {
-        // Network error, skip this tick
+        // Network or abort error, skip this tick
+      }
+
+      if (!controller.signal.aborted) {
+        timer = setTimeout(poll, POLL_INTERVAL_MS);
       }
     };
 
-    const timer = setInterval(poll, POLL_INTERVAL_MS);
-    // Run first poll immediately to establish baseline
     poll();
 
-    return () => clearInterval(timer);
+    return () => {
+      controller.abort();
+      if (timer !== null) clearTimeout(timer);
+    };
   }, [filePath]);
 }

--- a/src/ui/hooks/useArtifactMtimePoll.ts
+++ b/src/ui/hooks/useArtifactMtimePoll.ts
@@ -1,0 +1,51 @@
+/**
+ * Artifact Mtime Poll Hook
+ *
+ * Polls the server for the active artifact's file modification time.
+ * When mtimeMs changes, reloads the tab with a cache-busted URL.
+ * Only polls for one file at a time (the active tab).
+ */
+
+import { useEffect, useRef } from 'react';
+import { useArtifactStore } from '../stores/artifact';
+
+const POLL_INTERVAL_MS = 2000;
+
+export function useArtifactMtimePoll(filePath: string | null): void {
+  const lastMtime = useRef<number | null>(null);
+
+  useEffect(() => {
+    // Reset mtime when the active file changes
+    lastMtime.current = null;
+
+    if (!filePath) return;
+
+    const poll = async () => {
+      try {
+        const res = await fetch(`/api/artifact-mtime?path=${encodeURIComponent(filePath)}`);
+        if (!res.ok) return;
+        const data = (await res.json()) as { mtimeMs: number };
+
+        if (lastMtime.current === null) {
+          // First poll: store baseline, don't reload
+          lastMtime.current = data.mtimeMs;
+          return;
+        }
+
+        if (data.mtimeMs !== lastMtime.current) {
+          lastMtime.current = data.mtimeMs;
+          const freshUrl = `/api/artifact?path=${encodeURIComponent(filePath)}&t=${Date.now()}`;
+          useArtifactStore.getState().reloadTab(filePath, freshUrl);
+        }
+      } catch {
+        // Network error, skip this tick
+      }
+    };
+
+    const timer = setInterval(poll, POLL_INTERVAL_MS);
+    // Run first poll immediately to establish baseline
+    poll();
+
+    return () => clearInterval(timer);
+  }, [filePath]);
+}

--- a/src/ui/hooks/useWebSocket.ts
+++ b/src/ui/hooks/useWebSocket.ts
@@ -180,7 +180,10 @@ export function useWebSocket() {
             const existingTab = artifactStore.tabs.find((t) => t.filePath === message.filePath);
             if (existingTab) {
               const separator = message.url.includes('?') ? '&' : '?';
-              artifactStore.reloadTab(message.filePath, `${message.url}${separator}t=${Date.now()}`);
+              artifactStore.reloadTab(
+                message.filePath,
+                `${message.url}${separator}t=${Date.now()}`
+              );
             } else {
               artifactStore.openArtifact(message.url, message.title, message.filePath);
             }

--- a/src/ui/hooks/useWebSocket.ts
+++ b/src/ui/hooks/useWebSocket.ts
@@ -179,7 +179,8 @@ export function useWebSocket() {
           if (message.filePath) {
             const existingTab = artifactStore.tabs.find((t) => t.filePath === message.filePath);
             if (existingTab) {
-              artifactStore.reloadTab(message.filePath, message.url);
+              const separator = message.url.includes('?') ? '&' : '?';
+              artifactStore.reloadTab(message.filePath, `${message.url}${separator}t=${Date.now()}`);
             } else {
               artifactStore.openArtifact(message.url, message.title, message.filePath);
             }

--- a/src/ui/stores/artifact-reload.test.ts
+++ b/src/ui/stores/artifact-reload.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { useArtifactStore } from '../stores/artifact';
+import { useArtifactStore } from './artifact';
 
 const ARTIFACT_PATH = '/home/user/dashboard.html';
 
-describe('useArtifactMtimePoll (store integration)', () => {
+describe('artifact store reloadTab', () => {
   beforeEach(() => {
     useArtifactStore.setState({
       tabs: [

--- a/src/ui/stores/artifact.test.ts
+++ b/src/ui/stores/artifact.test.ts
@@ -99,6 +99,40 @@ describe('useArtifactStore', () => {
     });
   });
 
+  describe('setActiveTab', () => {
+    it('cache-busts the URL when switching to an iframe tab', () => {
+      useArtifactStore.setState({
+        tabs: [
+          {
+            id: 'tab-1',
+            type: 'iframe',
+            url: '/api/artifact?path=%2Ffoo.html',
+            filePath: '/foo.html',
+            title: 'foo.html',
+          },
+        ],
+        activeTabId: null,
+      });
+
+      useArtifactStore.getState().setActiveTab('tab-1');
+
+      const tab = useArtifactStore.getState().tabs.find((t) => t.id === 'tab-1');
+      expect(tab?.url).toContain('&t=');
+      expect(tab?.url).toContain('path=%2Ffoo.html');
+    });
+
+    it('does not modify the URL for native tabs', () => {
+      useArtifactStore.getState().openKanbanTab();
+      // Switch away first
+      useArtifactStore.setState({ activeTabId: null });
+
+      useArtifactStore.getState().setActiveTab('kanban');
+
+      const tab = useArtifactStore.getState().tabs.find((t) => t.id === 'kanban');
+      expect(tab?.url).toBe('');
+    });
+  });
+
   describe('toggleCronJobs', () => {
     it('opens the cron jobs panel', () => {
       useArtifactStore.getState().toggleCronJobs();

--- a/src/ui/stores/artifact.ts
+++ b/src/ui/stores/artifact.ts
@@ -125,7 +125,7 @@ export const useArtifactStore = create<ArtifactState>()(
       setActiveTab: (tabId: string) => {
         const state = get();
         const tab = state.tabs.find((t) => t.id === tabId);
-        if (!tab || tab.type === 'native') {
+        if (!tab || tab.type === 'native' || tabId === state.activeTabId) {
           set({ activeTabId: tabId });
           return;
         }

--- a/src/ui/stores/artifact.ts
+++ b/src/ui/stores/artifact.ts
@@ -123,7 +123,18 @@ export const useArtifactStore = create<ArtifactState>()(
       },
 
       setActiveTab: (tabId: string) => {
-        set({ activeTabId: tabId });
+        const state = get();
+        const tab = state.tabs.find((t) => t.id === tabId);
+        if (!tab || tab.type === 'native') {
+          set({ activeTabId: tabId });
+          return;
+        }
+        // Cache-bust the URL so the iframe/content reloads with fresh data
+        const freshUrl = `/api/artifact?path=${encodeURIComponent(tab.filePath)}&t=${Date.now()}`;
+        set({
+          activeTabId: tabId,
+          tabs: state.tabs.map((t) => (t.id === tabId ? { ...t, url: freshUrl } : t)),
+        });
       },
 
       reloadTab: (filePath: string, newUrl: string) => {


### PR DESCRIPTION
## Summary

- Replace unreliable `fs.watch` (FSEvents misses atomic writes) with a polling approach: the UI polls `GET /api/artifact-mtime` every 2 seconds for the active tab's file and reloads when `mtimeMs` changes
- Add cache-busting (`&t=<timestamp>`) on tab switch and on `show_artifact` WebSocket messages so artifacts always display fresh content
- Remove the single-file `FSWatcher` from the WebSocket handler (was silently broken: only watched one artifact at a time, missed rename-based writes)

## Changes

**Server**
- New `GET /api/artifact-mtime` endpoint returning `{ mtimeMs }` via `fs.statSync`
- Removed `FSWatcher` fields and `watchArtifact()` method from WebSocket handler

**UI**
- New `useArtifactMtimePoll` hook: polls active iframe tab, stores baseline on first poll, reloads on mtime change
- `setActiveTab` now cache-busts iframe URLs (native tabs like kanban pass through unchanged)
- `useWebSocket` cache-busts URL when `show_artifact` targets an already-open tab

**Tests**
- `useArtifactMtimePoll.test.ts`: store integration tests for `reloadTab`
- `artifact.test.ts`: tests for `setActiveTab` cache-busting behavior

**Docs**
- Updated `artifacts.md`, `websocket-protocol.md`, `tools.md`, `ui.md` to describe the new polling mechanism

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (695 tests)
- [ ] Manual: open an HTML artifact, edit the file externally, verify it reloads within ~2s
- [ ] Manual: switch between artifact tabs, verify each displays fresh content
- [ ] Manual: kanban board unaffected by mtime polling