### PR TITLE
feat: Claude Pro/Max OAuth support with two-tier auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ It exists to help people think more clearly about complex questions and empower 
 ### Prerequisites
 
 1. **[Node.js 20+](https://nodejs.org/)** and **[pnpm 8+](https://pnpm.io/installation)** (in a terminal, run `node -v` and `pnpm -v` to check)
-2. **An LLM API key** (required). [OpenRouter](https://openrouter.ai/) is highly recommended: it provides access to multiple models with a single key. Anthropic, Google, OpenAI, and other providers also work.
+2. **An LLM credential** (at least one required). Two options, combinable:
+   - **Claude Pro/Max OAuth** (recommended if you have a Claude subscription): no API key needed. During onboarding you will be offered this as the first step.
+   - **An API key**: [OpenRouter](https://openrouter.ai/) is highly recommended (access to multiple models with one key). Anthropic, Google, OpenAI, and other providers also work.
 3. **Brave Search API key** (highly recommended). Enables agents to search the web and fetch web pages content. This is useful for researching APIs, documentation, and data sources on the web. [Get one here](https://brave.com/search/api/).
 
 ### Install and run
@@ -35,7 +37,7 @@ pnpm add -g @diegoscarabelli/system2      # install System2 globally
 system2 onboard          # one-time setup (see below)
 ```
 
-`system2 onboard` creates the `~/.system2/` directory and walks you through configuration: pick your LLM provider, enter API keys (you can add multiple for rotation and fallback providers for redundancy), and optionally set up Brave Search. Everything is saved to `~/.system2/config.toml`, which you can edit directly later.
+`system2 onboard` creates the `~/.system2/` directory and walks you through configuration: optionally set up Claude Pro/Max OAuth (recommended if you have a subscription), then pick your LLM provider and enter API keys (you can add multiple for rotation and fallback providers for redundancy), and optionally set up Brave Search. Everything is saved to `~/.system2/config.toml`, which you can edit directly later.
 
 ```bash
 system2 start            # starts the server and opens the browser
@@ -97,7 +99,8 @@ pnpm update -g @diegoscarabelli/system2   # upgrade System2 to the latest releas
 
 All settings live in `~/.system2/config.toml`, created by `system2 onboard`.
 
-- **`[llm]`**: primary provider, fallback order, per-provider API keys with automatic rotation
+- **`[llm.oauth]`**: OAuth tier — subscription credentials (Claude Pro/Max). Tried before API keys. See [Auth Tiers](docs/configuration.md#auth-tiers).
+- **`[llm]`**: API key tier — primary provider, fallback order, per-provider API keys with automatic rotation
 - **`[databases.*]`**: analytical database connections (PostgreSQL, ClickHouse, DuckDB, Snowflake, BigQuery, MySQL, MSSQL, SQLite) that agents and dashboard artifacts can query
 - **`[agents.*]`**: per-role overrides for thinking level, context compaction depth, and model selection per provider
 - **`[services.brave_search]`**: web search via Brave Search API (highly recommended)
@@ -133,6 +136,8 @@ System2's home directory is `~/.system2/`. It holds all system state: configurat
 ├── .gitignore
 ├── app.db                           SQLite database (gitignored)
 ├── config.toml                      Settings and API keys (0600, gitignored)
+├── oauth/                           OAuth credentials (0600, gitignored)
+│   └── anthropic.json               Claude Pro/Max tokens
 ├── knowledge/                       Persistent knowledge (git-tracked)
 │   ├── conductor.md                 Conductor role-specific knowledge
 │   ├── daily_summaries/             Daily activity logs

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,7 @@ For installation and usage, see the [project README](../README.md).
 
 - [Shared types](shared.md): The TypeScript types and interfaces used across the codebase.
 - [Server](server.md): The main runtime, hosting agents, serving the UI over HTTP and WebSocket, and running scheduled jobs.
-- [CLI](cli.md): Command-line tool for managing the server (initial setup, starting, stopping, checking status).
+- [CLI](cli.md): Command-line tool for managing the server (initial setup, OAuth login/logout, starting, stopping, checking status).
 - [UI](ui.md): The browser-based chat interface where you interact with the Guide agent and view artifacts.
 
 ## Core Systems
@@ -29,5 +29,5 @@ For installation and usage, see the [project README](../README.md).
 
 ## Reference
 
-- [Configuration](configuration.md): All settings in `config.toml`, including LLM provider credentials, failover chains, database connections, per-role agent overrides, and operational settings.
+- [Configuration](configuration.md): All settings in `config.toml`, including LLM provider credentials, OAuth tier and re-auth, failover chains, database connections, per-role agent overrides, and operational settings.
 - [Contributing](../CONTRIBUTING.md): Development setup, code standards, testing, and PR process.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -216,6 +216,20 @@ Auto-compaction is also configured to fire earlier (at ~50% of the context windo
 
 **Last-resort provider recovery:** after all normal recovery paths (retry, failover, context overflow) are exhausted, `handlePotentialError` checks if a different provider is available before giving up. This covers cases where an agent is stuck on a dead fallback provider (e.g., Anthropic with $0 credits returning 400 `client` errors) while the primary provider's cooldown has expired. `getNextProvider()` iterates in provider order (primary first), so agents naturally gravitate back to the primary when it becomes available.
 
+### Two-Tier Credentials (OAuth + API Keys)
+
+When `[llm.oauth]` is configured, `AuthResolver` walks credentials across two tiers:
+
+1. **OAuth tier** — providers listed in `[llm.oauth].primary` + `fallback`, each with one credential loaded from `~/.system2/oauth/<provider>.json` at startup.
+2. **API key tier** — providers listed in `[llm].primary` + `fallback`, with one or more API keys each.
+
+`getActiveCredential()` returns a `{ tier, provider, keyIndex, label }` tuple. Cooldown keys are namespaced as `${tier}:${provider}:${keyIndex}` so the same provider in both tiers (e.g., Anthropic OAuth and Anthropic API keys) doesn't collide. The OAuth tier is fully exhausted (every credential in cooldown) before the resolver returns a keys-tier credential.
+
+Two extra concerns over plain API keys:
+
+1. **Refresh.** `AuthResolver.ensureFresh()` is awaited before each session creation in `AgentHost.initialize()` and `reinitializeWithProvider()`. If an OAuth access token is within 5 minutes of expiry, the resolver calls the SDK's `refreshAnthropicToken`, updates in-memory state, and persists via the callback registered through `setPersistOAuth()`. Concurrent refreshes per provider are serialized via a Promise lock.
+2. **401 handling.** Normally `auth` errors trigger immediate failover. For OAuth-tier credentials, `AgentHost` first calls `ensureFresh()` and reinitializes the session before falling over — this catches expiry-related 401s without losing the credential. If refresh itself fails, the credential goes into cooldown via the standard path.
+
 ## Session Persistence
 
 Agent sessions are persisted as JSONL files in `~/.system2/sessions/{role}_{id}/`. The pi-coding-agent SDK manages:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,7 +56,7 @@ After running `system2 login`, restart the daemon to pick up the new credential:
 system2 stop && system2 start
 ```
 
-See [Auth Tiers](../configuration.md#auth-tiers) in the configuration reference for how OAuth credentials interact with API key fallback and refresh behavior.
+See [Auth Tiers](configuration.md#auth-tiers) in the configuration reference for how OAuth credentials interact with API key fallback and refresh behavior.
 
 ### `system2 logout [provider]`
 
@@ -108,7 +108,7 @@ The config utility handles:
 - Validating required fields (at least one LLM provider with keys)
 - Building a `ServerConfig` object for the server
 
-See [Configuration](../configuration.md) for the full config.toml reference.
+See [Configuration](configuration.md) for the full config.toml reference.
 
 ## Utilities
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -127,4 +127,4 @@ On every CLI invocation, checks whether a newer version of `@diegoscarabelli/sys
 ## See Also
 
 - [Server](server.md): the server this CLI manages
-- [Configuration](../configuration.md): config.toml format and defaults
+- [Configuration](configuration.md): config.toml format and defaults

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,6 +14,8 @@ src/
 ├── index.ts               # CLI entry point (Commander setup)
 ├── commands/
 │   ├── onboard.ts         # Interactive setup wizard
+│   ├── login.ts           # OAuth login flow (add or refresh credential)
+│   ├── logout.ts          # OAuth logout (remove credential)
 │   ├── start.ts           # Start server (daemon or foreground)
 │   ├── stop.ts            # Graceful shutdown
 │   └── status.ts          # Server status info
@@ -32,11 +34,43 @@ src/
 
 Interactive setup wizard using [@clack/prompts](https://github.com/bombshell-dev/clack):
 
-1. Select primary LLM provider (Anthropic / Google / OpenAI)
-2. Enter API keys (supports multiple labeled keys per provider)
+1. Optionally configure the OAuth tier (Claude Pro/Max): runs the browser OAuth flow and writes `~/.system2/oauth/anthropic.json`
+2. Select primary LLM provider (Anthropic / Google / OpenAI) and enter API keys (supports multiple labeled keys per provider)
 3. Optionally configure fallback provider
 4. Optionally configure Brave Search API key
 5. Creates `~/.system2/` directory and writes `config.toml` (permissions `0600`)
+
+At least one auth tier (OAuth or API key) must be configured. The OAuth step comes first and is independent: you can configure OAuth only, API keys only, or both.
+
+### `system2 login [provider]`
+
+Runs the OAuth flow for `provider` (default: `anthropic`, the only supported provider in v1), writes the resulting tokens to `~/.system2/oauth/<provider>.json` (mode 0600), and offers to patch `[llm.oauth]` in `config.toml` if the provider is not already there.
+
+Use this command to:
+- Add OAuth credentials after onboarding (if you skipped the OAuth step).
+- Re-authenticate when a refresh token has been invalidated — for example after signing out of Claude.ai, changing your password, revoking the app's grant, or hitting an idle expiry on the refresh token.
+
+After running `system2 login`, restart the daemon to pick up the new credential:
+
+```bash
+system2 stop && system2 start
+```
+
+See [Auth Tiers](../configuration.md#auth-tiers) in the configuration reference for how OAuth credentials interact with API key fallback and refresh behavior.
+
+### `system2 logout [provider]`
+
+Removes the OAuth credential for `provider` (default: `anthropic`). The command:
+1. Asks for confirmation, then deletes `~/.system2/oauth/<provider>.json`.
+2. Offers to remove `provider` from `[llm.oauth]` in `config.toml`.
+
+If `[llm.oauth]` becomes empty (the last provider is removed), the entire section is dropped from `config.toml`, and system2 reverts to API-key-only behavior on next start.
+
+After running `system2 logout`, restart the daemon to apply the change:
+
+```bash
+system2 stop && system2 start
+```
 
 ### `system2 start`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,7 +10,12 @@ All System2 settings live in `~/.system2/config.toml`, created by `system2 onboa
 ## config.toml Reference
 
 ```toml
-# LLM providers and API keys
+# OAuth tier — subscription credentials, tried first
+[llm.oauth]
+primary = "anthropic"
+fallback = []   # only anthropic OAuth supported in v1
+
+# API key tier — billed per token, used after OAuth tier exhausted
 [llm]
 primary = "anthropic"
 fallback = ["google", "openai"]
@@ -125,7 +130,7 @@ budget_chars = 20000  # Max chars per knowledge file; Narrator condenses overrun
 
 | Provider | Models Used |
 |----------|------------|
-| `anthropic` | Claude (Sonnet, Opus, Haiku) |
+| `anthropic` | Claude (Sonnet, Opus, Haiku); also supports OAuth (Claude Pro/Max) |
 | `cerebras` | Fast inference (Llama, Qwen) |
 | `google` | Gemini |
 | `groq` | Fast inference (Llama, DeepSeek, Gemma) |
@@ -160,6 +165,45 @@ When API errors occur, System2 automatically retries and fails over:
 **Cooldown recovery:** Rate limit and transient failures enter a 5-minute cooldown. Keys become available again automatically after cooldown expires. Auth errors (invalid/revoked keys) are permanent until you edit config.toml.
 
 See [Agents](agents.md#authresolver-auth-resolverts) for implementation details.
+
+## Auth Tiers
+
+System2 has two auth tiers:
+
+- **OAuth tier** — subscription credentials (`[llm.oauth]`). Tried first. v1 supports Anthropic Claude Pro/Max OAuth. Pi-ai supports Google Gemini CLI, GitHub Copilot, and OpenAI Codex OAuth as well; those will be added in future iterations.
+- **API key tier** — `[llm].primary` + `fallback`. Same shape as today. Used after the OAuth tier is fully exhausted (every OAuth credential in cooldown).
+
+The OAuth tier is fully exhausted before the system drops into the API key tier — never interleaving. If `[llm.oauth]` is absent, system2 behaves exactly like an API-key-only setup.
+
+### Anthropic OAuth (Claude Pro/Max)
+
+The pi-ai SDK detects OAuth tokens (substring match `sk-ant-oat`) and switches the Anthropic client to Bearer auth + Claude Code identity headers. The agent loop, custom tools, and multi-agent orchestration are unchanged.
+
+**Setup:** During `system2 onboard`, the first step asks whether to configure OAuth. Selecting "yes" + "Anthropic" opens a browser for Claude.ai authentication. The resulting tokens are saved to `~/.system2/oauth/anthropic.json` (mode 0600).
+
+**Refresh:** OAuth access tokens expire roughly hourly. The daemon refreshes them automatically before each agent session creation and on 401 errors. Refreshed tokens are persisted back to `~/.system2/oauth/anthropic.json`.
+
+**Failover:** A 401 on an OAuth credential triggers one refresh-and-retry. If refresh succeeds, the session reinitializes with the new token and the prompt retries. If refresh fails (or any other error), the OAuth credential enters cooldown and the next OAuth fallback is tried; once the OAuth tier is exhausted, the system drops into the API key tier.
+
+**Caveats:**
+- Claude Pro/Max usage limits are sized for one human in Claude Code. A multi-agent system2 workload (Guide + Conductor + Reviewer + Workers + Narrator running concurrently) can hit the 5-hour message cap quickly. Configure the API key tier as fallback for sustained workloads.
+- Programmatic use of Pro/Max credentials outside Claude Code is in a TOS gray area. Use at your own discretion.
+- Prompt caching is disabled on the OAuth path (the SDK strips `cache_control` from system prompts for OAuth tokens). Per-call billing still goes through the subscription.
+
+### Re-authenticating and managing credentials post-onboarding
+
+Use `system2 login <provider>` to add an OAuth credential after onboarding (or to re-authenticate when a refresh token has been invalidated — for example, after signing out of Claude.ai, changing your password, revoking the app's grant, or hitting an idle-expiry on the refresh token). The command runs the OAuth flow, writes `~/.system2/oauth/<provider>.json`, and (if `[llm.oauth]` is missing or doesn't include the provider) offers to patch `config.toml` to enable the OAuth tier. If the daemon is running, restart it to pick up the new credential: `system2 stop && system2 start`.
+
+Use `system2 logout <provider>` to remove an OAuth credential. The command deletes the credentials file and offers to remove the provider from `[llm.oauth]` in `config.toml`.
+
+### Changing primary provider or switching auth method
+
+System2 reads `~/.system2/config.toml` only at startup. To change the primary provider, swap which tier is preferred, add or remove a fallback provider, or edit any other LLM configuration:
+
+1. Edit `~/.system2/config.toml` directly (or use `system2 login` / `system2 logout` for OAuth credential changes).
+2. Restart the daemon: `system2 stop && system2 start`.
+
+You do not need to switch auth methods manually for cost or rate-limit reasons — the two-tier failover handles that automatically. OAuth is tried first; once exhausted, the system drops to the API key tier without any user action. If a transient failure has put a credential into cooldown and you want to force the system to retry it sooner than the cooldown expiry, restart the daemon (which clears in-memory cooldowns).
 
 ## Agent Overrides
 

--- a/docs/superpowers/plans/2026-04-27-claude-pro-max-oauth.md
+++ b/docs/superpowers/plans/2026-04-27-claude-pro-max-oauth.md
@@ -1,0 +1,1772 @@
+# Claude Pro/Max OAuth Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a separate OAuth auth tier to system2, with Claude Pro/Max OAuth as the only v1 OAuth provider. The OAuth tier is fully exhausted (cooldown on every OAuth credential) before falling over to the existing API key tier. If OAuth is not configured, system2 behaves exactly as today.
+
+**Architecture:** Two ordered auth tiers in `AuthResolver`:
+- **OAuth tier** (`[llm.oauth].primary` + `fallback`): subscription credentials, tried first.
+- **API key tier** (`[llm].primary` + `fallback`): billed per-token, used after OAuth tier is exhausted.
+
+Failover walks the OAuth tier first; only when every OAuth credential is in cooldown does it drop into the API key tier — never interleaving. OAuth credentials live in `~/.system2/oauth/<provider>.json` (mode 0600), one file per provider, refreshed automatically before each session creation. The pi-ai SDK already supports Anthropic OAuth (substring match `sk-ant-oat` switches the SDK to Bearer auth + Claude Code identity headers + tool-name remapping), so no SDK fork is needed. The agent loop, custom tools, and multi-agent orchestration all stay intact.
+
+**Tech Stack:** TypeScript, `@mariozechner/pi-ai` (`loginAnthropic`, `refreshAnthropicToken`), `@iarna/toml`, `@clack/prompts`, `vitest`.
+
+---
+
+## File Structure
+
+**Created:**
+- `src/server/agents/oauth-credentials.ts` — load/save `~/.system2/oauth/<provider>.json` (mode 0600). Parameterized by provider for future expansion (pi-ai also supports Google Gemini CLI, GitHub Copilot, OpenAI Codex OAuth).
+- `src/server/agents/oauth-credentials.test.ts`
+- `src/server/agents/oauth.ts` — wraps pi-ai's `loginAnthropic` and `refreshAnthropicToken`. Re-exports `loginAnthropic` for onboarding. Adds `isExpiringSoon()`.
+- `src/server/agents/oauth.test.ts`
+
+**Modified:**
+- `src/shared/types/config.ts` — add `LlmOAuthConfig`; add `oauth?: LlmOAuthConfig` to `LlmConfig`.
+- `src/cli/utils/config.ts` — TOML round-trip for `[llm.oauth]` section.
+- `src/cli/commands/onboard.ts` — two-step onboarding: OAuth tier first (optional), API key tier second (optional). At least one tier required.
+- `src/server/agents/auth-resolver.ts` — two-tier credential model. Cooldown keys become `${tier}:${provider}:${keyIndex}`. New `getActiveCredential()` returns tier-tagged result. Tier cursor advances to keys tier when OAuth tier exhausted.
+- `src/server/agents/auth-resolver.test.ts`
+- `src/server/agents/host.ts` — track `currentTier`; call `ensureFresh()` before session creation; refresh-and-retry once on 401 from OAuth tier credential.
+- `src/server/agents/host.test.ts`
+- `src/server/server.ts` — load OAuth credentials at startup for each provider in `[llm.oauth]`; wire persist callbacks.
+- `docs/configuration.md` — document `[llm.oauth]` section, credentials files, refresh, two-tier failover.
+- `docs/agents.md` — document two-tier AuthResolver.
+
+---
+
+## Task 1: Add `LlmOAuthConfig` type
+
+**Files:**
+- Modify: `src/shared/types/config.ts:32-36`
+
+- [ ] **Step 1: Add the type**
+
+In `src/shared/types/config.ts`, after the existing `LlmConfig` interface, add:
+
+```typescript
+export interface LlmOAuthConfig {
+  primary: LlmProvider;
+  fallback: LlmProvider[];
+}
+```
+
+Then extend `LlmConfig`:
+
+```typescript
+export interface LlmConfig {
+  primary: LlmProvider;
+  fallback: LlmProvider[];
+  providers: Partial<Record<LlmProvider, LlmProviderConfig>>;
+  /** Optional OAuth tier. When present, OAuth credentials are tried before API keys. */
+  oauth?: LlmOAuthConfig;
+}
+```
+
+`LlmKey` and `LlmProviderConfig` are unchanged from today — OAuth credentials live outside `LlmKey`, in their own data structure.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/shared/types/config.ts
+git commit -m "feat(config): add LlmOAuthConfig type for OAuth tier"
+```
+
+---
+
+## Task 2: TOML round-trip for `[llm.oauth]`
+
+**Files:**
+- Modify: `src/cli/utils/config.ts:74-94` (TomlConfig), `:183-248` (`convertTomlLlm`), `:543-599` (`buildConfigToml`)
+- Test: `src/cli/utils/config.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/cli/utils/config.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import TOML from '@iarna/toml';
+import type { LlmConfig } from '../../shared/index.js';
+import { buildConfigToml } from './config.js';
+
+describe('buildConfigToml — [llm.oauth] tier', () => {
+  it('emits oauth section with primary and fallback', () => {
+    const llm: LlmConfig = {
+      primary: 'anthropic',
+      fallback: [],
+      providers: { anthropic: { keys: [] } },
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const toml = buildConfigToml({ llm });
+    expect(toml).toMatch(/\[llm\.oauth\]\s*\nprimary\s*=\s*"anthropic"\s*\nfallback\s*=\s*\[\]/);
+  });
+
+  it('omits oauth section when undefined', () => {
+    const llm: LlmConfig = {
+      primary: 'anthropic',
+      fallback: [],
+      providers: { anthropic: { keys: [{ key: 'k', label: 'l' }] } },
+    };
+    const toml = buildConfigToml({ llm });
+    expect(toml).not.toMatch(/\[llm\.oauth\]/);
+  });
+
+  it('round-trips through TOML.parse', () => {
+    const llm: LlmConfig = {
+      primary: 'openai',
+      fallback: ['google'],
+      providers: {
+        anthropic: { keys: [] },
+        openai: { keys: [{ key: 'oai-1', label: 'main' }] },
+      },
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const toml = buildConfigToml({ llm });
+    const parsed = TOML.parse(toml) as { llm?: { oauth?: { primary?: string; fallback?: string[] } } };
+    expect(parsed.llm?.oauth?.primary).toBe('anthropic');
+    expect(parsed.llm?.oauth?.fallback).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/cli/utils/config.test.ts`
+Expected: FAIL — no oauth section emitted yet.
+
+- [ ] **Step 3: Update `TomlConfig` interface**
+
+In `src/cli/utils/config.ts:74-94`, add to the `llm` block:
+
+```typescript
+    oauth?: {
+      primary?: string;
+      fallback?: string[];
+    };
+```
+
+- [ ] **Step 4: Update `convertTomlLlm` to read oauth**
+
+In `src/cli/utils/config.ts:243-247`, change the return statement:
+
+```typescript
+  const config: LlmConfig = {
+    primary: (toml.primary as LlmProvider) ?? 'anthropic',
+    fallback: (toml.fallback as LlmProvider[]) ?? [],
+    providers,
+  };
+
+  if (toml.oauth?.primary) {
+    config.oauth = {
+      primary: toml.oauth.primary as LlmProvider,
+      fallback: (toml.oauth.fallback as LlmProvider[]) ?? [],
+    };
+  }
+
+  return config;
+```
+
+- [ ] **Step 5: Update `buildConfigToml` to emit oauth**
+
+In `src/cli/utils/config.ts`, after the `[llm]` section header (around line 549, after `lines.push('');`), insert:
+
+```typescript
+    if (options.llm.oauth) {
+      lines.push('[llm.oauth]');
+      lines.push(`primary = "${options.llm.oauth.primary}"`);
+      const fb = options.llm.oauth.fallback.map((f) => `"${f}"`).join(', ');
+      lines.push(`fallback = [${fb}]`);
+      lines.push('');
+    }
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `pnpm test src/cli/utils/config.test.ts`
+Expected: PASS (all 3 tests)
+
+- [ ] **Step 7: Run full check**
+
+Run: `pnpm check && pnpm typecheck`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/cli/utils/config.ts src/cli/utils/config.test.ts
+git commit -m "feat(config): support [llm.oauth] section in TOML round-trip"
+```
+
+---
+
+## Task 3: OAuth credentials file storage (provider-parameterized)
+
+**Files:**
+- Create: `src/server/agents/oauth-credentials.ts`
+- Test: `src/server/agents/oauth-credentials.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/server/agents/oauth-credentials.test.ts`:
+
+```typescript
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadOAuthCredentials, saveOAuthCredentials } from './oauth-credentials.js';
+
+describe('oauth-credentials', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'system2-oauth-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns null when credentials file does not exist', () => {
+    expect(loadOAuthCredentials(dir, 'anthropic')).toBeNull();
+  });
+
+  it('round-trips credentials per provider', () => {
+    const creds = {
+      access: 'sk-ant-oat-abc',
+      refresh: 'rt-xyz',
+      expires: 1714680000000,
+      label: 'claude-pro',
+    };
+    saveOAuthCredentials(dir, 'anthropic', creds);
+    expect(loadOAuthCredentials(dir, 'anthropic')).toEqual(creds);
+    expect(loadOAuthCredentials(dir, 'openai')).toBeNull();
+  });
+
+  it('writes file with mode 0600', () => {
+    saveOAuthCredentials(dir, 'anthropic', { access: 'a', refresh: 'b', expires: 1, label: 'l' });
+    const mode = statSync(join(dir, 'oauth', 'anthropic.json')).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('returns null when file is corrupt JSON', async () => {
+    const { mkdirSync, writeFileSync } = await import('node:fs');
+    mkdirSync(join(dir, 'oauth'), { recursive: true });
+    writeFileSync(join(dir, 'oauth', 'anthropic.json'), '{not json');
+    expect(loadOAuthCredentials(dir, 'anthropic')).toBeNull();
+  });
+
+  it('returns null when file is missing required fields', async () => {
+    const { mkdirSync, writeFileSync } = await import('node:fs');
+    mkdirSync(join(dir, 'oauth'), { recursive: true });
+    writeFileSync(join(dir, 'oauth', 'anthropic.json'), JSON.stringify({ access: 'a' }));
+    expect(loadOAuthCredentials(dir, 'anthropic')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/server/agents/oauth-credentials.test.ts`
+Expected: FAIL — module does not exist
+
+- [ ] **Step 3: Implement the module**
+
+Create `src/server/agents/oauth-credentials.ts`:
+
+```typescript
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { LlmProvider } from '../../shared/index.js';
+import { log } from '../utils/logger.js';
+
+export interface OAuthCredentials {
+  access: string;
+  refresh: string;
+  /** Epoch ms when access token expires (already includes pi-ai's 5 min safety buffer). */
+  expires: number;
+  label: string;
+}
+
+const OAUTH_DIR = 'oauth';
+
+function credentialsPath(system2Dir: string, provider: LlmProvider): string {
+  return join(system2Dir, OAUTH_DIR, `${provider}.json`);
+}
+
+export function loadOAuthCredentials(
+  system2Dir: string,
+  provider: LlmProvider
+): OAuthCredentials | null {
+  const path = credentialsPath(system2Dir, provider);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as OAuthCredentials;
+    if (
+      typeof parsed.access !== 'string' ||
+      typeof parsed.refresh !== 'string' ||
+      typeof parsed.expires !== 'number' ||
+      typeof parsed.label !== 'string'
+    ) {
+      log.warn(`[oauth-credentials] ${provider}.json missing required fields, ignoring`);
+      return null;
+    }
+    return parsed;
+  } catch (err) {
+    log.warn(`[oauth-credentials] Failed to parse ${provider}.json:`, err);
+    return null;
+  }
+}
+
+export function saveOAuthCredentials(
+  system2Dir: string,
+  provider: LlmProvider,
+  credentials: OAuthCredentials
+): void {
+  const dir = join(system2Dir, OAUTH_DIR);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+  writeFileSync(credentialsPath(system2Dir, provider), JSON.stringify(credentials, null, 2), {
+    mode: 0o600,
+  });
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm test src/server/agents/oauth-credentials.test.ts`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/agents/oauth-credentials.ts src/server/agents/oauth-credentials.test.ts
+git commit -m "feat(oauth): add per-provider OAuth credentials file storage"
+```
+
+---
+
+## Task 4: OAuth refresh helper
+
+**Files:**
+- Create: `src/server/agents/oauth.ts`
+- Test: `src/server/agents/oauth.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/server/agents/oauth.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import { isExpiringSoon } from './oauth.js';
+
+describe('isExpiringSoon', () => {
+  it('returns true when expires is within buffer', () => {
+    expect(isExpiringSoon(Date.now() + 60_000, 5 * 60_000)).toBe(true);
+  });
+
+  it('returns false when expires is well in the future', () => {
+    expect(isExpiringSoon(Date.now() + 60 * 60_000, 5 * 60_000)).toBe(false);
+  });
+
+  it('returns true when already expired', () => {
+    expect(isExpiringSoon(Date.now() - 1000, 5 * 60_000)).toBe(true);
+  });
+
+  it('uses default buffer when not provided', () => {
+    expect(isExpiringSoon(Date.now() + 60_000)).toBe(true);
+    expect(isExpiringSoon(Date.now() + 60 * 60_000)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test src/server/agents/oauth.test.ts`
+Expected: FAIL — module does not exist
+
+- [ ] **Step 3: Implement the module**
+
+Create `src/server/agents/oauth.ts`:
+
+```typescript
+import { loginAnthropic, refreshAnthropicToken } from '@mariozechner/pi-ai';
+
+/** How close to expiry we trigger a refresh. pi-ai's expires already includes a 5min buffer; we add another 5. */
+export const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+export interface RefreshedTokens {
+  access: string;
+  refresh: string;
+  expires: number;
+}
+
+export function isExpiringSoon(expires: number, bufferMs: number = REFRESH_BUFFER_MS): boolean {
+  return Date.now() + bufferMs >= expires;
+}
+
+/**
+ * Refresh the Anthropic OAuth access token via the SDK.
+ * Throws on network/auth failure.
+ */
+export async function refreshAnthropic(refreshToken: string): Promise<RefreshedTokens> {
+  const updated = await refreshAnthropicToken(refreshToken);
+  return {
+    access: updated.access,
+    refresh: updated.refresh,
+    expires: updated.expires,
+  };
+}
+
+export { loginAnthropic };
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm test src/server/agents/oauth.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/agents/oauth.ts src/server/agents/oauth.test.ts
+git commit -m "feat(oauth): add refresh helper wrapping pi-ai SDK"
+```
+
+---
+
+## Task 5: AuthResolver — two-tier credential model
+
+**Files:**
+- Modify: `src/server/agents/auth-resolver.ts` (substantial refactor)
+- Test: `src/server/agents/auth-resolver.test.ts`
+
+This task introduces tier-aware cooldowns and a new `getActiveCredential()` method. Existing callers (`host.ts`) keep using `getActiveKey(provider)`, `markKeyFailed`, `getNextProvider`, but those methods now respect the global tier cursor.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/server/agents/auth-resolver.test.ts`:
+
+```typescript
+import { loadOAuthCredentials, saveOAuthCredentials, type OAuthCredentials } from './oauth-credentials.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+function makeTwoTierConfig(): LlmConfig {
+  return {
+    primary: 'anthropic',
+    fallback: ['openai'],
+    providers: {
+      anthropic: {
+        keys: [
+          { key: 'ant-key-1', label: 'main' },
+          { key: 'ant-key-2', label: 'backup' },
+        ],
+      },
+      openai: { keys: [{ key: 'oai-key-1', label: 'main' }] },
+    },
+    oauth: { primary: 'anthropic', fallback: [] },
+  };
+}
+
+function makeOAuthCreds(expiresInMs: number = 60 * 60_000): OAuthCredentials {
+  return {
+    access: 'sk-ant-oat-abc',
+    refresh: 'rt-xyz',
+    expires: Date.now() + expiresInMs,
+    label: 'claude-pro',
+  };
+}
+
+describe('AuthResolver — two-tier model', () => {
+  it('returns OAuth credential as active when oauth tier configured', () => {
+    const resolver = new AuthResolver(makeTwoTierConfig(), undefined, {
+      anthropic: makeOAuthCreds(),
+    });
+    const active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('oauth');
+    expect(active?.provider).toBe('anthropic');
+    expect(active?.label).toBe('claude-pro');
+  });
+
+  it('falls back to keys tier when oauth tier is omitted', () => {
+    const cfg = makeTwoTierConfig();
+    delete cfg.oauth;
+    const resolver = new AuthResolver(cfg);
+    const active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('keys');
+    expect(active?.provider).toBe('anthropic');
+    expect(active?.label).toBe('main');
+  });
+
+  it('falls back to keys tier when oauth credentials are missing', () => {
+    const resolver = new AuthResolver(makeTwoTierConfig());
+    const active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('keys');
+  });
+
+  it('exhausts oauth tier before dropping to keys tier', () => {
+    const resolver = new AuthResolver(makeTwoTierConfig(), undefined, {
+      anthropic: makeOAuthCreds(),
+    });
+    resolver.markKeyFailed('anthropic', 'auth', 'invalid_grant', 0, 'oauth');
+    const active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('keys');
+    expect(active?.provider).toBe('anthropic');
+    expect(active?.label).toBe('main');
+  });
+
+  it('cooldown keys for same provider in different tiers do not collide', () => {
+    const resolver = new AuthResolver(makeTwoTierConfig(), undefined, {
+      anthropic: makeOAuthCreds(),
+    });
+    resolver.markKeyFailed('anthropic', 'auth', 'oauth fail', 0, 'oauth');
+    expect(resolver.isKeyInCooldown('anthropic', 0, 'oauth')).toBe(true);
+    expect(resolver.isKeyInCooldown('anthropic', 0, 'keys')).toBe(false);
+  });
+
+  it('walks oauth fallback before dropping to keys tier', () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: ['openai'] },
+    };
+    const resolver = new AuthResolver(cfg, undefined, {
+      anthropic: makeOAuthCreds(),
+      openai: { ...makeOAuthCreds(), label: 'codex' },
+    });
+    resolver.markKeyFailed('anthropic', 'auth', 'fail', 0, 'oauth');
+    const active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('oauth');
+    expect(active?.provider).toBe('openai');
+  });
+
+  it('providerOrder includes both tiers, deduplicated', () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const resolver = new AuthResolver(cfg, undefined, { anthropic: makeOAuthCreds() });
+    expect(resolver.providerOrder).toEqual(['anthropic', 'openai']);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test src/server/agents/auth-resolver.test.ts -t "two-tier"`
+Expected: FAIL
+
+- [ ] **Step 3: Refactor AuthResolver**
+
+In `src/server/agents/auth-resolver.ts`, add the following imports:
+
+```typescript
+import type { OAuthCredentials } from './oauth-credentials.js';
+```
+
+Add new types near the top of the file:
+
+```typescript
+export type AuthTier = 'oauth' | 'keys';
+
+export interface ActiveCredential {
+  tier: AuthTier;
+  provider: LlmProvider;
+  keyIndex: number;
+  label: string;
+}
+
+export type OAuthCredentialsMap = Partial<Record<LlmProvider, OAuthCredentials>>;
+```
+
+Replace the existing `ActiveKey` interface with the new tier-aware one (`ActiveCredential` above) for clarity in callers.
+
+Update the constructor:
+
+```typescript
+  private oauthCredentials: OAuthCredentialsMap;
+  private oauthOrder: LlmProvider[];
+  private keysOrder: LlmProvider[];
+
+  constructor(
+    llmConfig: LlmConfig,
+    cooldownConfig?: Partial<CooldownConfig>,
+    oauthCredentials?: OAuthCredentialsMap
+  ) {
+    this.config = this.validateConfig(llmConfig);
+    this.cooldownConfig = {
+      rateLimitMs: cooldownConfig?.rateLimitMs ?? DEFAULT_RATE_LIMIT_COOLDOWN_MS,
+      defaultMs: cooldownConfig?.defaultMs ?? DEFAULT_COOLDOWN_MS,
+    };
+    this.oauthCredentials = oauthCredentials ?? {};
+
+    this.oauthOrder = this.config.oauth
+      ? [this.config.oauth.primary, ...this.config.oauth.fallback].filter(
+          (p) => this.oauthCredentials[p] !== undefined
+        )
+      : [];
+    this.keysOrder = [this.config.primary, ...this.config.fallback];
+
+    for (const provider of Object.keys(this.config.providers) as LlmProvider[]) {
+      if (this.config.providers[provider]) {
+        this.activeKeys.set(provider, 0);
+      }
+    }
+  }
+```
+
+Update `providerOrder` getter:
+
+```typescript
+  get providerOrder(): LlmProvider[] {
+    const seen = new Set<LlmProvider>();
+    const out: LlmProvider[] = [];
+    for (const p of [...this.oauthOrder, ...this.keysOrder]) {
+      if (!seen.has(p)) {
+        seen.add(p);
+        out.push(p);
+      }
+    }
+    return out;
+  }
+```
+
+Update `primaryProvider` to be the active tier's primary:
+
+```typescript
+  get primaryProvider(): LlmProvider {
+    return this.oauthOrder[0] ?? this.config.primary;
+  }
+```
+
+Replace cooldown-key construction throughout to use tier:
+
+```typescript
+  private cooldownKey(tier: AuthTier, provider: LlmProvider, keyIndex: number): string {
+    return `${tier}:${provider}:${keyIndex}`;
+  }
+```
+
+Replace every `${provider}:${i}` construction in this file with `this.cooldownKey(tier, provider, i)`.
+
+Add the new `getActiveCredential()`:
+
+```typescript
+  /**
+   * Walk OAuth tier first, then keys tier, returning the first credential not in cooldown.
+   */
+  getActiveCredential(): ActiveCredential | undefined {
+    // OAuth tier
+    for (const provider of this.oauthOrder) {
+      const cred = this.oauthCredentials[provider];
+      if (!cred) continue;
+      if (this.isKeyUnavailable(this.cooldownKey('oauth', provider, 0))) continue;
+      return { tier: 'oauth', provider, keyIndex: 0, label: cred.label };
+    }
+    // Keys tier
+    for (const provider of this.keysOrder) {
+      const providerConfig = this.config.providers[provider];
+      if (!providerConfig) continue;
+      for (let i = 0; i < providerConfig.keys.length; i++) {
+        const key = providerConfig.keys[i];
+        if (key.key && !this.isKeyUnavailable(this.cooldownKey('keys', provider, i))) {
+          this.activeKeys.set(provider, i);
+          return { tier: 'keys', provider, keyIndex: i, label: key.label };
+        }
+      }
+    }
+    return undefined;
+  }
+```
+
+Update `getActiveKey(provider: LlmProvider)` to be tier-aware: it returns the active credential for the given provider in the *current* tier (OAuth if available, else keys). Add an optional `tier` parameter for callers that need to pin to one tier:
+
+```typescript
+  getActiveKey(provider: LlmProvider, tier?: AuthTier): ActiveCredential | undefined {
+    const tryOAuth = () => {
+      if (!this.oauthOrder.includes(provider)) return undefined;
+      const cred = this.oauthCredentials[provider];
+      if (!cred) return undefined;
+      if (this.isKeyUnavailable(this.cooldownKey('oauth', provider, 0))) return undefined;
+      return { tier: 'oauth' as const, provider, keyIndex: 0, label: cred.label };
+    };
+    const tryKeys = () => {
+      const providerConfig = this.config.providers[provider];
+      if (!providerConfig) return undefined;
+      for (let i = 0; i < providerConfig.keys.length; i++) {
+        const key = providerConfig.keys[i];
+        if (key.key && !this.isKeyUnavailable(this.cooldownKey('keys', provider, i))) {
+          this.activeKeys.set(provider, i);
+          return { tier: 'keys' as const, provider, keyIndex: i, label: key.label };
+        }
+      }
+      return undefined;
+    };
+
+    if (tier === 'oauth') return tryOAuth();
+    if (tier === 'keys') return tryKeys();
+    return tryOAuth() ?? tryKeys();
+  }
+```
+
+Update `isKeyInCooldown` to accept a tier:
+
+```typescript
+  isKeyInCooldown(provider: LlmProvider, keyIndex: number, tier: AuthTier = 'keys'): boolean {
+    return this.isKeyUnavailable(this.cooldownKey(tier, provider, keyIndex));
+  }
+```
+
+Update `markKeyFailed` to accept a tier:
+
+```typescript
+  markKeyFailed(
+    provider: LlmProvider,
+    reason: 'auth' | 'rate_limit' | 'transient' = 'transient',
+    errorMessage?: string,
+    keyIndex?: number,
+    tier: AuthTier = 'keys'
+  ): boolean {
+    const currentIndex = keyIndex ?? this.activeKeys.get(provider) ?? 0;
+    const keyId = this.cooldownKey(tier, provider, currentIndex);
+
+    if (!this.cooldowns.has(keyId)) {
+      const now = Date.now();
+      const duration =
+        reason === 'rate_limit' ? this.cooldownConfig.rateLimitMs : this.cooldownConfig.defaultMs;
+      this.cooldowns.set(keyId, { startTime: now, expiresAt: now + duration, reason });
+      const detail = errorMessage ? `: ${errorMessage}` : '';
+      log.info(`[AuthResolver] Key in cooldown: ${keyId}, expires in ${duration / 1000}s${detail}`);
+    } else {
+      log.info(`[AuthResolver] Key ${keyId} already in cooldown, skipping`);
+    }
+
+    // Walk forward through tiers/providers/keys to confirm something is still available
+    return this.getActiveCredential() !== undefined;
+  }
+```
+
+Update `getNextProvider`:
+
+```typescript
+  getNextProvider(): LlmProvider | undefined {
+    return this.getActiveCredential()?.provider;
+  }
+```
+
+Update `createAuthStorage()` to use the OAuth credential's access token when in OAuth tier for that provider:
+
+```typescript
+  createAuthStorage(): AuthStorage {
+    const data: Record<string, { type: 'api_key'; key: string }> = {};
+
+    // For each provider in either tier, choose the currently active credential.
+    const providersInScope = new Set<LlmProvider>([...this.oauthOrder, ...this.keysOrder]);
+    for (const provider of providersInScope) {
+      const active = this.getActiveKey(provider);
+      if (!active) continue;
+      let keyValue: string | undefined;
+      if (active.tier === 'oauth') {
+        keyValue = this.oauthCredentials[provider]?.access;
+      } else {
+        keyValue = this.config.providers[provider]?.keys[active.keyIndex]?.key;
+      }
+      if (keyValue) {
+        data[provider] = { type: 'api_key', key: keyValue };
+      }
+    }
+
+    return AuthStorage.inMemory(data);
+  }
+```
+
+Update `getStatus()` cooldown reporting to keep the new key format (no logical change beyond the key string being `tier:provider:idx`).
+
+- [ ] **Step 4: Update existing tests for the new cooldown key format**
+
+Existing tests in `auth-resolver.test.ts` that don't pass a tier default to `'keys'`. The cooldown key string changes from `anthropic:0` to `keys:anthropic:0`, but tests don't inspect the key string directly — they observe behavior via `getActiveKey`, `getNextProvider`, etc., which remain compatible. Run tests to confirm.
+
+Run: `pnpm test src/server/agents/auth-resolver.test.ts`
+Expected: PASS (existing tests + new two-tier tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/agents/auth-resolver.ts src/server/agents/auth-resolver.test.ts
+git commit -m "feat(auth): two-tier credential model with OAuth-first failover"
+```
+
+---
+
+## Task 6: AuthResolver `ensureFresh()` walks the OAuth tier
+
+**Files:**
+- Modify: `src/server/agents/auth-resolver.ts`
+- Test: `src/server/agents/auth-resolver.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/server/agents/auth-resolver.test.ts`:
+
+```typescript
+import type { RefreshedTokens } from './oauth.js';
+
+describe('AuthResolver.ensureFresh', () => {
+  it('refreshes OAuth credential within expiry buffer and persists', async () => {
+    const persisted: OAuthCredentials[] = [];
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const resolver = new AuthResolver(cfg, undefined, {
+      anthropic: makeOAuthCreds(60_000), // 1 min — within buffer
+    });
+    resolver.setPersistOAuth('anthropic', async (creds) => {
+      persisted.push(creds);
+    });
+    const refreshed = await resolver.ensureFresh({
+      refresh: async (): Promise<RefreshedTokens> => ({
+        access: 'new-access',
+        refresh: 'rt-2',
+        expires: Date.now() + 60 * 60_000,
+      }),
+    });
+    expect(refreshed.has('anthropic')).toBe(true);
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].refresh).toBe('rt-2');
+  });
+
+  it('does nothing when OAuth tier is empty', async () => {
+    const cfg = makeTwoTierConfig();
+    delete cfg.oauth;
+    const resolver = new AuthResolver(cfg);
+    const refreshed = await resolver.ensureFresh({
+      refresh: async () => {
+        throw new Error('should not be called');
+      },
+    });
+    expect(refreshed.size).toBe(0);
+  });
+
+  it('does nothing when OAuth tokens are fresh', async () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    let calls = 0;
+    const resolver = new AuthResolver(cfg, undefined, {
+      anthropic: makeOAuthCreds(60 * 60_000), // 1 hour — fresh
+    });
+    await resolver.ensureFresh({
+      refresh: async () => {
+        calls++;
+        return { access: 'x', refresh: 'y', expires: 1 };
+      },
+    });
+    expect(calls).toBe(0);
+  });
+
+  it('serializes concurrent ensureFresh calls per provider', async () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const resolver = new AuthResolver(cfg, undefined, { anthropic: makeOAuthCreds(1000) });
+    let count = 0;
+    const slow = async (): Promise<RefreshedTokens> => {
+      count++;
+      await new Promise((r) => setTimeout(r, 20));
+      return { access: 'new', refresh: 'rt-2', expires: Date.now() + 60 * 60_000 };
+    };
+    await Promise.all([
+      resolver.ensureFresh({ refresh: slow }),
+      resolver.ensureFresh({ refresh: slow }),
+      resolver.ensureFresh({ refresh: slow }),
+    ]);
+    expect(count).toBe(1);
+  });
+
+  it('throws when refresh fails', async () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const resolver = new AuthResolver(cfg, undefined, { anthropic: makeOAuthCreds(1000) });
+    await expect(
+      resolver.ensureFresh({
+        refresh: async () => {
+          throw new Error('network down');
+        },
+      })
+    ).rejects.toThrow('network down');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test src/server/agents/auth-resolver.test.ts -t "ensureFresh"`
+Expected: FAIL
+
+- [ ] **Step 3: Implement `ensureFresh` and `setPersistOAuth`**
+
+In `src/server/agents/auth-resolver.ts`, add the import:
+
+```typescript
+import { isExpiringSoon, type RefreshedTokens } from './oauth.js';
+```
+
+Add fields to the class:
+
+```typescript
+  private persistCallbacks: Partial<Record<LlmProvider, (creds: OAuthCredentials) => Promise<void>>> = {};
+  private refreshLocks: Map<LlmProvider, Promise<void>> = new Map();
+```
+
+Add methods:
+
+```typescript
+  setPersistOAuth(
+    provider: LlmProvider,
+    callback: (creds: OAuthCredentials) => Promise<void>
+  ): void {
+    this.persistCallbacks[provider] = callback;
+  }
+
+  /**
+   * Refresh any OAuth credential whose access token is within the expiry buffer.
+   * Returns the set of providers whose credentials were refreshed; callers should
+   * reinitialize SDK sessions for those providers (existing sessions hold a snapshot
+   * of the old access token).
+   * Concurrent callers are serialized per provider so refresh runs once.
+   */
+  async ensureFresh(deps: {
+    refresh: (refreshToken: string) => Promise<RefreshedTokens>;
+  }): Promise<Set<LlmProvider>> {
+    const refreshed = new Set<LlmProvider>();
+    for (const provider of this.oauthOrder) {
+      const cred = this.oauthCredentials[provider];
+      if (!cred || !isExpiringSoon(cred.expires)) continue;
+
+      const existing = this.refreshLocks.get(provider);
+      if (existing) {
+        await existing;
+        const after = this.oauthCredentials[provider];
+        if (after && !isExpiringSoon(after.expires)) {
+          refreshed.add(provider);
+          continue;
+        }
+      }
+
+      const lock = this.doRefresh(provider, cred, deps.refresh).then(() => {
+        this.refreshLocks.delete(provider);
+      });
+      this.refreshLocks.set(provider, lock);
+      await lock;
+      refreshed.add(provider);
+    }
+    return refreshed;
+  }
+
+  private async doRefresh(
+    provider: LlmProvider,
+    cred: OAuthCredentials,
+    refresh: (refreshToken: string) => Promise<RefreshedTokens>
+  ): Promise<void> {
+    const tokens = await refresh(cred.refresh);
+    const updated: OAuthCredentials = {
+      access: tokens.access,
+      refresh: tokens.refresh,
+      expires: tokens.expires,
+      label: cred.label,
+    };
+    this.oauthCredentials[provider] = updated;
+    log.info(`[AuthResolver] OAuth token refreshed for ${provider}:${cred.label}`);
+
+    const persist = this.persistCallbacks[provider];
+    if (persist) {
+      try {
+        await persist(updated);
+      } catch (err) {
+        log.warn(`[AuthResolver] Failed to persist refreshed OAuth for ${provider}:`, err);
+      }
+    }
+  }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm test src/server/agents/auth-resolver.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/agents/auth-resolver.ts src/server/agents/auth-resolver.test.ts
+git commit -m "feat(auth): ensureFresh() refreshes OAuth tier credentials with per-provider lock"
+```
+
+---
+
+## Task 7: Wire OAuth loading into server startup
+
+**Files:**
+- Modify: `src/server/server.ts` (the file that constructs the shared AuthResolver)
+
+- [ ] **Step 1: Locate AuthResolver construction**
+
+Run: `grep -rn "new AuthResolver" src/server --include="*.ts" | grep -v test`
+Note the file and line number.
+
+- [ ] **Step 2: Add OAuth loading at startup**
+
+In that file, near the top:
+
+```typescript
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import {
+  loadOAuthCredentials,
+  saveOAuthCredentials,
+  type OAuthCredentials,
+} from './agents/oauth-credentials.js';
+import type { OAuthCredentialsMap } from './agents/auth-resolver.js';
+import type { LlmProvider } from '../shared/index.js';
+
+const SYSTEM2_DIR = join(homedir(), '.system2');
+```
+
+Replace the `new AuthResolver(config.llm)` call (skipping the existing null-check pattern, whatever it is) with:
+
+```typescript
+  const oauthCredentials: OAuthCredentialsMap = {};
+  if (config.llm?.oauth) {
+    const oauthProviders: LlmProvider[] = [
+      config.llm.oauth.primary,
+      ...config.llm.oauth.fallback,
+    ];
+    for (const provider of oauthProviders) {
+      const creds = loadOAuthCredentials(SYSTEM2_DIR, provider);
+      if (creds) {
+        oauthCredentials[provider] = creds;
+      } else {
+        log.warn(
+          `[server] [llm.oauth] declares ${provider} but ~/.system2/oauth/${provider}.json is missing — skipping`
+        );
+      }
+    }
+  }
+
+  const authResolver = new AuthResolver(config.llm!, undefined, oauthCredentials);
+
+  for (const provider of Object.keys(oauthCredentials) as LlmProvider[]) {
+    authResolver.setPersistOAuth(provider, async (creds: OAuthCredentials) => {
+      saveOAuthCredentials(SYSTEM2_DIR, provider, creds);
+    });
+  }
+```
+
+- [ ] **Step 3: Run typecheck and tests**
+
+Run: `pnpm typecheck && pnpm test`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server/server.ts
+git commit -m "feat(server): load OAuth credentials at startup and wire persist callbacks"
+```
+
+---
+
+## Task 8: AgentHost tracks tier and refreshes before session creation
+
+**Files:**
+- Modify: `src/server/agents/host.ts` (`initialize()` ~line 232; `reinitializeWithProvider()` ~line 844)
+- Test: `src/server/agents/host.test.ts`
+
+- [ ] **Step 1: Add `currentTier` field and call `ensureFresh`**
+
+In `src/server/agents/host.ts`, add the import:
+
+```typescript
+import { refreshAnthropic } from './oauth.js';
+import type { AuthTier } from './auth-resolver.js';
+```
+
+Add a field to the class:
+
+```typescript
+  private currentTier: AuthTier = 'keys';
+```
+
+In the constructor, set initial tier from active credential:
+
+```typescript
+    const activeCred = this.authResolver.getActiveCredential();
+    this.currentProvider = activeCred?.provider ?? this.authResolver.primaryProvider;
+    this.currentKeyIndex = activeCred?.keyIndex ?? 0;
+    this.currentTier = activeCred?.tier ?? 'keys';
+```
+
+(replacing the existing `this.currentProvider = this.authResolver.primaryProvider;` line and the `currentKeyIndex` line on 223-224.)
+
+In `initialize()`, just before `createAuthStorage()` (around line 472), insert:
+
+```typescript
+    // Refresh near-expiry OAuth tokens before snapshotting auth state into the SDK.
+    try {
+      await this.authResolver.ensureFresh({ refresh: refreshAnthropic });
+    } catch (err) {
+      log.warn('[AgentHost] OAuth refresh failed during initialize:', err);
+      // Fall through with possibly-stale token; SDK will return 401 → handlePotentialError refreshes again.
+    }
+    // Re-read active credential in case ensureFresh changed which credential is active
+    const cred = this.authResolver.getActiveCredential();
+    if (cred) {
+      this.currentTier = cred.tier;
+      // currentProvider was already resolved above; only update tier and keyIndex
+      this.currentKeyIndex = cred.keyIndex;
+    }
+```
+
+In `reinitializeWithProvider()` (around line 844), insert the same `ensureFresh` block before line 883:
+
+```typescript
+    try {
+      await this.authResolver.ensureFresh({ refresh: refreshAnthropic });
+    } catch (err) {
+      log.warn('[AgentHost] OAuth refresh failed during reinitialize:', err);
+    }
+```
+
+After the line `this.currentKeyIndex = this.authResolver.getActiveKey(provider)?.keyIndex ?? 0;` (around line 874), add:
+
+```typescript
+    this.currentTier = this.authResolver.getActiveKey(provider)?.tier ?? 'keys';
+```
+
+- [ ] **Step 2: Update cooldown check to pass tier**
+
+Around line 602 in `handlePotentialError()`:
+
+```typescript
+    if (this.authResolver.isKeyInCooldown(this.currentProvider, this.currentKeyIndex, this.currentTier)) {
+```
+
+Around line 710:
+
+```typescript
+      const hasMore = this.authResolver.markKeyFailed(
+        this.currentProvider,
+        category,
+        errorMessage,
+        this.currentKeyIndex,
+        this.currentTier
+      );
+```
+
+- [ ] **Step 3: Add a smoke test**
+
+Append to `src/server/agents/host.test.ts` a minimal regression test confirming `currentTier` reflects the active credential. Use the existing test fixtures for AgentHost; if no harness exists, fall back to a simpler test that constructs an AuthResolver with OAuth credentials and asserts `host.currentTier === 'oauth'` after `initialize()`.
+
+(Since `currentTier` is private, expose a `getCurrentTier()` test helper or — preferred — assert the behavior via cooldown key inspection: after a simulated auth failure, `getStatus()` reports `oauth:anthropic:0` in cooldowns iff the host was on the OAuth tier.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm test`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/server/agents/host.ts src/server/agents/host.test.ts
+git commit -m "feat(host): track auth tier and refresh OAuth before session creation"
+```
+
+---
+
+## Task 9: AgentHost refresh-and-retry on 401 from OAuth tier
+
+**Files:**
+- Modify: `src/server/agents/host.ts` (`handlePotentialError()` around line 558)
+- Test: `src/server/agents/host.test.ts`
+
+- [ ] **Step 1: Add the refresh-and-retry branch**
+
+In `handlePotentialError()`, after `category` is computed (line 580) and *before* the cooldown check on line 602, insert:
+
+```typescript
+    // OAuth refresh-and-retry: 401 from an OAuth-tier credential should refresh once
+    // before failing over. Refresh updates in-memory tokens; reinitialize the session
+    // so the SDK picks up the new access token.
+    if (category === 'auth' && this.currentTier === 'oauth' && !this.oauthRefreshAttempted) {
+      this.oauthRefreshAttempted = true;
+      try {
+        await this.authResolver.ensureFresh({ refresh: refreshAnthropic });
+        log.info('[AgentHost] OAuth token refreshed after 401, retrying via reinitialize');
+        await this.reinitializeWithProvider(
+          this.currentProvider,
+          promptToRetry,
+          deliveriesToRetry,
+          'OAuth token refreshed',
+          `401 on ${this.currentProvider} OAuth credential, refreshed and retrying`
+        );
+        return;
+      } catch (refreshErr) {
+        log.warn('[AgentHost] OAuth refresh failed after 401, falling over:', refreshErr);
+        // Fall through to standard auth-failure handling below
+      }
+    }
+```
+
+Add the field at the top of the class:
+
+```typescript
+  private oauthRefreshAttempted = false;
+```
+
+Reset it on successful turn — in `handleSessionEvent()`'s `agent_end` branch, inside the existing `if (!this.lastTurnErrored) { ... }` block:
+
+```typescript
+        this.oauthRefreshAttempted = false;
+```
+
+- [ ] **Step 2: Add tests**
+
+Append to `src/server/agents/host.test.ts`. Use a stubbed AuthResolver that exposes a controllable `ensureFresh` and a mock session that emits a `message_end` with `stopReason: 'error'` and a 401-shaped errorMessage. Two cases:
+1. `ensureFresh` succeeds → `reinitializeWithProvider` is called, `markKeyFailed` is **not** called.
+2. `ensureFresh` throws → falls through to standard failover (`markKeyFailed` is called).
+
+(If the existing host.test.ts harness already covers the `handlePotentialError` path, mirror that style; otherwise a small targeted unit test exercising `handlePotentialError` directly is acceptable.)
+
+- [ ] **Step 3: Run tests**
+
+Run: `pnpm test src/server/agents/host.test.ts`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server/agents/host.ts src/server/agents/host.test.ts
+git commit -m "feat(host): refresh OAuth and retry once on 401 before failover"
+```
+
+---
+
+## Task 10: Onboarding — two-step flow
+
+**Files:**
+- Modify: `src/cli/commands/onboard.ts`
+
+- [ ] **Step 1: Add imports**
+
+At the top of `src/cli/commands/onboard.ts`:
+
+```typescript
+import { mkdir as mkdirAsync } from 'node:fs/promises';
+import { loginAnthropic } from '../../server/agents/oauth.js';
+import { saveOAuthCredentials } from '../../server/agents/oauth-credentials.js';
+```
+
+- [ ] **Step 2: Define OAuth provider catalog**
+
+Add near the top, alongside `PROVIDERS`:
+
+```typescript
+const OAUTH_PROVIDERS: { value: LlmProvider; label: string; hint: string }[] = [
+  {
+    value: 'anthropic',
+    label: 'Anthropic (Claude Pro/Max)',
+    hint: 'Uses your Claude.ai subscription. No API key needed.',
+  },
+];
+```
+
+(Future: add Google Gemini CLI, GitHub Copilot, OpenAI Codex.)
+
+- [ ] **Step 3: Implement OAuth login helper**
+
+```typescript
+async function runOAuthLogin(provider: LlmProvider): Promise<{ label: string } | null> {
+  if (provider !== 'anthropic') {
+    p.log.error(`OAuth login for ${provider} is not implemented yet`);
+    return null;
+  }
+
+  const label = (await p.text({
+    message: 'Label for this OAuth credential:',
+    placeholder: 'claude-pro',
+    defaultValue: 'claude-pro',
+  })) as string;
+
+  if (p.isCancel(label)) {
+    p.cancel('Onboarding cancelled');
+    process.exit(0);
+  }
+
+  if (!existsSync(SYSTEM2_DIR)) {
+    await mkdirAsync(SYSTEM2_DIR, { recursive: true });
+  }
+
+  const s = p.spinner();
+  s.start('Waiting for browser authentication...');
+  try {
+    const creds = await loginAnthropic({
+      onAuth: ({ url }) => {
+        s.message(`Open this URL to authenticate:\n${url}`);
+      },
+      onPrompt: async ({ message, placeholder }) => {
+        s.stop('Browser callback timed out');
+        const value = (await p.text({ message, placeholder })) as string;
+        if (p.isCancel(value)) {
+          p.cancel('Onboarding cancelled');
+          process.exit(0);
+        }
+        s.start('Exchanging code...');
+        return value;
+      },
+      onProgress: (m) => s.message(m),
+    });
+    saveOAuthCredentials(SYSTEM2_DIR, provider, {
+      access: creds.access,
+      refresh: creds.refresh,
+      expires: creds.expires,
+      label: label || 'claude-pro',
+    });
+    s.stop('✓ OAuth login successful');
+    return { label: label || 'claude-pro' };
+  } catch (err) {
+    s.stop('✗ OAuth login failed');
+    p.log.error(err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Implement OAuth tier collection**
+
+```typescript
+async function collectOAuthTier(): Promise<LlmOAuthConfig | null> {
+  const wantsOAuth = await p.confirm({
+    message: 'Configure OAuth providers? (recommended if you have a Claude Pro/Max subscription)',
+    initialValue: true,
+  });
+  if (p.isCancel(wantsOAuth)) {
+    p.cancel('Onboarding cancelled');
+    process.exit(0);
+  }
+  if (!wantsOAuth) return null;
+
+  const primary = (await p.select({
+    message: 'Select your primary OAuth provider:',
+    options: OAUTH_PROVIDERS,
+  })) as LlmProvider;
+  if (p.isCancel(primary)) {
+    p.cancel('Onboarding cancelled');
+    process.exit(0);
+  }
+
+  const result = await runOAuthLogin(primary);
+  if (!result) {
+    const retry = await p.confirm({
+      message: 'OAuth login failed. Skip OAuth tier and continue with API keys only?',
+      initialValue: true,
+    });
+    if (p.isCancel(retry) || !retry) {
+      p.cancel('Onboarding cancelled');
+      process.exit(0);
+    }
+    return null;
+  }
+
+  const fallback: LlmProvider[] = [];
+  let availableOAuth = OAUTH_PROVIDERS.filter((o) => o.value !== primary);
+  while (availableOAuth.length > 0) {
+    const addMore = await p.confirm({
+      message: 'Add another OAuth provider as fallback?',
+      initialValue: false,
+    });
+    if (p.isCancel(addMore)) {
+      p.cancel('Onboarding cancelled');
+      process.exit(0);
+    }
+    if (!addMore) break;
+
+    const next = (await p.select({
+      message: 'Select fallback OAuth provider:',
+      options: availableOAuth,
+    })) as LlmProvider;
+    if (p.isCancel(next)) {
+      p.cancel('Onboarding cancelled');
+      process.exit(0);
+    }
+    const r = await runOAuthLogin(next);
+    if (r) {
+      fallback.push(next);
+    }
+    availableOAuth = availableOAuth.filter((o) => o.value !== next);
+  }
+
+  return { primary, fallback };
+}
+```
+
+Add the import at the top:
+
+```typescript
+import type { LlmOAuthConfig } from '../../shared/index.js';
+```
+
+- [ ] **Step 5: Wrap API-key tier collection so it can be skipped**
+
+Refactor the existing API-key collection (the chunk currently between the intro and the LlmConfig assembly, roughly lines 252-345) into a helper:
+
+```typescript
+async function collectApiKeyTier(): Promise<{
+  llm: { primary: LlmProvider; fallback: LlmProvider[]; providers: Partial<Record<LlmProvider, LlmProviderConfig>> } | null;
+  services?: ServicesConfig;
+  tools?: ToolsConfig;
+}> {
+  // Body lifted from existing onboard() — keeps the same prompts, returns the assembled
+  // primary/fallback/providers/services/tools tuple. Returns { llm: null } if user opts out.
+}
+```
+
+(The exact body is the existing onboarding code, unchanged. Take care to preserve the `openai-compatible` extras path.)
+
+Add at the start of that helper:
+
+```typescript
+  const wantsApiKeys = await p.confirm({
+    message: 'Configure API key providers? (recommended as fallback when OAuth rate-limits)',
+    initialValue: true,
+  });
+  if (p.isCancel(wantsApiKeys)) {
+    p.cancel('Onboarding cancelled');
+    process.exit(0);
+  }
+  if (!wantsApiKeys) {
+    return { llm: null };
+  }
+```
+
+- [ ] **Step 6: Compose the two tiers in `onboard()`**
+
+The body of `onboard()` becomes:
+
+```typescript
+    const oauthTier = await collectOAuthTier();
+    const apiKeyTier = await collectApiKeyTier();
+
+    if (!oauthTier && !apiKeyTier.llm) {
+      p.log.error('At least one auth tier (OAuth or API keys) must be configured.');
+      // Loop or exit — for v1, exit and ask user to re-run onboard.
+      p.cancel('Onboarding cancelled');
+      process.exit(1);
+    }
+
+    const llmConfig: LlmConfig = apiKeyTier.llm
+      ? { ...apiKeyTier.llm }
+      : {
+          primary: oauthTier!.primary, // safe: at least one tier configured
+          fallback: [],
+          providers: {},
+        };
+    if (oauthTier) {
+      llmConfig.oauth = oauthTier;
+    }
+
+    const { services, tools } = await collectWebSearchConfig();
+
+    // ... existing bootstrap call ...
+```
+
+(If `apiKeyTier.llm` is null but OAuth is configured, set `llmConfig.primary` to the OAuth primary and leave `providers` empty. Add the matching empty `providers[oauthTier.primary] = { keys: [] }` so later code that iterates providers doesn't fail; verify by running the daemon in this state.)
+
+- [ ] **Step 7: Run typecheck and tests**
+
+Run: `pnpm typecheck && pnpm test`
+Expected: PASS
+
+- [ ] **Step 8: Manual smoke test**
+
+Run: `pnpm build && node dist/cli/index.js onboard`
+Expected: First prompt is "Configure OAuth providers?". Selecting yes then anthropic opens browser. After login, second pass asks about API keys. Both can be configured independently. Final state: `~/.system2/oauth/anthropic.json` (mode 0600), `~/.system2/config.toml` with `[llm.oauth]` section.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/cli/commands/onboard.ts
+git commit -m "feat(onboard): two-step flow for OAuth tier then API key tier"
+```
+
+---
+
+## Task 11: Documentation
+
+**Files:**
+- Modify: `docs/configuration.md`, `docs/agents.md`
+
+- [ ] **Step 1: Update `docs/configuration.md`**
+
+Add to the config example near the top (around line 15):
+
+````markdown
+# OAuth tier — subscription credentials, tried first
+[llm.oauth]
+primary = "anthropic"
+fallback = []   # only anthropic OAuth supported in v1
+
+# API key tier — billed per token, used after OAuth tier exhausted
+[llm]
+primary = "anthropic"
+fallback = ["google", "openai"]
+````
+
+Add a new section after "Automatic Failover" (around line 162):
+
+````markdown
+## Auth Tiers
+
+System2 has two auth tiers:
+
+- **OAuth tier** — subscription credentials (`[llm.oauth]`). Tried first. v1 supports Anthropic Claude Pro/Max OAuth. Pi-ai supports Google Gemini CLI, GitHub Copilot, and OpenAI Codex OAuth as well; those will be added in future iterations.
+- **API key tier** — `[llm].primary` + `fallback`. Same shape as today. Used after the OAuth tier is fully exhausted (every OAuth credential in cooldown).
+
+The OAuth tier is fully exhausted before the system drops into the API key tier — never interleaving. If `[llm.oauth]` is absent, system2 behaves exactly like an API-key-only setup.
+
+### Anthropic OAuth (Claude Pro/Max)
+
+The pi-ai SDK detects OAuth tokens (substring match `sk-ant-oat`) and switches the Anthropic client to Bearer auth + Claude Code identity headers. The agent loop, custom tools, and multi-agent orchestration are unchanged.
+
+**Setup:** During `system2 onboard`, the first step asks whether to configure OAuth. Selecting "yes" + "Anthropic" opens a browser for Claude.ai authentication. The resulting tokens are saved to `~/.system2/oauth/anthropic.json` (mode 0600).
+
+**Refresh:** OAuth access tokens expire roughly hourly. The daemon refreshes them automatically before each agent session creation and on 401 errors. Refreshed tokens are persisted back to `~/.system2/oauth/anthropic.json`.
+
+**Failover:** A 401 on an OAuth credential triggers one refresh-and-retry. If refresh succeeds, the session reinitializes with the new token and the prompt retries. If refresh fails (or any other error), the OAuth credential enters cooldown and the next OAuth fallback is tried; once the OAuth tier is exhausted, the system drops into the API key tier.
+
+**Caveats:**
+- Claude Pro/Max usage limits are sized for one human in Claude Code. A multi-agent system2 workload (Guide + Conductor + Reviewer + Workers + Narrator running concurrently) can hit the 5-hour message cap quickly. Configure the API key tier as fallback for sustained workloads.
+- Programmatic use of Pro/Max credentials outside Claude Code is in a TOS gray area. Use at your own discretion.
+- Prompt caching is disabled on the OAuth path (the SDK strips `cache_control` from system prompts for OAuth tokens). Per-call billing still goes through the subscription.
+````
+
+- [ ] **Step 2: Update `docs/agents.md`**
+
+In the `AuthResolver` section (around line 138-160), append:
+
+````markdown
+### Two-Tier Credentials (OAuth + API Keys)
+
+When `[llm.oauth]` is configured, `AuthResolver` walks credentials across two tiers:
+
+1. **OAuth tier** — providers listed in `[llm.oauth].primary` + `fallback`, each with one credential loaded from `~/.system2/oauth/<provider>.json` at startup.
+2. **API key tier** — providers listed in `[llm].primary` + `fallback`, with one or more API keys each.
+
+`getActiveCredential()` returns a `{ tier, provider, keyIndex, label }` tuple. Cooldown keys are namespaced as `${tier}:${provider}:${keyIndex}` so the same provider in both tiers (e.g., Anthropic OAuth and Anthropic API keys) doesn't collide. The OAuth tier is fully exhausted (every credential in cooldown) before the resolver returns a keys-tier credential.
+
+Two extra concerns over plain API keys:
+
+1. **Refresh.** `AuthResolver.ensureFresh()` is awaited before each session creation in `AgentHost.initialize()` and `reinitializeWithProvider()`. If an OAuth access token is within 5 minutes of expiry, the resolver calls the SDK's `refreshAnthropicToken`, updates in-memory state, and persists via the callback registered through `setPersistOAuth()`. Concurrent refreshes per provider are serialized via a Promise lock.
+2. **401 handling.** Normally `auth` errors trigger immediate failover. For OAuth-tier credentials, `AgentHost` first calls `ensureFresh()` and reinitializes the session before falling over — this catches expiry-related 401s without losing the credential. If refresh itself fails, the credential goes into cooldown via the standard path.
+````
+
+- [ ] **Step 3: Run docs check**
+
+Run: `pnpm check`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/configuration.md docs/agents.md
+git commit -m "docs: document two-tier auth and Claude Pro/Max OAuth"
+```
+
+---
+
+## Task 12: End-to-end integration test
+
+**Files:**
+- Create: `src/server/agents/oauth-flow.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Create `src/server/agents/oauth-flow.test.ts`:
+
+```typescript
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LlmConfig } from '../../shared/index.js';
+import { AuthResolver } from './auth-resolver.js';
+import { loadOAuthCredentials, saveOAuthCredentials } from './oauth-credentials.js';
+
+function makeTwoTierConfig(): LlmConfig {
+  return {
+    primary: 'anthropic',
+    fallback: ['openai'],
+    providers: {
+      anthropic: { keys: [{ key: 'sk-ant-api03-fallback', label: 'api-fallback' }] },
+      openai: { keys: [{ key: 'oai-1', label: 'main' }] },
+    },
+    oauth: { primary: 'anthropic', fallback: [] },
+  };
+}
+
+describe('OAuth end-to-end flow', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'system2-oauth-e2e-'));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('loads, refreshes, persists, and prefers OAuth tier over keys tier', async () => {
+    saveOAuthCredentials(tmpDir, 'anthropic', {
+      access: 'sk-ant-oat-old',
+      refresh: 'rt-1',
+      expires: Date.now() + 60_000,
+      label: 'claude-pro',
+    });
+
+    const loaded = loadOAuthCredentials(tmpDir, 'anthropic');
+    expect(loaded).not.toBeNull();
+
+    const resolver = new AuthResolver(makeTwoTierConfig(), undefined, {
+      anthropic: loaded!,
+    });
+
+    resolver.setPersistOAuth('anthropic', async (creds) => {
+      saveOAuthCredentials(tmpDir, 'anthropic', creds);
+    });
+
+    let active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('oauth');
+    expect(active?.label).toBe('claude-pro');
+
+    const fakeRefresh = vi.fn(async () => ({
+      access: 'sk-ant-oat-new',
+      refresh: 'rt-2',
+      expires: Date.now() + 60 * 60_000,
+    }));
+    const refreshed = await resolver.ensureFresh({ refresh: fakeRefresh });
+    expect(refreshed.has('anthropic')).toBe(true);
+    expect(fakeRefresh).toHaveBeenCalledOnce();
+
+    const reloaded = loadOAuthCredentials(tmpDir, 'anthropic');
+    expect(reloaded?.access).toBe('sk-ant-oat-new');
+    expect(reloaded?.refresh).toBe('rt-2');
+
+    active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('oauth');
+  });
+
+  it('drops to keys tier only after OAuth tier is exhausted', async () => {
+    saveOAuthCredentials(tmpDir, 'anthropic', {
+      access: 'sk-ant-oat-old',
+      refresh: 'rt-1',
+      expires: Date.now() + 60 * 60_000,
+      label: 'claude-pro',
+    });
+    const resolver = new AuthResolver(makeTwoTierConfig(), undefined, {
+      anthropic: loadOAuthCredentials(tmpDir, 'anthropic')!,
+    });
+
+    expect(resolver.getActiveCredential()?.tier).toBe('oauth');
+
+    resolver.markKeyFailed('anthropic', 'auth', 'invalid_grant', 0, 'oauth');
+
+    const active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('keys');
+    expect(active?.provider).toBe('anthropic');
+    expect(active?.label).toBe('api-fallback');
+  });
+
+  it('cycles through entire OAuth tier before dropping to keys tier', async () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: ['openai'] },
+    };
+    saveOAuthCredentials(tmpDir, 'anthropic', {
+      access: 'a',
+      refresh: 'ar',
+      expires: Date.now() + 60 * 60_000,
+      label: 'claude-pro',
+    });
+    saveOAuthCredentials(tmpDir, 'openai', {
+      access: 'o',
+      refresh: 'or',
+      expires: Date.now() + 60 * 60_000,
+      label: 'codex',
+    });
+    const resolver = new AuthResolver(cfg, undefined, {
+      anthropic: loadOAuthCredentials(tmpDir, 'anthropic')!,
+      openai: loadOAuthCredentials(tmpDir, 'openai')!,
+    });
+
+    expect(resolver.getActiveCredential()).toMatchObject({
+      tier: 'oauth',
+      provider: 'anthropic',
+    });
+
+    resolver.markKeyFailed('anthropic', 'auth', 'fail', 0, 'oauth');
+    expect(resolver.getActiveCredential()).toMatchObject({ tier: 'oauth', provider: 'openai' });
+
+    resolver.markKeyFailed('openai', 'auth', 'fail', 0, 'oauth');
+    expect(resolver.getActiveCredential()).toMatchObject({ tier: 'keys', provider: 'anthropic' });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `pnpm test src/server/agents/oauth-flow.test.ts`
+Expected: PASS
+
+- [ ] **Step 3: Run full check**
+
+Run: `pnpm check && pnpm typecheck && pnpm build && pnpm test`
+Expected: PASS across the board
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server/agents/oauth-flow.test.ts
+git commit -m "test: end-to-end two-tier OAuth flow"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** Two-tier model with OAuth-first failover (Tasks 1, 2, 5, 6, 12), OAuth opt-in via onboarding asked first (Task 10), at least one tier required (Task 10), API key tier behaves identically when OAuth absent (Tasks 5, 7), refresh-and-retry on 401 (Task 9), token persistence (Tasks 3, 6, 7).
+- **Type consistency:** `OAuthCredentials` defined in Task 3, used in Tasks 5, 6, 7, 12. `RefreshedTokens` defined in Task 4, used in Task 6. `ActiveCredential`, `AuthTier`, `OAuthCredentialsMap` defined in Task 5, used in Tasks 7, 8, 12. `LlmOAuthConfig` defined in Task 1, used in Tasks 2, 10.
+- **Backwards compatibility:** `[llm.oauth]` is optional. Existing configs without `[llm.oauth]` keep the today's behavior (single keys tier). Cooldown key format changes from `provider:idx` to `tier:provider:idx`, but no consumer parses these strings — they're internal map keys.
+- **Concurrency:** Per-provider refresh lock (Task 6) prevents thundering-herd refresh from multiple agents.
+- **Failure modes covered:** corrupt credentials file (Task 3), refresh network failure (Tasks 6, 9), revoked OAuth grant (Tasks 9, 12), missing credentials file when `[llm.oauth]` declares a provider (Task 7), OAuth tier exhaustion → keys tier transition (Task 12).
+
+## Things deliberately out of scope
+
+- A `system2 login <provider>` standalone re-auth command. Users can re-run onboarding (after backing up `~/.system2`) or manually delete the credentials file and edit config.toml.
+- UI surfacing of OAuth state in `/api/agents`. Logging via the existing chat-message error path is sufficient for v1.
+- Multi-account OAuth (more than one credential per provider). v1 supports one credential per provider.
+- Per-role override of which tier to use. The user explicitly does not want this — both tiers apply globally to every agent.
+- Google Gemini CLI, GitHub Copilot, OpenAI Codex OAuth. The architecture supports them (provider-parameterized credentials file, OAuth-tier orderings), but each needs its own pi-ai integration plumbing. Filed as a follow-up.

--- a/docs/superpowers/plans/2026-04-27-claude-pro-max-oauth.md
+++ b/docs/superpowers/plans/2026-04-27-claude-pro-max-oauth.md
@@ -1560,6 +1560,21 @@ The pi-ai SDK detects OAuth tokens (substring match `sk-ant-oat`) and switches t
 - Claude Pro/Max usage limits are sized for one human in Claude Code. A multi-agent system2 workload (Guide + Conductor + Reviewer + Workers + Narrator running concurrently) can hit the 5-hour message cap quickly. Configure the API key tier as fallback for sustained workloads.
 - Programmatic use of Pro/Max credentials outside Claude Code is in a TOS gray area. Use at your own discretion.
 - Prompt caching is disabled on the OAuth path (the SDK strips `cache_control` from system prompts for OAuth tokens). Per-call billing still goes through the subscription.
+
+### Re-authenticating and managing credentials post-onboarding
+
+Use `system2 login <provider>` to add an OAuth credential after onboarding (or to re-authenticate when a refresh token has been invalidated — for example, after signing out of Claude.ai, changing your password, revoking the app's grant, or hitting an idle-expiry on the refresh token). The command runs the OAuth flow, writes `~/.system2/oauth/<provider>.json`, and (if `[llm.oauth]` is missing or doesn't include the provider) offers to patch `config.toml` to enable the OAuth tier. If the daemon is running, restart it to pick up the new credential: `system2 stop && system2 start`.
+
+Use `system2 logout <provider>` to remove an OAuth credential. The command deletes the credentials file and offers to remove the provider from `[llm.oauth]` in `config.toml`.
+
+### Changing primary provider or switching auth method
+
+System2 reads `~/.system2/config.toml` only at startup. To change the primary provider, swap which tier is preferred, add or remove a fallback provider, or edit any other LLM configuration:
+
+1. Edit `~/.system2/config.toml` directly (or use `system2 login` / `system2 logout` for OAuth credential changes).
+2. Restart the daemon: `system2 stop && system2 start`.
+
+You do not need to switch auth methods manually for cost or rate-limit reasons — the two-tier failover handles that automatically. OAuth is tried first; once exhausted, the system drops to the API key tier without any user action. If a transient failure has put a credential into cooldown and you want to force the system to retry it sooner than the cooldown expiry, restart the daemon (which clears in-memory cooldowns).
 ````
 
 - [ ] **Step 2: Update `docs/agents.md`**
@@ -1755,9 +1770,546 @@ git commit -m "test: end-to-end two-tier OAuth flow"
 
 ---
 
+## Task 13: `system2 login <provider>` command
+
+**Files:**
+- Create: `src/cli/commands/login.ts`
+- Modify: `src/cli/index.ts` (register the command)
+- Test: `src/cli/commands/login.test.ts` (the config-patching helper is the testable unit)
+
+This task wires up post-onboarding OAuth login. It reuses the OAuth helper from Task 4 (`loginAnthropic`) and the credentials writer from Task 3 (`saveOAuthCredentials`), and uses the TOML round-trip from Task 2 to optionally patch `[llm.oauth]` when the provider is not yet enabled.
+
+- [ ] **Step 1: Write the failing test for the config-patch helper**
+
+Create `src/cli/commands/login.test.ts`:
+
+```typescript
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { addProviderToOAuthTier } from './login.js';
+
+describe('addProviderToOAuthTier', () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'system2-login-test-'));
+    configPath = join(dir, 'config.toml');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('adds [llm.oauth] section when missing', () => {
+    writeFileSync(configPath, `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.anthropic]\nkeys = []\n`);
+    const result = addProviderToOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(true);
+    const content = readFileSync(configPath, 'utf-8');
+    expect(content).toMatch(/\[llm\.oauth\][\s\S]*primary\s*=\s*"anthropic"/);
+  });
+
+  it('appends to fallback when oauth section exists with different primary', () => {
+    writeFileSync(
+      configPath,
+      `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.oauth]\nprimary = "google"\nfallback = []\n\n[llm.anthropic]\nkeys = []\n`
+    );
+    const result = addProviderToOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(true);
+    const content = readFileSync(configPath, 'utf-8');
+    expect(content).toMatch(/primary\s*=\s*"google"/);
+    expect(content).toMatch(/fallback\s*=\s*\[\s*"anthropic"\s*\]/);
+  });
+
+  it('is a no-op when provider already in oauth tier', () => {
+    writeFileSync(
+      configPath,
+      `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.oauth]\nprimary = "anthropic"\nfallback = []\n\n[llm.anthropic]\nkeys = []\n`
+    );
+    const before = readFileSync(configPath, 'utf-8');
+    const result = addProviderToOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(false);
+    expect(readFileSync(configPath, 'utf-8')).toBe(before);
+  });
+});
+```
+
+- [ ] **Step 2: Run the failing test**
+
+Run: `pnpm test src/cli/commands/login.test.ts`
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement `addProviderToOAuthTier` and the `login` command**
+
+Create `src/cli/commands/login.ts`:
+
+```typescript
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdir as mkdirAsync } from 'node:fs/promises';
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import TOML from '@iarna/toml';
+import type { LlmConfig, LlmProvider } from '../../shared/index.js';
+import { loginAnthropic } from '../../server/agents/oauth.js';
+import { saveOAuthCredentials } from '../../server/agents/oauth-credentials.js';
+import { buildConfigToml, CONFIG_FILE, SYSTEM2_DIR } from '../utils/config.js';
+
+const OAUTH_PROVIDERS: LlmProvider[] = ['anthropic'];
+
+/**
+ * Patch config.toml to include `provider` in the OAuth tier (`[llm.oauth]`).
+ * If the section is missing, create it with `provider` as primary and empty fallback.
+ * If present with a different primary, append `provider` to fallback.
+ * If `provider` is already in the tier, no-op.
+ *
+ * Returns { changed: boolean }.
+ */
+export function addProviderToOAuthTier(
+  configPath: string,
+  provider: LlmProvider
+): { changed: boolean } {
+  if (!existsSync(configPath)) {
+    throw new Error(`config.toml not found at ${configPath}`);
+  }
+  const raw = readFileSync(configPath, 'utf-8');
+  const parsed = TOML.parse(raw) as { llm?: { oauth?: { primary?: string; fallback?: string[] } } };
+  const oauth = parsed.llm?.oauth;
+
+  if (!oauth) {
+    // Append [llm.oauth] section. We use a regex insert so we don't disturb other sections.
+    const insertion = `\n[llm.oauth]\nprimary = "${provider}"\nfallback = []\n`;
+    // Insert immediately after the existing [llm] block (before the next [llm.<x>] section).
+    const updated = raw.replace(/(\n\[llm\][^\[]*?)(\n\[llm\.)/s, `$1${insertion}$2`);
+    if (updated === raw) {
+      // Fallback: append to end of file
+      writeFileSync(configPath, raw.endsWith('\n') ? raw + insertion : raw + '\n' + insertion);
+    } else {
+      writeFileSync(configPath, updated);
+    }
+    return { changed: true };
+  }
+
+  const inTier = oauth.primary === provider || (oauth.fallback ?? []).includes(provider);
+  if (inTier) return { changed: false };
+
+  // Append to fallback array. Reconstruct the section in-place via regex on the existing section.
+  const sectionPattern = /\[llm\.oauth\]([\s\S]*?)(?=\n\[|$)/;
+  const match = raw.match(sectionPattern);
+  if (!match) {
+    // Shouldn't happen because oauth is non-null, but guard anyway
+    return { changed: false };
+  }
+  const newFallback = [...(oauth.fallback ?? []), provider];
+  const fallbackLine = `fallback = [${newFallback.map((f) => `"${f}"`).join(', ')}]`;
+  const replacedSection = match[0].replace(/fallback\s*=\s*\[[^\]]*\]/, fallbackLine);
+  writeFileSync(configPath, raw.replace(sectionPattern, replacedSection));
+  return { changed: true };
+}
+
+export async function login(provider?: string): Promise<void> {
+  console.clear();
+  p.intro('🧠 System2 OAuth login');
+
+  if (!existsSync(CONFIG_FILE)) {
+    p.cancel(`No System2 installation found at ${SYSTEM2_DIR}. Run "system2 onboard" first.`);
+    process.exit(1);
+  }
+
+  let target: LlmProvider;
+  if (provider) {
+    if (!OAUTH_PROVIDERS.includes(provider as LlmProvider)) {
+      p.cancel(`OAuth login for "${provider}" is not supported. Supported: ${OAUTH_PROVIDERS.join(', ')}`);
+      process.exit(1);
+    }
+    target = provider as LlmProvider;
+  } else {
+    if (OAUTH_PROVIDERS.length === 1) {
+      target = OAUTH_PROVIDERS[0];
+    } else {
+      target = (await p.select({
+        message: 'Which OAuth provider?',
+        options: OAUTH_PROVIDERS.map((id) => ({ value: id, label: id })),
+      })) as LlmProvider;
+      if (p.isCancel(target)) {
+        p.cancel('Cancelled');
+        process.exit(0);
+      }
+    }
+  }
+
+  const label = (await p.text({
+    message: 'Label for this OAuth credential:',
+    placeholder: 'claude-pro',
+    defaultValue: 'claude-pro',
+  })) as string;
+  if (p.isCancel(label)) {
+    p.cancel('Cancelled');
+    process.exit(0);
+  }
+
+  if (!existsSync(SYSTEM2_DIR)) {
+    await mkdirAsync(SYSTEM2_DIR, { recursive: true });
+  }
+
+  const s = p.spinner();
+  s.start('Waiting for browser authentication...');
+  try {
+    const creds = await loginAnthropic({
+      onAuth: ({ url }) => {
+        s.message(`Open this URL to authenticate:\n${url}`);
+      },
+      onPrompt: async ({ message, placeholder }) => {
+        s.stop('Browser callback timed out');
+        const value = (await p.text({ message, placeholder })) as string;
+        if (p.isCancel(value)) {
+          p.cancel('Cancelled');
+          process.exit(0);
+        }
+        s.start('Exchanging code...');
+        return value;
+      },
+      onProgress: (m) => s.message(m),
+    });
+    saveOAuthCredentials(SYSTEM2_DIR, target, {
+      access: creds.access,
+      refresh: creds.refresh,
+      expires: creds.expires,
+      label: label || 'claude-pro',
+    });
+    s.stop('✓ OAuth login successful');
+  } catch (err) {
+    s.stop('✗ OAuth login failed');
+    p.log.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  // Offer to patch config.toml
+  const patch = await p.confirm({
+    message: `Add ${target} to [llm.oauth] in config.toml?`,
+    initialValue: true,
+  });
+  if (p.isCancel(patch)) {
+    p.cancel('Cancelled (credentials saved, config not modified)');
+    process.exit(0);
+  }
+  if (patch) {
+    const result = addProviderToOAuthTier(CONFIG_FILE, target);
+    if (result.changed) {
+      p.log.info(`✓ Updated [llm.oauth] in ${CONFIG_FILE}`);
+    } else {
+      p.log.info(`${target} is already in [llm.oauth] — no changes`);
+    }
+  }
+
+  p.outro(
+    `✨ Done. If system2 is running, restart to apply: ${pc.bold('system2 stop && system2 start')}`
+  );
+}
+```
+
+Register the command in `src/cli/index.ts`. Find the existing command registrations (search for `onboard` to find the pattern) and add a `login` command that takes an optional `<provider>` argument.
+
+- [ ] **Step 4: Run the helper tests**
+
+Run: `pnpm test src/cli/commands/login.test.ts`
+Expected: PASS (3 tests)
+
+- [ ] **Step 5: Run full quality checks**
+
+Run: `pnpm check && pnpm typecheck && pnpm build`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/commands/login.ts src/cli/commands/login.test.ts src/cli/index.ts
+git commit -m "feat(cli): add 'system2 login' command for OAuth re-auth post-onboarding"
+```
+
+---
+
+## Task 14: `system2 logout <provider>` command
+
+**Files:**
+- Create: `src/cli/commands/logout.ts`
+- Modify: `src/cli/index.ts` (register the command)
+- Test: `src/cli/commands/logout.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/cli/commands/logout.test.ts`:
+
+```typescript
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { removeProviderFromOAuthTier } from './logout.js';
+
+describe('removeProviderFromOAuthTier', () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'system2-logout-test-'));
+    configPath = join(dir, 'config.toml');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('removes provider when it is the only entry: drops [llm.oauth] section', () => {
+    writeFileSync(
+      configPath,
+      `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.oauth]\nprimary = "anthropic"\nfallback = []\n\n[llm.anthropic]\nkeys = []\n`
+    );
+    const result = removeProviderFromOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(true);
+    const content = readFileSync(configPath, 'utf-8');
+    expect(content).not.toMatch(/\[llm\.oauth\]/);
+  });
+
+  it('removes provider from fallback', () => {
+    writeFileSync(
+      configPath,
+      `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.oauth]\nprimary = "google"\nfallback = ["anthropic"]\n\n[llm.anthropic]\nkeys = []\n`
+    );
+    const result = removeProviderFromOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(true);
+    const content = readFileSync(configPath, 'utf-8');
+    expect(content).toMatch(/primary\s*=\s*"google"/);
+    expect(content).toMatch(/fallback\s*=\s*\[\]/);
+  });
+
+  it('promotes first fallback when removing primary', () => {
+    writeFileSync(
+      configPath,
+      `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.oauth]\nprimary = "anthropic"\nfallback = ["google"]\n\n[llm.anthropic]\nkeys = []\n`
+    );
+    const result = removeProviderFromOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(true);
+    const content = readFileSync(configPath, 'utf-8');
+    expect(content).toMatch(/primary\s*=\s*"google"/);
+    expect(content).toMatch(/fallback\s*=\s*\[\]/);
+  });
+
+  it('is a no-op when provider not in oauth tier', () => {
+    writeFileSync(
+      configPath,
+      `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.oauth]\nprimary = "google"\nfallback = []\n\n[llm.anthropic]\nkeys = []\n`
+    );
+    const before = readFileSync(configPath, 'utf-8');
+    const result = removeProviderFromOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(false);
+    expect(readFileSync(configPath, 'utf-8')).toBe(before);
+  });
+});
+```
+
+- [ ] **Step 2: Verify failure**
+
+Run: `pnpm test src/cli/commands/logout.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `removeProviderFromOAuthTier` and the command**
+
+Create `src/cli/commands/logout.ts`:
+
+```typescript
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as p from '@clack/prompts';
+import pc from 'picocolors';
+import TOML from '@iarna/toml';
+import type { LlmProvider } from '../../shared/index.js';
+import { CONFIG_FILE, SYSTEM2_DIR } from '../utils/config.js';
+
+const OAUTH_PROVIDERS: LlmProvider[] = ['anthropic'];
+
+/**
+ * Patch config.toml to remove `provider` from `[llm.oauth]`.
+ * - If `provider` is the primary and there's a fallback: promote the first fallback to primary.
+ * - If `provider` is the primary and no fallback: drop the `[llm.oauth]` section entirely.
+ * - If `provider` is in fallback: remove it from the fallback list.
+ * - If `provider` not in the tier: no-op.
+ */
+export function removeProviderFromOAuthTier(
+  configPath: string,
+  provider: LlmProvider
+): { changed: boolean } {
+  if (!existsSync(configPath)) {
+    throw new Error(`config.toml not found at ${configPath}`);
+  }
+  const raw = readFileSync(configPath, 'utf-8');
+  const parsed = TOML.parse(raw) as { llm?: { oauth?: { primary?: string; fallback?: string[] } } };
+  const oauth = parsed.llm?.oauth;
+  if (!oauth) return { changed: false };
+
+  const fallback = oauth.fallback ?? [];
+  const isPrimary = oauth.primary === provider;
+  const inFallback = fallback.includes(provider);
+  if (!isPrimary && !inFallback) return { changed: false };
+
+  // Compute the new shape
+  let newPrimary: string | null = oauth.primary ?? null;
+  let newFallback = fallback.slice();
+
+  if (isPrimary) {
+    if (newFallback.length > 0) {
+      newPrimary = newFallback.shift() ?? null;
+    } else {
+      newPrimary = null;
+    }
+  } else {
+    newFallback = newFallback.filter((f) => f !== provider);
+  }
+
+  const sectionPattern = /\n?\[llm\.oauth\][\s\S]*?(?=\n\[|$)/;
+
+  if (newPrimary === null) {
+    // Drop the entire section
+    writeFileSync(configPath, raw.replace(sectionPattern, ''));
+    return { changed: true };
+  }
+
+  const fbStr = newFallback.map((f) => `"${f}"`).join(', ');
+  const replacement = `\n[llm.oauth]\nprimary = "${newPrimary}"\nfallback = [${fbStr}]\n`;
+  writeFileSync(configPath, raw.replace(sectionPattern, replacement));
+  return { changed: true };
+}
+
+export async function logout(provider?: string): Promise<void> {
+  console.clear();
+  p.intro('🧠 System2 OAuth logout');
+
+  if (!existsSync(CONFIG_FILE)) {
+    p.cancel(`No System2 installation found at ${SYSTEM2_DIR}.`);
+    process.exit(1);
+  }
+
+  let target: LlmProvider;
+  if (provider) {
+    if (!OAUTH_PROVIDERS.includes(provider as LlmProvider)) {
+      p.cancel(`OAuth logout for "${provider}" is not supported. Supported: ${OAUTH_PROVIDERS.join(', ')}`);
+      process.exit(1);
+    }
+    target = provider as LlmProvider;
+  } else {
+    target = OAUTH_PROVIDERS[0];
+  }
+
+  const credPath = join(SYSTEM2_DIR, 'oauth', `${target}.json`);
+  const fileExists = existsSync(credPath);
+
+  if (!fileExists) {
+    p.log.info(`No credentials file found at ${credPath}`);
+  } else {
+    const confirmDelete = await p.confirm({
+      message: `Delete OAuth credentials for ${target} (${credPath})?`,
+      initialValue: true,
+    });
+    if (p.isCancel(confirmDelete) || !confirmDelete) {
+      p.cancel('Cancelled');
+      process.exit(0);
+    }
+    rmSync(credPath);
+    p.log.info(`✓ Deleted ${credPath}`);
+  }
+
+  const confirmConfig = await p.confirm({
+    message: `Remove ${target} from [llm.oauth] in config.toml?`,
+    initialValue: true,
+  });
+  if (p.isCancel(confirmConfig)) {
+    p.cancel('Cancelled');
+    process.exit(0);
+  }
+  if (confirmConfig) {
+    const result = removeProviderFromOAuthTier(CONFIG_FILE, target);
+    if (result.changed) {
+      p.log.info(`✓ Updated [llm.oauth] in ${CONFIG_FILE}`);
+    } else {
+      p.log.info(`${target} was not in [llm.oauth] — no changes`);
+    }
+  }
+
+  p.outro(
+    `Done. If system2 is running, restart to apply: ${pc.bold('system2 stop && system2 start')}`
+  );
+}
+```
+
+Register the command in `src/cli/index.ts` next to `login`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm test src/cli/commands/logout.test.ts`
+Expected: PASS (4 tests)
+
+- [ ] **Step 5: Run full quality checks**
+
+Run: `pnpm check && pnpm typecheck && pnpm build && pnpm test`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cli/commands/logout.ts src/cli/commands/logout.test.ts src/cli/index.ts
+git commit -m "feat(cli): add 'system2 logout' command to remove OAuth credentials"
+```
+
+---
+
+## Task 15: Final cross-task review and finalization
+
+**Files:**
+- Modify (as needed): `README.md`, `docs/cli.md`, `docs/configuration.md`, `docs/agents.md`, `docs/README.md`
+- Verify: full build / test / check passes from a clean state
+
+This task is the wrap-up after Tasks 1–14 are merged: confirm everything is consistent, README and docs index reflect the new commands, and there are no loose ends.
+
+- [ ] **Step 1: Confirm all docs reflect the new behavior**
+
+- `README.md`: update the quick-start to mention the OAuth login choice during onboarding. If the README has a "Configuration" or "Auth" section, link to `docs/configuration.md` for the OAuth tier explanation.
+- `docs/README.md`: ensure the index entry for `configuration.md` and `cli.md` still accurately summarize the file. If the OAuth content is substantial enough, add a one-line index note ("OAuth tier and re-auth").
+- `docs/cli.md`: document the new `system2 login` and `system2 logout` commands with usage examples. Cross-reference `docs/configuration.md` for the OAuth tier semantics.
+- `docs/configuration.md`: confirm Tasks 11's docs render correctly and the new sections (Auth Tiers, Anthropic OAuth, Re-authenticating, Changing primary provider) are coherent and link to each other where useful.
+- `docs/agents.md`: confirm the AuthResolver section reflects the two-tier model.
+
+- [ ] **Step 2: Run the full quality gate from a clean state**
+
+```bash
+pnpm install
+pnpm check
+pnpm typecheck
+pnpm build
+pnpm test
+```
+
+All must pass. Capture and address any pre-existing failures or warnings introduced by this branch.
+
+- [ ] **Step 3: Verify cross-task consistency**
+
+- Type names: `LlmOAuthConfig`, `OAuthCredentials`, `OAuthCredentialsMap`, `RefreshedTokens`, `ActiveCredential`, `AuthTier` are consistently named and imported across every file that references them.
+- Filesystem layout: `~/.system2/oauth/<provider>.json` is the only canonical credentials path. No leftover references to other paths in code or docs.
+- Cooldown key format: `${tier}:${provider}:${keyIndex}` is used everywhere (auth-resolver.ts, host.ts).
+- Onboarding output: TOML written by onboarding round-trips through `convertTomlLlm` without warnings.
+
+- [ ] **Step 4: Commit any doc updates**
+
+```bash
+git add README.md docs/
+git commit -m "docs: cross-reference OAuth login/logout commands and finalize docs"
+```
+
+---
+
 ## Self-review notes
 
-- **Spec coverage:** Two-tier model with OAuth-first failover (Tasks 1, 2, 5, 6, 12), OAuth opt-in via onboarding asked first (Task 10), at least one tier required (Task 10), API key tier behaves identically when OAuth absent (Tasks 5, 7), refresh-and-retry on 401 (Task 9), token persistence (Tasks 3, 6, 7).
+- **Spec coverage:** Two-tier model with OAuth-first failover (Tasks 1, 2, 5, 6, 12), OAuth opt-in via onboarding asked first (Task 10), at least one tier required (Task 10), API key tier behaves identically when OAuth absent (Tasks 5, 7), refresh-and-retry on 401 (Task 9), token persistence (Tasks 3, 6, 7), post-onboarding re-auth (Task 13), credential removal (Task 14), final consistency check (Task 15).
 - **Type consistency:** `OAuthCredentials` defined in Task 3, used in Tasks 5, 6, 7, 12. `RefreshedTokens` defined in Task 4, used in Task 6. `ActiveCredential`, `AuthTier`, `OAuthCredentialsMap` defined in Task 5, used in Tasks 7, 8, 12. `LlmOAuthConfig` defined in Task 1, used in Tasks 2, 10.
 - **Backwards compatibility:** `[llm.oauth]` is optional. Existing configs without `[llm.oauth]` keep the today's behavior (single keys tier). Cooldown key format changes from `provider:idx` to `tier:provider:idx`, but no consumer parses these strings — they're internal map keys.
 - **Concurrency:** Per-provider refresh lock (Task 6) prevents thundering-herd refresh from multiple agents.
@@ -1765,7 +2317,8 @@ git commit -m "test: end-to-end two-tier OAuth flow"
 
 ## Things deliberately out of scope
 
-- A `system2 login <provider>` standalone re-auth command. Users can re-run onboarding (after backing up `~/.system2`) or manually delete the credentials file and edit config.toml.
+- Hot-reload of OAuth credentials or provider config without restarting the daemon. After `system2 login` / `logout` (or any edit to `config.toml`), users must `system2 stop && system2 start` to pick up changes. A `POST /api/auth/reload` endpoint is a feasible follow-up if usage demands it.
+- A `system2 config` CLI helper for editing `[llm].primary` / `[llm].fallback`. Documented workflow is "edit `~/.system2/config.toml` and restart" (see Task 11). Add the helper later if users find this clunky.
 - UI surfacing of OAuth state in `/api/agents`. Logging via the existing chat-message error path is sufficient for v1.
 - Multi-account OAuth (more than one credential per provider). v1 supports one credential per provider.
 - Per-role override of which tier to use. The user explicitly does not want this — both tiers apply globally to every agent.

--- a/src/cli/commands/login.test.ts
+++ b/src/cli/commands/login.test.ts
@@ -50,4 +50,16 @@ describe('addProviderToOAuthTier', () => {
     expect(result.changed).toBe(false);
     expect(readFileSync(configPath, 'utf-8')).toBe(before);
   });
+
+  it('inserts fallback line when [llm.oauth] has primary but no fallback', () => {
+    writeFileSync(
+      configPath,
+      `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.oauth]\nprimary = "google"\n\n[llm.anthropic]\nkeys = []\n`
+    );
+    const result = addProviderToOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(true);
+    const content = readFileSync(configPath, 'utf-8');
+    expect(content).toMatch(/primary\s*=\s*"google"/);
+    expect(content).toMatch(/fallback\s*=\s*\[\s*"anthropic"\s*\]/);
+  });
 });

--- a/src/cli/commands/login.test.ts
+++ b/src/cli/commands/login.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { addProviderToOAuthTier } from './login.js';
+
+describe('addProviderToOAuthTier', () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'system2-login-test-'));
+    configPath = join(dir, 'config.toml');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('adds [llm.oauth] section when missing', () => {
+    writeFileSync(
+      configPath,
+      `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.anthropic]\nkeys = []\n`
+    );
+    const result = addProviderToOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(true);
+    const content = readFileSync(configPath, 'utf-8');
+    expect(content).toMatch(/\[llm\.oauth\][\s\S]*primary\s*=\s*"anthropic"/);
+  });
+
+  it('appends to fallback when oauth section exists with different primary', () => {
+    writeFileSync(
+      configPath,
+      `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.oauth]\nprimary = "google"\nfallback = []\n\n[llm.anthropic]\nkeys = []\n`
+    );
+    const result = addProviderToOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(true);
+    const content = readFileSync(configPath, 'utf-8');
+    expect(content).toMatch(/primary\s*=\s*"google"/);
+    expect(content).toMatch(/fallback\s*=\s*\[\s*"anthropic"\s*\]/);
+  });
+
+  it('is a no-op when provider already in oauth tier', () => {
+    writeFileSync(
+      configPath,
+      `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.oauth]\nprimary = "anthropic"\nfallback = []\n\n[llm.anthropic]\nkeys = []\n`
+    );
+    const before = readFileSync(configPath, 'utf-8');
+    const result = addProviderToOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(false);
+    expect(readFileSync(configPath, 'utf-8')).toBe(before);
+  });
+});

--- a/src/cli/commands/login.test.ts
+++ b/src/cli/commands/login.test.ts
@@ -17,7 +17,7 @@ describe('addProviderToOAuthTier', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it('adds [llm.oauth] section when missing', () => {
+  it('adds [llm.oauth] section when missing, between [llm] and [llm.anthropic]', () => {
     writeFileSync(
       configPath,
       `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.anthropic]\nkeys = []\n`
@@ -26,6 +26,11 @@ describe('addProviderToOAuthTier', () => {
     expect(result.changed).toBe(true);
     const content = readFileSync(configPath, 'utf-8');
     expect(content).toMatch(/\[llm\.oauth\][\s\S]*primary\s*=\s*"anthropic"/);
+    // Position check: [llm.oauth] must come before [llm.anthropic]
+    const oauthIdx = content.indexOf('[llm.oauth]');
+    const anthropicIdx = content.indexOf('[llm.anthropic]');
+    expect(oauthIdx).toBeGreaterThan(-1);
+    expect(anthropicIdx).toBeGreaterThan(oauthIdx);
   });
 
   it('appends to fallback when oauth section exists with different primary', () => {

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -44,16 +44,29 @@ export function addProviderToOAuthTier(
   const oauth = parsed.llm?.oauth;
 
   if (!oauth) {
-    // Append [llm.oauth] section. We use a regex insert so we don't disturb other sections.
-    const insertion = `\n[llm.oauth]\nprimary = "${provider}"\nfallback = []\n`;
-    // Insert immediately after the existing [llm] block (before the next [llm.<x>] section).
-    const updated = raw.replace(/(\n\[llm\][^[]*?)(\n\[llm\.)/s, `$1${insertion}$2`);
-    if (updated === raw) {
-      // Fallback: append to end of file
-      writeFileSync(configPath, raw.endsWith('\n') ? raw + insertion : `${raw}\n${insertion}`);
-    } else {
-      writeFileSync(configPath, updated);
+    const insertion = `[llm.oauth]\nprimary = "${provider}"\nfallback = []\n`;
+    const lines = raw.split('\n');
+    const llmHeaderIdx = lines.findIndex((l) => l.trim() === '[llm]');
+    if (llmHeaderIdx === -1) {
+      // No [llm] block. Append at end (preserve trailing newline behavior).
+      const sep = raw.endsWith('\n') ? '' : '\n';
+      writeFileSync(configPath, `${raw}${sep}\n${insertion}`);
+      return { changed: true };
     }
+    // Find end of [llm] block: next line that starts a new table, or EOF
+    let insertIdx = lines.length;
+    for (let i = llmHeaderIdx + 1; i < lines.length; i++) {
+      if (/^\[/.test(lines[i].trim())) {
+        insertIdx = i;
+        break;
+      }
+    }
+    // Skip any blank lines immediately before the next section so we insert *before* the blank line
+    while (insertIdx > llmHeaderIdx + 1 && lines[insertIdx - 1].trim() === '') {
+      insertIdx--;
+    }
+    lines.splice(insertIdx, 0, '', `[llm.oauth]`, `primary = "${provider}"`, 'fallback = []');
+    writeFileSync(configPath, lines.join('\n'));
     return { changed: true };
   }
 

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -1,0 +1,163 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdir as mkdirAsync } from 'node:fs/promises';
+import * as p from '@clack/prompts';
+import TOML from '@iarna/toml';
+import pc from 'picocolors';
+import { loginAnthropic } from '../../server/agents/oauth.js';
+import { saveOAuthCredentials } from '../../server/agents/oauth-credentials.js';
+import type { LlmProvider } from '../../shared/index.js';
+import { CONFIG_FILE, SYSTEM2_DIR } from '../utils/config.js';
+
+const OAUTH_PROVIDERS: LlmProvider[] = ['anthropic'];
+
+/**
+ * Patch config.toml to include `provider` in the OAuth tier (`[llm.oauth]`).
+ * If the section is missing, create it with `provider` as primary and empty fallback.
+ * If present with a different primary, append `provider` to fallback.
+ * If `provider` is already in the tier, no-op.
+ *
+ * Returns { changed: boolean }.
+ */
+export function addProviderToOAuthTier(
+  configPath: string,
+  provider: LlmProvider
+): { changed: boolean } {
+  if (!existsSync(configPath)) {
+    throw new Error(`config.toml not found at ${configPath}`);
+  }
+  const raw = readFileSync(configPath, 'utf-8');
+  const parsed = TOML.parse(raw) as { llm?: { oauth?: { primary?: string; fallback?: string[] } } };
+  const oauth = parsed.llm?.oauth;
+
+  if (!oauth) {
+    // Append [llm.oauth] section. We use a regex insert so we don't disturb other sections.
+    const insertion = `\n[llm.oauth]\nprimary = "${provider}"\nfallback = []\n`;
+    // Insert immediately after the existing [llm] block (before the next [llm.<x>] section).
+    const updated = raw.replace(/(\n\[llm\][^[]*?)(\n\[llm\.)/s, `$1${insertion}$2`);
+    if (updated === raw) {
+      // Fallback: append to end of file
+      writeFileSync(configPath, raw.endsWith('\n') ? raw + insertion : `${raw}\n${insertion}`);
+    } else {
+      writeFileSync(configPath, updated);
+    }
+    return { changed: true };
+  }
+
+  const inTier = oauth.primary === provider || (oauth.fallback ?? []).includes(provider);
+  if (inTier) return { changed: false };
+
+  // Append to fallback array. Reconstruct the section in-place via regex on the existing section.
+  const sectionPattern = /\[llm\.oauth\]([\s\S]*?)(?=\n\[|$)/;
+  const match = raw.match(sectionPattern);
+  if (!match) {
+    // Shouldn't happen because oauth is non-null, but guard anyway
+    return { changed: false };
+  }
+  const newFallback = [...(oauth.fallback ?? []), provider];
+  const fallbackLine = `fallback = [${newFallback.map((f) => `"${f}"`).join(', ')}]`;
+  const replacedSection = match[0].replace(/fallback\s*=\s*\[[^\]]*\]/, fallbackLine);
+  writeFileSync(configPath, raw.replace(sectionPattern, replacedSection));
+  return { changed: true };
+}
+
+export async function login(provider?: string): Promise<void> {
+  console.clear();
+  p.intro('🧠 System2 OAuth login');
+
+  if (!existsSync(CONFIG_FILE)) {
+    p.cancel(`No System2 installation found at ${SYSTEM2_DIR}. Run "system2 onboard" first.`);
+    process.exit(1);
+  }
+
+  let target: LlmProvider;
+  if (provider) {
+    if (!OAUTH_PROVIDERS.includes(provider as LlmProvider)) {
+      p.cancel(
+        `OAuth login for "${provider}" is not supported. Supported: ${OAUTH_PROVIDERS.join(', ')}`
+      );
+      process.exit(1);
+    }
+    target = provider as LlmProvider;
+  } else {
+    if (OAUTH_PROVIDERS.length === 1) {
+      target = OAUTH_PROVIDERS[0];
+    } else {
+      target = (await p.select({
+        message: 'Which OAuth provider?',
+        options: OAUTH_PROVIDERS.map((id) => ({ value: id, label: id })),
+      })) as LlmProvider;
+      if (p.isCancel(target)) {
+        p.cancel('Cancelled');
+        process.exit(0);
+      }
+    }
+  }
+
+  const label = (await p.text({
+    message: 'Label for this OAuth credential:',
+    placeholder: 'claude-pro',
+    defaultValue: 'claude-pro',
+  })) as string;
+  if (p.isCancel(label)) {
+    p.cancel('Cancelled');
+    process.exit(0);
+  }
+
+  if (!existsSync(SYSTEM2_DIR)) {
+    await mkdirAsync(SYSTEM2_DIR, { recursive: true });
+  }
+
+  const s = p.spinner();
+  s.start('Waiting for browser authentication...');
+  try {
+    const creds = await loginAnthropic({
+      onAuth: ({ url }) => {
+        s.message(`Open this URL to authenticate:\n${url}`);
+      },
+      onPrompt: async ({ message, placeholder }) => {
+        s.stop('Browser callback timed out');
+        const value = (await p.text({ message, placeholder })) as string;
+        if (p.isCancel(value)) {
+          p.cancel('Cancelled');
+          process.exit(0);
+        }
+        s.start('Exchanging code...');
+        return value;
+      },
+      onProgress: (m) => s.message(m),
+    });
+    saveOAuthCredentials(SYSTEM2_DIR, target, {
+      access: creds.access,
+      refresh: creds.refresh,
+      expires: creds.expires,
+      label: label || 'claude-pro',
+    });
+    s.stop('✓ OAuth login successful');
+  } catch (err) {
+    s.stop('✗ OAuth login failed');
+    p.log.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  // Offer to patch config.toml
+  const patch = await p.confirm({
+    message: `Add ${target} to [llm.oauth] in config.toml?`,
+    initialValue: true,
+  });
+  if (p.isCancel(patch)) {
+    p.cancel('Cancelled (credentials saved, config not modified)');
+    process.exit(0);
+  }
+  if (patch) {
+    const result = addProviderToOAuthTier(CONFIG_FILE, target);
+    if (result.changed) {
+      p.log.info(`✓ Updated [llm.oauth] in ${CONFIG_FILE}`);
+    } else {
+      p.log.info(`${target} is already in [llm.oauth] — no changes`);
+    }
+  }
+
+  p.outro(
+    `✨ Done. If system2 is running, restart to apply: ${pc.bold('system2 stop && system2 start')}`
+  );
+}

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { mkdir as mkdirAsync } from 'node:fs/promises';
+import { join } from 'node:path';
 import * as p from '@clack/prompts';
 import TOML from '@iarna/toml';
 import pc from 'picocolors';
@@ -7,6 +8,19 @@ import { loginAnthropic } from '../../server/agents/oauth.js';
 import { saveOAuthCredentials } from '../../server/agents/oauth-credentials.js';
 import type { LlmProvider } from '../../shared/index.js';
 import { CONFIG_FILE, SYSTEM2_DIR } from '../utils/config.js';
+
+function isDaemonRunning(): boolean {
+  const pidFile = join(SYSTEM2_DIR, 'server.pid');
+  if (!existsSync(pidFile)) return false;
+  const pid = parseInt(readFileSync(pidFile, 'utf-8').trim(), 10);
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0); // signal 0 = check existence
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 const OAUTH_PROVIDERS: LlmProvider[] = ['anthropic'];
 
@@ -79,6 +93,11 @@ export async function login(provider?: string): Promise<void> {
 
   if (!existsSync(CONFIG_FILE)) {
     p.cancel(`No System2 installation found at ${SYSTEM2_DIR}. Run "system2 onboard" first.`);
+    process.exit(1);
+  }
+
+  if (isDaemonRunning()) {
+    p.cancel('System2 daemon is running. Stop it first with: system2 stop');
     process.exit(1);
   }
 

--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -56,6 +56,19 @@ export function addProviderToOAuthTier(
   const newFallback = [...(oauth.fallback ?? []), provider];
   const fallbackLine = `fallback = [${newFallback.map((f) => `"${f}"`).join(', ')}]`;
   const replacedSection = match[0].replace(/fallback\s*=\s*\[[^\]]*\]/, fallbackLine);
+
+  // If regex didn't match an existing fallback line, the section is unchanged.
+  // We need to insert the fallback line after the primary line instead.
+  if (replacedSection === match[0]) {
+    const withFallback = match[0].replace(/(primary\s*=\s*"[^"]*"\s*\n)/, `$1${fallbackLine}\n`);
+    if (withFallback === match[0]) {
+      // Could not even find a primary= line — bail.
+      return { changed: false };
+    }
+    writeFileSync(configPath, raw.replace(sectionPattern, withFallback));
+    return { changed: true };
+  }
+
   writeFileSync(configPath, raw.replace(sectionPattern, replacedSection));
   return { changed: true };
 }

--- a/src/cli/commands/logout.test.ts
+++ b/src/cli/commands/logout.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { removeProviderFromOAuthTier } from './logout.js';
+
+describe('removeProviderFromOAuthTier', () => {
+  let dir: string;
+  let configPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'system2-logout-test-'));
+    configPath = join(dir, 'config.toml');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('removes provider when it is the only entry: drops [llm.oauth] section', () => {
+    writeFileSync(
+      configPath,
+      `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.oauth]\nprimary = "anthropic"\nfallback = []\n\n[llm.anthropic]\nkeys = []\n`
+    );
+    const result = removeProviderFromOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(true);
+    const content = readFileSync(configPath, 'utf-8');
+    expect(content).not.toMatch(/\[llm\.oauth\]/);
+  });
+
+  it('removes provider from fallback', () => {
+    writeFileSync(
+      configPath,
+      `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.oauth]\nprimary = "google"\nfallback = ["anthropic"]\n\n[llm.anthropic]\nkeys = []\n`
+    );
+    const result = removeProviderFromOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(true);
+    const content = readFileSync(configPath, 'utf-8');
+    expect(content).toMatch(/primary\s*=\s*"google"/);
+    expect(content).toMatch(/fallback\s*=\s*\[\]/);
+  });
+
+  it('promotes first fallback when removing primary', () => {
+    writeFileSync(
+      configPath,
+      `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.oauth]\nprimary = "anthropic"\nfallback = ["google"]\n\n[llm.anthropic]\nkeys = []\n`
+    );
+    const result = removeProviderFromOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(true);
+    const content = readFileSync(configPath, 'utf-8');
+    expect(content).toMatch(/primary\s*=\s*"google"/);
+    expect(content).toMatch(/fallback\s*=\s*\[\]/);
+  });
+
+  it('is a no-op when provider not in oauth tier', () => {
+    writeFileSync(
+      configPath,
+      `[llm]\nprimary = "anthropic"\nfallback = []\n\n[llm.oauth]\nprimary = "google"\nfallback = []\n\n[llm.anthropic]\nkeys = []\n`
+    );
+    const before = readFileSync(configPath, 'utf-8');
+    const result = removeProviderFromOAuthTier(configPath, 'anthropic');
+    expect(result.changed).toBe(false);
+    expect(readFileSync(configPath, 'utf-8')).toBe(before);
+  });
+});

--- a/src/cli/commands/logout.ts
+++ b/src/cli/commands/logout.ts
@@ -6,6 +6,19 @@ import pc from 'picocolors';
 import type { LlmProvider } from '../../shared/index.js';
 import { CONFIG_FILE, SYSTEM2_DIR } from '../utils/config.js';
 
+function isDaemonRunning(): boolean {
+  const pidFile = join(SYSTEM2_DIR, 'server.pid');
+  if (!existsSync(pidFile)) return false;
+  const pid = parseInt(readFileSync(pidFile, 'utf-8').trim(), 10);
+  if (!pid) return false;
+  try {
+    process.kill(pid, 0); // signal 0 = check existence
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 const OAUTH_PROVIDERS: LlmProvider[] = ['anthropic'];
 
 /**
@@ -66,6 +79,11 @@ export async function logout(provider?: string): Promise<void> {
 
   if (!existsSync(CONFIG_FILE)) {
     p.cancel(`No System2 installation found at ${SYSTEM2_DIR}.`);
+    process.exit(1);
+  }
+
+  if (isDaemonRunning()) {
+    p.cancel('System2 daemon is running. Stop it first with: system2 stop');
     process.exit(1);
   }
 

--- a/src/cli/commands/logout.ts
+++ b/src/cli/commands/logout.ts
@@ -1,0 +1,123 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import * as p from '@clack/prompts';
+import TOML from '@iarna/toml';
+import pc from 'picocolors';
+import type { LlmProvider } from '../../shared/index.js';
+import { CONFIG_FILE, SYSTEM2_DIR } from '../utils/config.js';
+
+const OAUTH_PROVIDERS: LlmProvider[] = ['anthropic'];
+
+/**
+ * Patch config.toml to remove `provider` from `[llm.oauth]`.
+ * - If `provider` is the primary and there's a fallback: promote the first fallback to primary.
+ * - If `provider` is the primary and no fallback: drop the `[llm.oauth]` section entirely.
+ * - If `provider` is in fallback: remove it from the fallback list.
+ * - If `provider` not in the tier: no-op.
+ */
+export function removeProviderFromOAuthTier(
+  configPath: string,
+  provider: LlmProvider
+): { changed: boolean } {
+  if (!existsSync(configPath)) {
+    throw new Error(`config.toml not found at ${configPath}`);
+  }
+  const raw = readFileSync(configPath, 'utf-8');
+  const parsed = TOML.parse(raw) as { llm?: { oauth?: { primary?: string; fallback?: string[] } } };
+  const oauth = parsed.llm?.oauth;
+  if (!oauth) return { changed: false };
+
+  const fallback = oauth.fallback ?? [];
+  const isPrimary = oauth.primary === provider;
+  const inFallback = fallback.includes(provider);
+  if (!isPrimary && !inFallback) return { changed: false };
+
+  // Compute the new shape
+  let newPrimary: string | null = oauth.primary ?? null;
+  let newFallback = fallback.slice();
+
+  if (isPrimary) {
+    if (newFallback.length > 0) {
+      newPrimary = newFallback.shift() ?? null;
+    } else {
+      newPrimary = null;
+    }
+  } else {
+    newFallback = newFallback.filter((f) => f !== provider);
+  }
+
+  const sectionPattern = /\n?\[llm\.oauth\][\s\S]*?(?=\n\[|$)/;
+
+  if (newPrimary === null) {
+    // Drop the entire section
+    writeFileSync(configPath, raw.replace(sectionPattern, ''));
+    return { changed: true };
+  }
+
+  const fbStr = newFallback.map((f) => `"${f}"`).join(', ');
+  const replacement = `\n[llm.oauth]\nprimary = "${newPrimary}"\nfallback = [${fbStr}]\n`;
+  writeFileSync(configPath, raw.replace(sectionPattern, replacement));
+  return { changed: true };
+}
+
+export async function logout(provider?: string): Promise<void> {
+  console.clear();
+  p.intro('🧠 System2 OAuth logout');
+
+  if (!existsSync(CONFIG_FILE)) {
+    p.cancel(`No System2 installation found at ${SYSTEM2_DIR}.`);
+    process.exit(1);
+  }
+
+  let target: LlmProvider;
+  if (provider) {
+    if (!OAUTH_PROVIDERS.includes(provider as LlmProvider)) {
+      p.cancel(
+        `OAuth logout for "${provider}" is not supported. Supported: ${OAUTH_PROVIDERS.join(', ')}`
+      );
+      process.exit(1);
+    }
+    target = provider as LlmProvider;
+  } else {
+    target = OAUTH_PROVIDERS[0];
+  }
+
+  const credPath = join(SYSTEM2_DIR, 'oauth', `${target}.json`);
+  const fileExists = existsSync(credPath);
+
+  if (!fileExists) {
+    p.log.info(`No credentials file found at ${credPath}`);
+  } else {
+    const confirmDelete = await p.confirm({
+      message: `Delete OAuth credentials for ${target} (${credPath})?`,
+      initialValue: true,
+    });
+    if (p.isCancel(confirmDelete) || !confirmDelete) {
+      p.cancel('Cancelled');
+      process.exit(0);
+    }
+    rmSync(credPath);
+    p.log.info(`✓ Deleted ${credPath}`);
+  }
+
+  const confirmConfig = await p.confirm({
+    message: `Remove ${target} from [llm.oauth] in config.toml?`,
+    initialValue: true,
+  });
+  if (p.isCancel(confirmConfig)) {
+    p.cancel('Cancelled');
+    process.exit(0);
+  }
+  if (confirmConfig) {
+    const result = removeProviderFromOAuthTier(CONFIG_FILE, target);
+    if (result.changed) {
+      p.log.info(`✓ Updated [llm.oauth] in ${CONFIG_FILE}`);
+    } else {
+      p.log.info(`${target} was not in [llm.oauth] — no changes`);
+    }
+  }
+
+  p.outro(
+    `Done. If system2 is running, restart to apply: ${pc.bold('system2 stop && system2 start')}`
+  );
+}

--- a/src/cli/commands/onboard.ts
+++ b/src/cli/commands/onboard.ts
@@ -7,14 +7,18 @@
  */
 
 import { existsSync } from 'node:fs';
-import { mkdir } from 'node:fs/promises';
+import { mkdir, mkdir as mkdirAsync } from 'node:fs/promises';
 import { join } from 'node:path';
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
+import { loginAnthropic } from '../../server/agents/oauth.js';
+import { saveOAuthCredentials } from '../../server/agents/oauth-credentials.js';
 import type {
   LlmConfig,
   LlmKey,
+  LlmOAuthConfig,
   LlmProvider,
+  LlmProviderConfig,
   ServicesConfig,
   ToolsConfig,
 } from '../../shared/index.js';
@@ -30,6 +34,14 @@ const PROVIDERS: { value: LlmProvider; label: string }[] = [
   { value: 'openai-compatible', label: 'OpenAI-compatible (LiteLLM, vLLM, Ollama, Thaura, etc.)' },
   { value: 'openrouter', label: 'OpenRouter (multi-provider gateway)' },
   { value: 'xai', label: 'xAI (Grok)' },
+];
+
+const OAUTH_PROVIDERS: { value: LlmProvider; label: string; hint: string }[] = [
+  {
+    value: 'anthropic',
+    label: 'Anthropic (Claude Pro/Max)',
+    hint: 'Uses your Claude.ai subscription. No API key needed.',
+  },
 ];
 
 /**
@@ -222,6 +234,273 @@ async function collectWebSearchConfig(): Promise<{
   };
 }
 
+/**
+ * Run the OAuth login flow for a given provider.
+ * Returns { label } on success, null on failure.
+ */
+async function runOAuthLogin(provider: LlmProvider): Promise<{ label: string } | null> {
+  if (provider !== 'anthropic') {
+    p.log.error(`OAuth login for ${provider} is not implemented yet`);
+    return null;
+  }
+
+  const label = (await p.text({
+    message: 'Label for this OAuth credential:',
+    placeholder: 'claude-pro',
+    defaultValue: 'claude-pro',
+  })) as string;
+
+  if (p.isCancel(label)) {
+    p.cancel('Onboarding cancelled');
+    process.exit(0);
+  }
+
+  if (!existsSync(SYSTEM2_DIR)) {
+    await mkdirAsync(SYSTEM2_DIR, { recursive: true });
+  }
+
+  const s = p.spinner();
+  s.start('Waiting for browser authentication...');
+  try {
+    const creds = await loginAnthropic({
+      onAuth: ({ url }) => {
+        s.message(`Open this URL to authenticate:\n${url}`);
+      },
+      onPrompt: async ({ message, placeholder }) => {
+        s.stop('Browser callback timed out');
+        const value = (await p.text({ message, placeholder })) as string;
+        if (p.isCancel(value)) {
+          p.cancel('Onboarding cancelled');
+          process.exit(0);
+        }
+        s.start('Exchanging code...');
+        return value;
+      },
+      onProgress: (m) => s.message(m),
+    });
+    saveOAuthCredentials(SYSTEM2_DIR, provider, {
+      access: creds.access,
+      refresh: creds.refresh,
+      expires: creds.expires,
+      label: label || 'claude-pro',
+    });
+    s.stop('✓ OAuth login successful');
+    return { label: label || 'claude-pro' };
+  } catch (err) {
+    s.stop('✗ OAuth login failed');
+    p.log.error(err instanceof Error ? err.message : String(err));
+    return null;
+  }
+}
+
+/**
+ * Collect the OAuth tier configuration.
+ * Returns LlmOAuthConfig if configured, null if skipped or failed.
+ */
+async function collectOAuthTier(): Promise<LlmOAuthConfig | null> {
+  const wantsOAuth = await p.confirm({
+    message: 'Configure OAuth providers? (recommended if you have a Claude Pro/Max subscription)',
+    initialValue: true,
+  });
+  if (p.isCancel(wantsOAuth)) {
+    p.cancel('Onboarding cancelled');
+    process.exit(0);
+  }
+  if (!wantsOAuth) return null;
+
+  const primary = (await p.select({
+    message: 'Select your primary OAuth provider:',
+    options: OAUTH_PROVIDERS,
+  })) as LlmProvider;
+  if (p.isCancel(primary)) {
+    p.cancel('Onboarding cancelled');
+    process.exit(0);
+  }
+
+  const result = await runOAuthLogin(primary);
+  if (!result) {
+    const retry = await p.confirm({
+      message: 'OAuth login failed. Skip OAuth tier and continue with API keys only?',
+      initialValue: true,
+    });
+    if (p.isCancel(retry) || !retry) {
+      p.cancel('Onboarding cancelled');
+      process.exit(0);
+    }
+    return null;
+  }
+
+  const fallback: LlmProvider[] = [];
+  let availableOAuth = OAUTH_PROVIDERS.filter((o) => o.value !== primary);
+  while (availableOAuth.length > 0) {
+    const addMore = await p.confirm({
+      message: 'Add another OAuth provider as fallback?',
+      initialValue: false,
+    });
+    if (p.isCancel(addMore)) {
+      p.cancel('Onboarding cancelled');
+      process.exit(0);
+    }
+    if (!addMore) break;
+
+    const next = (await p.select({
+      message: 'Select fallback OAuth provider:',
+      options: availableOAuth,
+    })) as LlmProvider;
+    if (p.isCancel(next)) {
+      p.cancel('Onboarding cancelled');
+      process.exit(0);
+    }
+    const r = await runOAuthLogin(next);
+    if (r) {
+      fallback.push(next);
+    }
+    availableOAuth = availableOAuth.filter((o) => o.value !== next);
+  }
+
+  return { primary, fallback };
+}
+
+/**
+ * Collect the API key tier configuration.
+ * Returns { llm: null } if user opts out, otherwise the full provider config.
+ */
+async function collectApiKeyTier(): Promise<{
+  llm: {
+    primary: LlmProvider;
+    fallback: LlmProvider[];
+    providers: Partial<Record<LlmProvider, LlmProviderConfig>>;
+  } | null;
+  services?: ServicesConfig;
+  tools?: ToolsConfig;
+}> {
+  const wantsApiKeys = await p.confirm({
+    message: 'Configure API key providers? (recommended as fallback when OAuth rate-limits)',
+    initialValue: true,
+  });
+  if (p.isCancel(wantsApiKeys)) {
+    p.cancel('Onboarding cancelled');
+    process.exit(0);
+  }
+  if (!wantsApiKeys) {
+    return { llm: null };
+  }
+
+  const collectedKeys: Map<LlmProvider, LlmKey[]> = new Map();
+
+  // Step 1: Select primary provider
+  const primaryProvider = (await p.select({
+    message: 'Select your primary LLM provider:',
+    options: PROVIDERS,
+  })) as LlmProvider;
+
+  if (p.isCancel(primaryProvider)) {
+    p.cancel('Onboarding cancelled');
+    process.exit(0);
+  }
+
+  // Step 2: Collect keys for primary provider (openai-compatible needs extra config)
+  let compatExtras: { base_url: string; model: string; compat_reasoning: boolean } | undefined;
+
+  if (primaryProvider === 'openai-compatible') {
+    const compatConfig = await collectOpenAICompatibleConfig();
+    collectedKeys.set(primaryProvider, compatConfig.keys);
+    compatExtras = {
+      base_url: compatConfig.base_url,
+      model: compatConfig.model,
+      compat_reasoning: compatConfig.compat_reasoning,
+    };
+  } else {
+    const primaryKeys = await collectKeysForProvider(primaryProvider);
+    collectedKeys.set(primaryProvider, primaryKeys);
+  }
+
+  // Step 3: Ask about fallback providers
+  const wantsFallback = await p.confirm({
+    message: 'Configure fallback providers?',
+    initialValue: false,
+  });
+
+  if (p.isCancel(wantsFallback)) {
+    p.cancel('Onboarding cancelled');
+    process.exit(0);
+  }
+
+  const fallbackOrder: LlmProvider[] = [];
+
+  if (wantsFallback) {
+    let availableProviders = PROVIDERS.filter((p) => p.value !== primaryProvider);
+
+    while (availableProviders.length > 0) {
+      const fallbackProvider = (await p.select({
+        message:
+          fallbackOrder.length === 0
+            ? 'Select a fallback provider:'
+            : 'Select another fallback provider:',
+        options: availableProviders,
+      })) as LlmProvider;
+
+      if (p.isCancel(fallbackProvider)) {
+        p.cancel('Onboarding cancelled');
+        process.exit(0);
+      }
+
+      if (fallbackProvider === 'openai-compatible' && !compatExtras) {
+        const compatConfig = await collectOpenAICompatibleConfig();
+        collectedKeys.set(fallbackProvider, compatConfig.keys);
+        compatExtras = {
+          base_url: compatConfig.base_url,
+          model: compatConfig.model,
+          compat_reasoning: compatConfig.compat_reasoning,
+        };
+      } else {
+        const fallbackKeys = await collectKeysForProvider(fallbackProvider);
+        collectedKeys.set(fallbackProvider, fallbackKeys);
+      }
+      fallbackOrder.push(fallbackProvider);
+
+      availableProviders = availableProviders.filter((p) => p.value !== fallbackProvider);
+
+      if (availableProviders.length > 0) {
+        const addMore = await p.confirm({
+          message: 'Add another fallback provider?',
+          initialValue: false,
+        });
+
+        if (p.isCancel(addMore)) {
+          p.cancel('Onboarding cancelled');
+          process.exit(0);
+        }
+
+        if (!addMore) break;
+      }
+    }
+  }
+
+  // Build providers map
+  const providers: Partial<Record<LlmProvider, LlmProviderConfig>> = {};
+  for (const [provider, keys] of collectedKeys) {
+    if (provider === 'openai-compatible' && compatExtras) {
+      providers[provider] = {
+        keys,
+        base_url: compatExtras.base_url,
+        model: compatExtras.model,
+        compat_reasoning: compatExtras.compat_reasoning,
+      };
+    } else {
+      providers[provider] = { keys };
+    }
+  }
+
+  return {
+    llm: {
+      primary: primaryProvider,
+      fallback: fallbackOrder,
+      providers,
+    },
+  };
+}
+
 export async function onboard(): Promise<void> {
   console.clear();
 
@@ -244,125 +523,45 @@ export async function onboard(): Promise<void> {
   p.intro('🧠 Welcome to System2, the AI multi-agent system for working with data.');
 
   p.log.info(
-    'Before we can get to work, we need at least one LLM provider and an API key. ' +
-      'You can configure multiple providers and keys for redundancy and flexibility. ' +
-      "Don't worry, you can always change or add providers and keys later by editing ~/.system2/config.toml directly."
+    'Before we can get to work, we need at least one LLM provider configured. ' +
+      'You can use OAuth (Claude Pro/Max subscription) and/or API keys. ' +
+      "Don't worry, you can always change or add providers later by editing ~/.system2/config.toml directly."
   );
 
   try {
-    const collectedKeys: Map<LlmProvider, LlmKey[]> = new Map();
+    // Phase 1a: OAuth tier
+    const oauthTier = await collectOAuthTier();
 
-    // Step 1: Select primary provider
-    const primaryProvider = (await p.select({
-      message: 'Select your primary LLM provider:',
-      options: PROVIDERS,
-    })) as LlmProvider;
+    // Phase 1b: API key tier
+    const apiKeyTier = await collectApiKeyTier();
 
-    if (p.isCancel(primaryProvider)) {
+    // Validate: at least one tier must be configured
+    if (!oauthTier && !apiKeyTier.llm) {
+      p.log.error('At least one auth tier (OAuth or API keys) must be configured.');
       p.cancel('Onboarding cancelled');
-      process.exit(0);
+      process.exit(1);
     }
 
-    // Step 2: Collect keys for primary provider (openai-compatible needs extra config)
-    let compatExtras: { base_url: string; model: string; compat_reasoning: boolean } | undefined;
-
-    if (primaryProvider === 'openai-compatible') {
-      const compatConfig = await collectOpenAICompatibleConfig();
-      collectedKeys.set(primaryProvider, compatConfig.keys);
-      compatExtras = {
-        base_url: compatConfig.base_url,
-        model: compatConfig.model,
-        compat_reasoning: compatConfig.compat_reasoning,
-      };
+    // Build LLM config — at this point at least one tier is non-null (validated above)
+    let llmConfig: LlmConfig;
+    if (apiKeyTier.llm) {
+      llmConfig = { ...apiKeyTier.llm };
     } else {
-      const primaryKeys = await collectKeysForProvider(primaryProvider);
-      collectedKeys.set(primaryProvider, primaryKeys);
+      // oauthTier is guaranteed non-null: both-null case already exited above
+      const oauthPrimary = (oauthTier as LlmOAuthConfig).primary;
+      llmConfig = {
+        primary: oauthPrimary,
+        fallback: [],
+        providers: { [oauthPrimary]: { keys: [] } },
+      };
     }
 
-    // Step 3: Ask about fallback providers
-    const wantsFallback = await p.confirm({
-      message: 'Configure fallback providers?',
-      initialValue: false,
-    });
-
-    if (p.isCancel(wantsFallback)) {
-      p.cancel('Onboarding cancelled');
-      process.exit(0);
+    if (oauthTier) {
+      llmConfig.oauth = oauthTier;
     }
 
-    const fallbackOrder: LlmProvider[] = [];
-
-    if (wantsFallback) {
-      let availableProviders = PROVIDERS.filter((p) => p.value !== primaryProvider);
-
-      while (availableProviders.length > 0) {
-        const fallbackProvider = (await p.select({
-          message:
-            fallbackOrder.length === 0
-              ? 'Select a fallback provider:'
-              : 'Select another fallback provider:',
-          options: availableProviders,
-        })) as LlmProvider;
-
-        if (p.isCancel(fallbackProvider)) {
-          p.cancel('Onboarding cancelled');
-          process.exit(0);
-        }
-
-        if (fallbackProvider === 'openai-compatible' && !compatExtras) {
-          const compatConfig = await collectOpenAICompatibleConfig();
-          collectedKeys.set(fallbackProvider, compatConfig.keys);
-          compatExtras = {
-            base_url: compatConfig.base_url,
-            model: compatConfig.model,
-            compat_reasoning: compatConfig.compat_reasoning,
-          };
-        } else {
-          const fallbackKeys = await collectKeysForProvider(fallbackProvider);
-          collectedKeys.set(fallbackProvider, fallbackKeys);
-        }
-        fallbackOrder.push(fallbackProvider);
-
-        availableProviders = availableProviders.filter((p) => p.value !== fallbackProvider);
-
-        if (availableProviders.length > 0) {
-          const addMore = await p.confirm({
-            message: 'Add another fallback provider?',
-            initialValue: false,
-          });
-
-          if (p.isCancel(addMore)) {
-            p.cancel('Onboarding cancelled');
-            process.exit(0);
-          }
-
-          if (!addMore) break;
-        }
-      }
-    }
-
-    // Step 4: Ask about web search
+    // Phase 1c: Web search
     const { services, tools } = await collectWebSearchConfig();
-
-    // Build LLM config
-    const llmConfig: LlmConfig = {
-      primary: primaryProvider,
-      fallback: fallbackOrder,
-      providers: {},
-    };
-
-    for (const [provider, keys] of collectedKeys) {
-      if (provider === 'openai-compatible' && compatExtras) {
-        llmConfig.providers[provider] = {
-          keys,
-          base_url: compatExtras.base_url,
-          model: compatExtras.model,
-          compat_reasoning: compatExtras.compat_reasoning,
-        };
-      } else {
-        llmConfig.providers[provider] = { keys };
-      }
-    }
 
     // Phase 2: Bootstrap
     const s = p.spinner();

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@
 
 import { createRequire } from 'node:module';
 import { Command } from 'commander';
+import { login } from './commands/login.js';
 import { onboard } from './commands/onboard.js';
 import { start } from './commands/start.js';
 import { status } from './commands/status.js';
@@ -29,6 +30,13 @@ program
   .description('Initialize System2 and configure LLM providers')
   .action(async () => {
     await onboard();
+  });
+
+program
+  .command('login [provider]')
+  .description('Authenticate with an OAuth provider (re-auth post-onboarding)')
+  .action(async (provider?: string) => {
+    await login(provider);
   });
 
 program

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@
 import { createRequire } from 'node:module';
 import { Command } from 'commander';
 import { login } from './commands/login.js';
+import { logout } from './commands/logout.js';
 import { onboard } from './commands/onboard.js';
 import { start } from './commands/start.js';
 import { status } from './commands/status.js';
@@ -37,6 +38,13 @@ program
   .description('Authenticate with an OAuth provider (re-auth post-onboarding)')
   .action(async (provider?: string) => {
     await login(provider);
+  });
+
+program
+  .command('logout [provider]')
+  .description('Remove OAuth credentials and deregister provider from config')
+  .action(async (provider?: string) => {
+    await logout(provider);
   });
 
 program

--- a/src/cli/utils/config.test.ts
+++ b/src/cli/utils/config.test.ts
@@ -1,4 +1,6 @@
+import TOML from '@iarna/toml';
 import { describe, expect, it, vi } from 'vitest';
+import type { LlmConfig } from '../../shared/index.js';
 import { buildConfigToml, convertTomlAgents, convertTomlDatabases } from './config.js';
 
 describe('buildConfigToml', () => {
@@ -663,5 +665,46 @@ describe('convertTomlAgents', () => {
       conductor: { models: { google: 'gemini-2.5-pro' } },
       narrator: { thinking_level: 'off' },
     });
+  });
+});
+
+describe('buildConfigToml — [llm.oauth] tier', () => {
+  it('emits oauth section with primary and fallback', () => {
+    const llm: LlmConfig = {
+      primary: 'anthropic',
+      fallback: [],
+      providers: { anthropic: { keys: [] } },
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const toml = buildConfigToml({ llm });
+    expect(toml).toMatch(/\[llm\.oauth\]\s*\nprimary\s*=\s*"anthropic"\s*\nfallback\s*=\s*\[\]/);
+  });
+
+  it('omits oauth section when undefined', () => {
+    const llm: LlmConfig = {
+      primary: 'anthropic',
+      fallback: [],
+      providers: { anthropic: { keys: [{ key: 'k', label: 'l' }] } },
+    };
+    const toml = buildConfigToml({ llm });
+    expect(toml).not.toMatch(/\[llm\.oauth\]/);
+  });
+
+  it('round-trips through TOML.parse', () => {
+    const llm: LlmConfig = {
+      primary: 'openai',
+      fallback: ['google'],
+      providers: {
+        anthropic: { keys: [] },
+        openai: { keys: [{ key: 'oai-1', label: 'main' }] },
+      },
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const toml = buildConfigToml({ llm });
+    const parsed = TOML.parse(toml) as {
+      llm?: { oauth?: { primary?: string; fallback?: string[] } };
+    };
+    expect(parsed.llm?.oauth?.primary).toBe('anthropic');
+    expect(parsed.llm?.oauth?.fallback).toEqual([]);
   });
 });

--- a/src/cli/utils/config.test.ts
+++ b/src/cli/utils/config.test.ts
@@ -1,7 +1,12 @@
 import TOML from '@iarna/toml';
 import { describe, expect, it, vi } from 'vitest';
 import type { LlmConfig } from '../../shared/index.js';
-import { buildConfigToml, convertTomlAgents, convertTomlDatabases } from './config.js';
+import {
+  buildConfigToml,
+  convertTomlAgents,
+  convertTomlDatabases,
+  convertTomlLlm,
+} from './config.js';
 
 describe('buildConfigToml', () => {
   it('generates valid TOML with LLM config', () => {
@@ -690,7 +695,7 @@ describe('buildConfigToml — [llm.oauth] tier', () => {
     expect(toml).not.toMatch(/\[llm\.oauth\]/);
   });
 
-  it('round-trips through TOML.parse', () => {
+  it('round-trips through TOML.parse and convertTomlLlm', () => {
     const llm: LlmConfig = {
       primary: 'openai',
       fallback: ['google'],
@@ -701,10 +706,9 @@ describe('buildConfigToml — [llm.oauth] tier', () => {
       oauth: { primary: 'anthropic', fallback: [] },
     };
     const toml = buildConfigToml({ llm });
-    const parsed = TOML.parse(toml) as {
-      llm?: { oauth?: { primary?: string; fallback?: string[] } };
-    };
-    expect(parsed.llm?.oauth?.primary).toBe('anthropic');
-    expect(parsed.llm?.oauth?.fallback).toEqual([]);
+    const parsed = TOML.parse(toml) as Record<string, unknown>;
+    const llmSection = parsed.llm as Parameters<typeof convertTomlLlm>[0];
+    const reconstructed = convertTomlLlm(llmSection);
+    expect(reconstructed.oauth).toEqual({ primary: 'anthropic', fallback: [] });
   });
 });

--- a/src/cli/utils/config.ts
+++ b/src/cli/utils/config.ts
@@ -91,6 +91,10 @@ interface TomlConfig {
       model?: string;
       compat_reasoning?: boolean;
     };
+    oauth?: {
+      primary?: string;
+      fallback?: string[];
+    };
   };
   agents?: Record<
     string,
@@ -240,11 +244,20 @@ function convertTomlLlm(toml: NonNullable<TomlConfig['llm']>): LlmConfig {
     }
   }
 
-  return {
+  const config: LlmConfig = {
     primary: (toml.primary as LlmProvider) ?? 'anthropic',
     fallback: (toml.fallback as LlmProvider[]) ?? [],
     providers,
   };
+
+  if (toml.oauth?.primary) {
+    config.oauth = {
+      primary: toml.oauth.primary as LlmProvider,
+      fallback: (toml.oauth.fallback as LlmProvider[]) ?? [],
+    };
+  }
+
+  return config;
 }
 
 /**
@@ -547,6 +560,14 @@ export function buildConfigToml(options: {
     lines.push(`primary = "${primary}"`);
     lines.push(`fallback = [${fallback.map((f) => `"${f}"`).join(', ')}]`);
     lines.push('');
+
+    if (options.llm.oauth) {
+      lines.push('[llm.oauth]');
+      lines.push(`primary = "${options.llm.oauth.primary}"`);
+      const fb = options.llm.oauth.fallback.map((f) => `"${f}"`).join(', ');
+      lines.push(`fallback = [${fb}]`);
+      lines.push('');
+    }
 
     for (const name of [
       'anthropic',

--- a/src/cli/utils/config.ts
+++ b/src/cli/utils/config.ts
@@ -184,7 +184,7 @@ const DEFAULT_OPERATIONAL: Pick<
 /**
  * Convert TOML LLM section to LlmConfig.
  */
-function convertTomlLlm(toml: NonNullable<TomlConfig['llm']>): LlmConfig {
+export function convertTomlLlm(toml: NonNullable<TomlConfig['llm']>): LlmConfig {
   const providers: Partial<Record<LlmProvider, LlmProviderConfig>> = {};
 
   for (const name of [

--- a/src/server/agents/auth-resolver.test.ts
+++ b/src/server/agents/auth-resolver.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LlmConfig } from '../../shared/index.js';
 import { AuthResolver } from './auth-resolver.js';
+import type { OAuthCredentials } from './oauth-credentials.js';
 
 function makeConfig(overrides?: Partial<LlmConfig>): LlmConfig {
   return {
@@ -47,7 +48,7 @@ describe('AuthResolver', () => {
   it('returns first key as active by default', () => {
     const resolver = new AuthResolver(makeConfig());
     const active = resolver.getActiveKey('anthropic');
-    expect(active).toEqual({ provider: 'anthropic', keyIndex: 0, label: 'main' });
+    expect(active).toEqual({ tier: 'keys', provider: 'anthropic', keyIndex: 0, label: 'main' });
   });
 
   it('returns undefined for unconfigured provider', () => {
@@ -268,6 +269,7 @@ describe('AuthResolver', () => {
       );
       expect(resolver.primaryProvider).toBe('mistral');
       expect(resolver.getActiveKey('mistral')).toEqual({
+        tier: 'keys',
         provider: 'mistral',
         keyIndex: 0,
         label: 'default',
@@ -306,10 +308,117 @@ describe('AuthResolver', () => {
       );
       expect(resolver.primaryProvider).toBe('openai-compatible');
       expect(resolver.getActiveKey('openai-compatible')).toEqual({
+        tier: 'keys',
         provider: 'openai-compatible',
         keyIndex: 0,
         label: 'local',
       });
     });
+  });
+});
+
+function makeTwoTierConfig(): LlmConfig {
+  return {
+    primary: 'anthropic',
+    fallback: ['openai'],
+    providers: {
+      anthropic: {
+        keys: [
+          { key: 'ant-key-1', label: 'main' },
+          { key: 'ant-key-2', label: 'backup' },
+        ],
+      },
+      openai: { keys: [{ key: 'oai-key-1', label: 'main' }] },
+    },
+    oauth: { primary: 'anthropic', fallback: [] },
+  };
+}
+
+function makeOAuthCreds(expiresInMs: number = 60 * 60_000): OAuthCredentials {
+  return {
+    access: 'sk-ant-oat-abc',
+    refresh: 'rt-xyz',
+    expires: Date.now() + expiresInMs,
+    label: 'claude-pro',
+  };
+}
+
+describe('AuthResolver — two-tier model', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns OAuth credential as active when oauth tier configured', () => {
+    const resolver = new AuthResolver(makeTwoTierConfig(), undefined, {
+      anthropic: makeOAuthCreds(),
+    });
+    const active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('oauth');
+    expect(active?.provider).toBe('anthropic');
+    expect(active?.label).toBe('claude-pro');
+  });
+
+  it('falls back to keys tier when oauth tier is omitted', () => {
+    const cfg = makeTwoTierConfig();
+    delete cfg.oauth;
+    const resolver = new AuthResolver(cfg);
+    const active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('keys');
+    expect(active?.provider).toBe('anthropic');
+    expect(active?.label).toBe('main');
+  });
+
+  it('falls back to keys tier when oauth credentials are missing', () => {
+    const resolver = new AuthResolver(makeTwoTierConfig());
+    const active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('keys');
+  });
+
+  it('exhausts oauth tier before dropping to keys tier', () => {
+    const resolver = new AuthResolver(makeTwoTierConfig(), undefined, {
+      anthropic: makeOAuthCreds(),
+    });
+    resolver.markKeyFailed('anthropic', 'auth', 'invalid_grant', 0, 'oauth');
+    const active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('keys');
+    expect(active?.provider).toBe('anthropic');
+    expect(active?.label).toBe('main');
+  });
+
+  it('cooldown keys for same provider in different tiers do not collide', () => {
+    const resolver = new AuthResolver(makeTwoTierConfig(), undefined, {
+      anthropic: makeOAuthCreds(),
+    });
+    resolver.markKeyFailed('anthropic', 'auth', 'oauth fail', 0, 'oauth');
+    expect(resolver.isKeyInCooldown('anthropic', 0, 'oauth')).toBe(true);
+    expect(resolver.isKeyInCooldown('anthropic', 0, 'keys')).toBe(false);
+  });
+
+  it('walks oauth fallback before dropping to keys tier', () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: ['openai'] },
+    };
+    const resolver = new AuthResolver(cfg, undefined, {
+      anthropic: makeOAuthCreds(),
+      openai: { ...makeOAuthCreds(), label: 'codex' },
+    });
+    resolver.markKeyFailed('anthropic', 'auth', 'fail', 0, 'oauth');
+    const active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('oauth');
+    expect(active?.provider).toBe('openai');
+  });
+
+  it('providerOrder includes both tiers, deduplicated', () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const resolver = new AuthResolver(cfg, undefined, { anthropic: makeOAuthCreds() });
+    expect(resolver.providerOrder).toEqual(['anthropic', 'openai']);
   });
 });

--- a/src/server/agents/auth-resolver.test.ts
+++ b/src/server/agents/auth-resolver.test.ts
@@ -513,4 +513,32 @@ describe('AuthResolver.ensureFresh', () => {
       })
     ).rejects.toThrow('network down');
   });
+
+  it('releases the refresh lock after failure so subsequent calls can succeed', async () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const resolver = new AuthResolver(cfg, undefined, { anthropic: makeOAuthCreds(1000) });
+
+    // First call: refresh fails
+    await expect(
+      resolver.ensureFresh({
+        refresh: async () => {
+          throw new Error('transient failure');
+        },
+      })
+    ).rejects.toThrow('transient failure');
+
+    // Second call: refresh succeeds (lock must have been released)
+    const refreshed = await resolver.ensureFresh({
+      refresh: async () => ({
+        access: 'recovered',
+        refresh: 'rt-2',
+        expires: Date.now() + 60 * 60_000,
+      }),
+    });
+    expect(refreshed.has('anthropic')).toBe(true);
+    expect(resolver.getActiveCredential()?.provider).toBe('anthropic');
+  });
 });

--- a/src/server/agents/auth-resolver.test.ts
+++ b/src/server/agents/auth-resolver.test.ts
@@ -541,4 +541,90 @@ describe('AuthResolver.ensureFresh', () => {
     expect(refreshed.has('anthropic')).toBe(true);
     expect(resolver.getActiveCredential()?.provider).toBe('anthropic');
   });
+
+  // Bug A regression: force-refresh bypasses the expiry check
+  it('forces refresh for providers in the force list even if not near expiry', async () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const resolver = new AuthResolver(cfg, undefined, {
+      anthropic: makeOAuthCreds(60 * 60_000), // 1 hour — well within fresh window
+    });
+    let called = false;
+    const refreshed = await resolver.ensureFresh({
+      refresh: async () => {
+        called = true;
+        return { access: 'forced-new', refresh: 'rt-new', expires: Date.now() + 60 * 60_000 };
+      },
+      force: ['anthropic'],
+    });
+    expect(called).toBe(true);
+    expect(refreshed.has('anthropic')).toBe(true);
+    expect(resolver.getActiveOAuthCredential('anthropic')?.access).toBe('forced-new');
+  });
+
+  it('does not force-refresh providers not in the force list', async () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: ['openai'] },
+    };
+    let anthropicCalled = false;
+    let openaiCalled = false;
+    const resolver = new AuthResolver(cfg, undefined, {
+      anthropic: makeOAuthCreds(60 * 60_000), // fresh
+      openai: { ...makeOAuthCreds(60 * 60_000), label: 'openai-oauth' }, // fresh
+    });
+    await resolver.ensureFresh({
+      refresh: async (refreshToken) => {
+        // Identify which provider is being refreshed by the refresh token
+        if (refreshToken === 'rt-xyz') anthropicCalled = true;
+        else openaiCalled = true;
+        return { access: 'new', refresh: 'rt-new', expires: Date.now() + 60 * 60_000 };
+      },
+      force: ['anthropic'], // only force anthropic
+    });
+    expect(anthropicCalled).toBe(true);
+    expect(openaiCalled).toBe(false);
+  });
+
+  // Bug B regression: use latest credential after awaiting an existing refresh lock
+  it('uses the latest credential after awaiting an existing refresh lock', async () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const resolver = new AuthResolver(cfg, undefined, {
+      anthropic: makeOAuthCreds(1000), // expiring soon
+    });
+
+    const seen: string[] = [];
+
+    // First refresh: slow, rotates refresh token (but result still expiring soon for second refresh)
+    const slow = async (refreshToken: string): Promise<RefreshedTokens> => {
+      seen.push(refreshToken);
+      await new Promise((r) => setTimeout(r, 30));
+      return { access: 'a1', refresh: 'rt-rotated', expires: Date.now() + 1000 }; // still expiring
+    };
+
+    // Second refresh: fast, uses the rotated token from the first refresh
+    const fast = async (refreshToken: string): Promise<RefreshedTokens> => {
+      seen.push(refreshToken);
+      return { access: 'a2', refresh: 'rt-final', expires: Date.now() + 60 * 60_000 };
+    };
+
+    // Kick off both with force so the second caller hits the post-await path
+    const first = resolver.ensureFresh({ refresh: slow, force: ['anthropic'] });
+    // Brief delay so `first` acquires the lock before `second` is called
+    await new Promise((r) => setTimeout(r, 5));
+    const second = resolver.ensureFresh({ refresh: fast, force: ['anthropic'] });
+    await Promise.all([first, second]);
+
+    // First refresh should have used the original refresh token
+    expect(seen[0]).toBe('rt-xyz');
+    // Second refresh should have used the rotated token written by the first refresh
+    expect(seen[1]).toBe('rt-rotated');
+    // Final state should reflect the second refresh
+    expect(resolver.getActiveOAuthCredential('anthropic')?.refresh).toBe('rt-final');
+  });
 });

--- a/src/server/agents/auth-resolver.test.ts
+++ b/src/server/agents/auth-resolver.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LlmConfig } from '../../shared/index.js';
 import { AuthResolver } from './auth-resolver.js';
+import type { RefreshedTokens } from './oauth.js';
 import type { OAuthCredentials } from './oauth-credentials.js';
 
 function makeConfig(overrides?: Partial<LlmConfig>): LlmConfig {
@@ -420,5 +421,96 @@ describe('AuthResolver — two-tier model', () => {
     };
     const resolver = new AuthResolver(cfg, undefined, { anthropic: makeOAuthCreds() });
     expect(resolver.providerOrder).toEqual(['anthropic', 'openai']);
+  });
+});
+
+describe('AuthResolver.ensureFresh', () => {
+  it('refreshes OAuth credential within expiry buffer and persists', async () => {
+    const persisted: OAuthCredentials[] = [];
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const resolver = new AuthResolver(cfg, undefined, {
+      anthropic: makeOAuthCreds(60_000), // 1 min — within buffer
+    });
+    resolver.setPersistOAuth('anthropic', async (creds) => {
+      persisted.push(creds);
+    });
+    const refreshed = await resolver.ensureFresh({
+      refresh: async (): Promise<RefreshedTokens> => ({
+        access: 'new-access',
+        refresh: 'rt-2',
+        expires: Date.now() + 60 * 60_000,
+      }),
+    });
+    expect(refreshed.has('anthropic')).toBe(true);
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].refresh).toBe('rt-2');
+  });
+
+  it('does nothing when OAuth tier is empty', async () => {
+    const cfg = makeTwoTierConfig();
+    delete cfg.oauth;
+    const resolver = new AuthResolver(cfg);
+    const refreshed = await resolver.ensureFresh({
+      refresh: async () => {
+        throw new Error('should not be called');
+      },
+    });
+    expect(refreshed.size).toBe(0);
+  });
+
+  it('does nothing when OAuth tokens are fresh', async () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    let calls = 0;
+    const resolver = new AuthResolver(cfg, undefined, {
+      anthropic: makeOAuthCreds(60 * 60_000), // 1 hour — fresh
+    });
+    await resolver.ensureFresh({
+      refresh: async () => {
+        calls++;
+        return { access: 'x', refresh: 'y', expires: 1 };
+      },
+    });
+    expect(calls).toBe(0);
+  });
+
+  it('serializes concurrent ensureFresh calls per provider', async () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const resolver = new AuthResolver(cfg, undefined, { anthropic: makeOAuthCreds(1000) });
+    let count = 0;
+    const slow = async (): Promise<RefreshedTokens> => {
+      count++;
+      await new Promise((r) => setTimeout(r, 20));
+      return { access: 'new', refresh: 'rt-2', expires: Date.now() + 60 * 60_000 };
+    };
+    await Promise.all([
+      resolver.ensureFresh({ refresh: slow }),
+      resolver.ensureFresh({ refresh: slow }),
+      resolver.ensureFresh({ refresh: slow }),
+    ]);
+    expect(count).toBe(1);
+  });
+
+  it('throws when refresh fails', async () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: [] },
+    };
+    const resolver = new AuthResolver(cfg, undefined, { anthropic: makeOAuthCreds(1000) });
+    await expect(
+      resolver.ensureFresh({
+        refresh: async () => {
+          throw new Error('network down');
+        },
+      })
+    ).rejects.toThrow('network down');
   });
 });

--- a/src/server/agents/auth-resolver.ts
+++ b/src/server/agents/auth-resolver.ts
@@ -361,26 +361,39 @@ export class AuthResolver {
    * reinitialize SDK sessions for those providers (existing sessions hold a snapshot
    * of the old access token).
    * Concurrent callers are serialized per provider so refresh runs once.
+   *
+   * @param deps.force - Providers to refresh regardless of expiry (e.g., on 401 from a
+   *   revoked-but-not-expired token). Defaults to empty — only expiry-based refresh occurs.
    */
   async ensureFresh(deps: {
     refresh: (refreshToken: string) => Promise<RefreshedTokens>;
+    /** Providers to refresh regardless of expiry (e.g., on 401 from a revoked-but-not-expired token). */
+    force?: LlmProvider[];
   }): Promise<Set<LlmProvider>> {
     const refreshed = new Set<LlmProvider>();
+    const forceSet = new Set(deps.force ?? []);
     for (const provider of this.oauthOrder) {
       const cred = this.oauthCredentials[provider];
-      if (!cred || !isExpiringSoon(cred.expires)) continue;
+      if (!cred) continue;
+      const shouldRefresh = forceSet.has(provider) || isExpiringSoon(cred.expires);
+      if (!shouldRefresh) continue;
 
       const existing = this.refreshLocks.get(provider);
+      // Bug B fix: re-read credential after awaiting so we use the rotated refresh token.
+      let credToUse = cred;
       if (existing) {
         await existing;
         const after = this.oauthCredentials[provider];
-        if (after && !isExpiringSoon(after.expires)) {
+        if (!after) continue; // credential disappeared while we waited
+        const stillNeedsRefresh = forceSet.has(provider) || isExpiringSoon(after.expires);
+        if (!stillNeedsRefresh) {
           refreshed.add(provider);
           continue;
         }
+        credToUse = after;
       }
 
-      const lock = this.doRefresh(provider, cred, deps.refresh).finally(() => {
+      const lock = this.doRefresh(provider, credToUse, deps.refresh).finally(() => {
         this.refreshLocks.delete(provider);
       });
       this.refreshLocks.set(provider, lock);
@@ -388,6 +401,14 @@ export class AuthResolver {
       refreshed.add(provider);
     }
     return refreshed;
+  }
+
+  /**
+   * Get the current in-memory OAuth credential for a provider.
+   * Used for inspection and testing.
+   */
+  getActiveOAuthCredential(provider: LlmProvider): OAuthCredentials | undefined {
+    return this.oauthCredentials[provider];
   }
 
   private async doRefresh(

--- a/src/server/agents/auth-resolver.ts
+++ b/src/server/agents/auth-resolver.ts
@@ -14,6 +14,7 @@
 import { AuthStorage } from '@mariozechner/pi-coding-agent';
 import type { LlmConfig, LlmProvider } from '../../shared/index.js';
 import { log } from '../utils/logger.js';
+import { isExpiringSoon, type RefreshedTokens } from './oauth.js';
 import type { OAuthCredentials } from './oauth-credentials.js';
 
 /** Default cooldown durations */
@@ -57,6 +58,10 @@ export class AuthResolver {
   private oauthCredentials: OAuthCredentialsMap;
   private oauthOrder: LlmProvider[];
   private keysOrder: LlmProvider[];
+  private persistCallbacks: Partial<
+    Record<LlmProvider, (creds: OAuthCredentials) => Promise<void>>
+  > = {};
+  private refreshLocks: Map<LlmProvider, Promise<void>> = new Map();
 
   constructor(
     llmConfig: LlmConfig,
@@ -338,6 +343,76 @@ export class AuthResolver {
     }
 
     return AuthStorage.inMemory(data);
+  }
+
+  /**
+   * Register a callback that persists refreshed OAuth credentials for a provider.
+   */
+  setPersistOAuth(
+    provider: LlmProvider,
+    callback: (creds: OAuthCredentials) => Promise<void>
+  ): void {
+    this.persistCallbacks[provider] = callback;
+  }
+
+  /**
+   * Refresh any OAuth credential whose access token is within the expiry buffer.
+   * Returns the set of providers whose credentials were refreshed; callers should
+   * reinitialize SDK sessions for those providers (existing sessions hold a snapshot
+   * of the old access token).
+   * Concurrent callers are serialized per provider so refresh runs once.
+   */
+  async ensureFresh(deps: {
+    refresh: (refreshToken: string) => Promise<RefreshedTokens>;
+  }): Promise<Set<LlmProvider>> {
+    const refreshed = new Set<LlmProvider>();
+    for (const provider of this.oauthOrder) {
+      const cred = this.oauthCredentials[provider];
+      if (!cred || !isExpiringSoon(cred.expires)) continue;
+
+      const existing = this.refreshLocks.get(provider);
+      if (existing) {
+        await existing;
+        const after = this.oauthCredentials[provider];
+        if (after && !isExpiringSoon(after.expires)) {
+          refreshed.add(provider);
+          continue;
+        }
+      }
+
+      const lock = this.doRefresh(provider, cred, deps.refresh).then(() => {
+        this.refreshLocks.delete(provider);
+      });
+      this.refreshLocks.set(provider, lock);
+      await lock;
+      refreshed.add(provider);
+    }
+    return refreshed;
+  }
+
+  private async doRefresh(
+    provider: LlmProvider,
+    cred: OAuthCredentials,
+    refresh: (refreshToken: string) => Promise<RefreshedTokens>
+  ): Promise<void> {
+    const tokens = await refresh(cred.refresh);
+    const updated: OAuthCredentials = {
+      access: tokens.access,
+      refresh: tokens.refresh,
+      expires: tokens.expires,
+      label: cred.label,
+    };
+    this.oauthCredentials[provider] = updated;
+    log.info(`[AuthResolver] OAuth token refreshed for ${provider}:${cred.label}`);
+
+    const persist = this.persistCallbacks[provider];
+    if (persist) {
+      try {
+        await persist(updated);
+      } catch (err) {
+        log.warn(`[AuthResolver] Failed to persist refreshed OAuth for ${provider}:`, err);
+      }
+    }
   }
 
   /**

--- a/src/server/agents/auth-resolver.ts
+++ b/src/server/agents/auth-resolver.ts
@@ -34,9 +34,6 @@ export interface ActiveCredential {
   label: string;
 }
 
-/** @deprecated Use ActiveCredential */
-export type ActiveKey = ActiveCredential;
-
 export type OAuthCredentialsMap = Partial<Record<LlmProvider, OAuthCredentials>>;
 
 interface KeyCooldown {

--- a/src/server/agents/auth-resolver.ts
+++ b/src/server/agents/auth-resolver.ts
@@ -380,7 +380,7 @@ export class AuthResolver {
         }
       }
 
-      const lock = this.doRefresh(provider, cred, deps.refresh).then(() => {
+      const lock = this.doRefresh(provider, cred, deps.refresh).finally(() => {
         this.refreshLocks.delete(provider);
       });
       this.refreshLocks.set(provider, lock);

--- a/src/server/agents/auth-resolver.ts
+++ b/src/server/agents/auth-resolver.ts
@@ -5,30 +5,39 @@
  * and provides Pi SDK compatible AuthStorage with automatic key rotation on failure.
  *
  * Failover logic:
- * 1. Try keys for primary provider in order
- * 2. If all primary keys fail, try fallback providers in order
- * 3. Each provider's keys are tried in order until one works
+ * 1. Walk OAuth tier first (primary + fallback OAuth providers that have credentials)
+ * 2. Only when every OAuth credential is in cooldown, drop to the keys tier
+ * 3. Within the keys tier, try primary provider keys, then fallback providers in order
  * 4. Keys in cooldown recover after the cooldown period expires
  */
 
 import { AuthStorage } from '@mariozechner/pi-coding-agent';
-import type { LlmConfig, LlmKey, LlmProvider } from '../../shared/index.js';
+import type { LlmConfig, LlmProvider } from '../../shared/index.js';
 import { log } from '../utils/logger.js';
+import type { OAuthCredentials } from './oauth-credentials.js';
 
 /** Default cooldown durations */
 const DEFAULT_RATE_LIMIT_COOLDOWN_MS = 90 * 1000;
 const DEFAULT_COOLDOWN_MS = 5 * 60 * 1000;
+
+export type AuthTier = 'oauth' | 'keys';
 
 export interface CooldownConfig {
   rateLimitMs: number;
   defaultMs: number;
 }
 
-export interface ActiveKey {
+export interface ActiveCredential {
+  tier: AuthTier;
   provider: LlmProvider;
   keyIndex: number;
   label: string;
 }
+
+/** @deprecated Use ActiveCredential */
+export type ActiveKey = ActiveCredential;
+
+export type OAuthCredentialsMap = Partial<Record<LlmProvider, OAuthCredentials>>;
 
 interface KeyCooldown {
   /** When the cooldown started */
@@ -40,20 +49,36 @@ interface KeyCooldown {
 }
 
 /**
- * Manages API key resolution with failover support.
+ * Manages API key resolution with two-tier failover support.
+ * OAuth tier (subscription credentials) is exhausted before falling over to the API key tier.
  */
 export class AuthResolver {
   private config: LlmConfig;
   private activeKeys: Map<LlmProvider, number> = new Map();
   private cooldowns: Map<string, KeyCooldown> = new Map();
   private cooldownConfig: CooldownConfig;
+  private oauthCredentials: OAuthCredentialsMap;
+  private oauthOrder: LlmProvider[];
+  private keysOrder: LlmProvider[];
 
-  constructor(llmConfig: LlmConfig, cooldownConfig?: Partial<CooldownConfig>) {
+  constructor(
+    llmConfig: LlmConfig,
+    cooldownConfig?: Partial<CooldownConfig>,
+    oauthCredentials?: OAuthCredentialsMap
+  ) {
     this.config = this.validateConfig(llmConfig);
     this.cooldownConfig = {
       rateLimitMs: cooldownConfig?.rateLimitMs ?? DEFAULT_RATE_LIMIT_COOLDOWN_MS,
       defaultMs: cooldownConfig?.defaultMs ?? DEFAULT_COOLDOWN_MS,
     };
+    this.oauthCredentials = oauthCredentials ?? {};
+
+    this.oauthOrder = this.config.oauth
+      ? [this.config.oauth.primary, ...this.config.oauth.fallback].filter(
+          (p) => this.oauthCredentials[p] !== undefined
+        )
+      : [];
+    this.keysOrder = [this.config.primary, ...this.config.fallback];
 
     // Initialize active key index to 0 for each provider with keys
     for (const provider of Object.keys(this.config.providers) as LlmProvider[]) {
@@ -90,80 +115,113 @@ export class AuthResolver {
   }
 
   /**
-   * Get the primary provider.
+   * Build a namespaced cooldown key that includes the tier so OAuth and keys
+   * cooldowns for the same provider/index do not collide.
+   */
+  private cooldownKey(tier: AuthTier, provider: LlmProvider, keyIndex: number): string {
+    return `${tier}:${provider}:${keyIndex}`;
+  }
+
+  /**
+   * Get the primary provider (OAuth tier's primary if configured, else keys tier primary).
    */
   get primaryProvider(): LlmProvider {
-    return this.config.primary;
+    return this.oauthOrder[0] ?? this.config.primary;
   }
 
   /**
-   * Get ordered list of providers to try (primary first, then fallbacks).
+   * Get ordered list of providers to try (OAuth tier first, then keys tier), deduplicated.
    */
   get providerOrder(): LlmProvider[] {
-    return [this.config.primary, ...this.config.fallback];
+    const seen = new Set<LlmProvider>();
+    const out: LlmProvider[] = [];
+    for (const p of [...this.oauthOrder, ...this.keysOrder]) {
+      if (!seen.has(p)) {
+        seen.add(p);
+        out.push(p);
+      }
+    }
+    return out;
   }
 
   /**
-   * Get the first valid key for a provider.
+   * Walk OAuth tier first, then keys tier, returning the first credential not in cooldown.
    */
-  private getFirstValidKey(provider: LlmProvider): LlmKey | undefined {
-    const providerConfig = this.config.providers[provider];
-    if (!providerConfig) return undefined;
-
-    // Find first non-empty, available key (not failed or in cooldown)
-    for (let i = 0; i < providerConfig.keys.length; i++) {
-      const key = providerConfig.keys[i];
-      const keyId = `${provider}:${i}`;
-
-      if (key.key && !this.isKeyUnavailable(keyId)) {
-        this.activeKeys.set(provider, i);
-        return key;
+  getActiveCredential(): ActiveCredential | undefined {
+    // OAuth tier
+    for (const provider of this.oauthOrder) {
+      const cred = this.oauthCredentials[provider];
+      if (!cred) continue;
+      if (this.isKeyUnavailable(this.cooldownKey('oauth', provider, 0))) continue;
+      return { tier: 'oauth', provider, keyIndex: 0, label: cred.label };
+    }
+    // Keys tier
+    for (const provider of this.keysOrder) {
+      const providerConfig = this.config.providers[provider];
+      if (!providerConfig) continue;
+      for (let i = 0; i < providerConfig.keys.length; i++) {
+        const key = providerConfig.keys[i];
+        if (key.key && !this.isKeyUnavailable(this.cooldownKey('keys', provider, i))) {
+          this.activeKeys.set(provider, i);
+          return { tier: 'keys', provider, keyIndex: i, label: key.label };
+        }
       }
     }
-
     return undefined;
   }
 
   /**
-   * Get the currently active key for a provider.
+   * Get the currently active credential for a provider.
+   *
+   * When tier is not specified, tries OAuth first, then keys (for the given provider only).
+   * When tier is specified, restricts to that tier.
    */
-  getActiveKey(provider: LlmProvider): ActiveKey | undefined {
-    const index = this.activeKeys.get(provider) ?? 0;
-    const providerConfig = this.config.providers[provider];
-
-    if (!providerConfig) return undefined;
-
-    // Check if current index is valid and available
-    const keyId = `${provider}:${index}`;
-    if (this.isKeyUnavailable(keyId)) {
-      // Current key unavailable, find next valid
-      const nextKey = this.getFirstValidKey(provider);
-      if (!nextKey) return undefined;
-      // getFirstValidKey sets activeKeys, so this will always have a value
-      const newIndex = this.activeKeys.get(provider) ?? 0;
-      return {
-        provider,
-        keyIndex: newIndex,
-        label: nextKey.label,
-      };
-    }
-
-    const key = providerConfig.keys[index];
-    if (!key || !key.key) return undefined;
-
-    return {
-      provider,
-      keyIndex: index,
-      label: key.label,
+  getActiveKey(provider: LlmProvider, tier?: AuthTier): ActiveCredential | undefined {
+    const tryOAuth = (): ActiveCredential | undefined => {
+      if (!this.oauthOrder.includes(provider)) return undefined;
+      const cred = this.oauthCredentials[provider];
+      if (!cred) return undefined;
+      if (this.isKeyUnavailable(this.cooldownKey('oauth', provider, 0))) return undefined;
+      return { tier: 'oauth', provider, keyIndex: 0, label: cred.label };
     };
+
+    const tryKeys = (): ActiveCredential | undefined => {
+      const providerConfig = this.config.providers[provider];
+      if (!providerConfig) return undefined;
+      const index = this.activeKeys.get(provider) ?? 0;
+      // Check current index first
+      const currentKeyId = this.cooldownKey('keys', provider, index);
+      if (!this.isKeyUnavailable(currentKeyId)) {
+        const key = providerConfig.keys[index];
+        if (key?.key) {
+          return { tier: 'keys', provider, keyIndex: index, label: key.label };
+        }
+      }
+      // Current index unavailable, find next valid
+      for (let i = 0; i < providerConfig.keys.length; i++) {
+        const key = providerConfig.keys[i];
+        const keyId = this.cooldownKey('keys', provider, i);
+        if (key.key && !this.isKeyUnavailable(keyId)) {
+          this.activeKeys.set(provider, i);
+          return { tier: 'keys', provider, keyIndex: i, label: key.label };
+        }
+      }
+      return undefined;
+    };
+
+    if (tier === 'oauth') return tryOAuth();
+    if (tier === 'keys') return tryKeys();
+    return tryOAuth() ?? tryKeys();
   }
 
   /**
    * Check if a specific key is currently in cooldown.
    * Used by AgentHost to detect when another agent has already put its key in cooldown.
+   *
+   * @param tier - defaults to 'keys' for backward compatibility
    */
-  isKeyInCooldown(provider: LlmProvider, keyIndex: number): boolean {
-    return this.isKeyUnavailable(`${provider}:${keyIndex}`);
+  isKeyInCooldown(provider: LlmProvider, keyIndex: number, tier: AuthTier = 'keys'): boolean {
+    return this.isKeyUnavailable(this.cooldownKey(tier, provider, keyIndex));
   }
 
   /**
@@ -174,16 +232,18 @@ export class AuthResolver {
    * @param reason - Why it failed (determines cooldown duration for rate_limit)
    * @param errorMessage - Original API error message for logging
    * @param keyIndex - The specific key index that failed (avoids stale global state when multiple agents share the resolver)
+   * @param tier - Which tier the key belongs to (defaults to 'keys' for backward compatibility)
    * @returns true if there's a fallback available (next key or next provider)
    */
   markKeyFailed(
     provider: LlmProvider,
     reason: 'auth' | 'rate_limit' | 'transient' = 'transient',
     errorMessage?: string,
-    keyIndex?: number
+    keyIndex?: number,
+    tier: AuthTier = 'keys'
   ): boolean {
     const currentIndex = keyIndex ?? this.activeKeys.get(provider) ?? 0;
-    const keyId = `${provider}:${currentIndex}`;
+    const keyId = this.cooldownKey(tier, provider, currentIndex);
 
     if (!this.cooldowns.has(keyId)) {
       const now = Date.now();
@@ -200,26 +260,8 @@ export class AuthResolver {
       log.info(`[AuthResolver] Key ${keyId} already in cooldown, skipping`);
     }
 
-    // Try to find next valid key for this provider
-    const nextKey = this.getFirstValidKey(provider);
-    if (nextKey) {
-      log.info(`[AuthResolver] Switching to next key for ${provider}`);
-      return true;
-    }
-
-    // No more keys for this provider, check if there are fallback providers
-    const currentProviderIndex = this.providerOrder.indexOf(provider);
-    for (let i = currentProviderIndex + 1; i < this.providerOrder.length; i++) {
-      const fallbackProvider = this.providerOrder[i];
-      const fallbackKey = this.getFirstValidKey(fallbackProvider);
-      if (fallbackKey) {
-        log.info(`[AuthResolver] Falling back to provider: ${fallbackProvider}`);
-        return true;
-      }
-    }
-
-    log.info('[AuthResolver] No more fallback keys available');
-    return false;
+    // Walk forward through tiers/providers/keys to confirm something is still available
+    return this.getActiveCredential() !== undefined;
   }
 
   /**
@@ -227,13 +269,7 @@ export class AuthResolver {
    * Returns undefined if no providers are available.
    */
   getNextProvider(): LlmProvider | undefined {
-    for (const provider of this.providerOrder) {
-      const key = this.getActiveKey(provider);
-      if (key) {
-        return provider;
-      }
-    }
-    return undefined;
+    return this.getActiveCredential()?.provider;
   }
 
   /**
@@ -283,21 +319,24 @@ export class AuthResolver {
 
   /**
    * Create a Pi SDK AuthStorage with current active keys.
-   * The AuthStorage will have one key per provider (the currently active one).
+   * For providers in the OAuth tier, uses the OAuth access token.
+   * For providers in the keys tier, uses the API key.
    */
   createAuthStorage(): AuthStorage {
     const data: Record<string, { type: 'api_key'; key: string }> = {};
 
-    for (const provider of Object.keys(this.config.providers) as LlmProvider[]) {
-      const providerConfig = this.config.providers[provider];
-      if (!providerConfig) continue;
-
-      const activeKey = this.getActiveKey(provider);
-      if (activeKey) {
-        const key = providerConfig.keys[activeKey.keyIndex];
-        if (key?.key) {
-          data[provider] = { type: 'api_key', key: key.key };
-        }
+    const providersInScope = new Set<LlmProvider>([...this.oauthOrder, ...this.keysOrder]);
+    for (const provider of providersInScope) {
+      const active = this.getActiveKey(provider);
+      if (!active) continue;
+      let keyValue: string | undefined;
+      if (active.tier === 'oauth') {
+        keyValue = this.oauthCredentials[provider]?.access;
+      } else {
+        keyValue = this.config.providers[provider]?.keys[active.keyIndex]?.key;
+      }
+      if (keyValue) {
+        data[provider] = { type: 'api_key', key: keyValue };
       }
     }
 

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -2869,4 +2869,113 @@ describe('AgentHost', () => {
       expect(internal.handleContextOverflow).not.toHaveBeenCalled();
     });
   });
+
+  describe('currentTier tracking', () => {
+    it('initializes currentTier as "oauth" when active credential is from OAuth tier', async () => {
+      const { AuthResolver } = await import('./auth-resolver.js');
+
+      // Build a config that has both an OAuth tier (anthropic) and a keys tier (cerebras)
+      const llmConfig = {
+        primary: 'cerebras' as const,
+        fallback: [],
+        providers: {
+          cerebras: { keys: [{ key: 'cer-key-1', label: 'main' }] },
+        },
+        oauth: { primary: 'anthropic' as const, fallback: [] },
+      };
+
+      // Provide a non-expiring OAuth credential so the OAuth tier is active
+      const oauthCred = {
+        access: 'sk-ant-oat01-test',
+        refresh: 'sk-ant-ort01-test',
+        expires: Date.now() + 60 * 60 * 1000, // 1 hour from now
+        label: 'Pro',
+      };
+      const authResolver = new AuthResolver(llmConfig, undefined, { anthropic: oauthCred });
+
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig,
+        authResolver,
+      });
+
+      const internal = host as unknown as {
+        currentTier: string;
+        currentProvider: string;
+      };
+
+      expect(internal.currentTier).toBe('oauth');
+      expect(internal.currentProvider).toBe('anthropic');
+    });
+
+    it('initializes currentTier as "keys" when no OAuth credentials are present', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const internal = host as unknown as { currentTier: string };
+      expect(internal.currentTier).toBe('keys');
+    });
+
+    it('markKeyFailed uses oauth cooldown key when currentTier is "oauth"', async () => {
+      const { AuthResolver } = await import('./auth-resolver.js');
+
+      const llmConfig = {
+        primary: 'cerebras' as const,
+        fallback: [],
+        providers: {
+          cerebras: { keys: [{ key: 'cer-key-1', label: 'main' }] },
+        },
+        oauth: { primary: 'anthropic' as const, fallback: [] },
+      };
+
+      const oauthCred = {
+        access: 'sk-ant-oat01-test',
+        refresh: 'sk-ant-ort01-test',
+        expires: Date.now() + 60 * 60 * 1000,
+        label: 'Pro',
+      };
+      const authResolver = new AuthResolver(llmConfig, undefined, { anthropic: oauthCred });
+
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig,
+        authResolver,
+      });
+
+      const internal = host as unknown as {
+        handlePotentialError: (event: unknown) => Promise<void>;
+        currentProvider: string;
+        currentKeyIndex: number;
+        currentTier: string;
+        authResolver: import('./auth-resolver.js').AuthResolver;
+        reinitializeWithProvider: ReturnType<typeof vi.fn>;
+        session: unknown;
+      };
+
+      internal.session = { prompt: vi.fn() };
+      internal.reinitializeWithProvider = vi.fn().mockResolvedValue(undefined);
+
+      // Confirm tier is oauth before the error
+      expect(internal.currentTier).toBe('oauth');
+
+      // Fire an auth error — goes straight to failover (no retries for auth)
+      await internal.handlePotentialError({
+        type: 'message_end',
+        message: { stopReason: 'error', errorMessage: 'Error 401: Unauthorized - Invalid API key' },
+      });
+
+      // The OAuth credential for anthropic:0 should now be in cooldown under the oauth key
+      expect(internal.authResolver.isKeyInCooldown('anthropic', 0, 'oauth')).toBe(true);
+      // And NOT under the keys key (different namespace)
+      expect(internal.authResolver.isKeyInCooldown('anthropic', 0, 'keys')).toBe(false);
+    });
+  });
 });

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -3036,15 +3036,18 @@ describe('AgentHost', () => {
     it('refreshes token and retries via reinitializeWithProvider when ensureFresh succeeds', async () => {
       const { internal, authResolver } = await makeOAuthHost();
 
-      // Stub ensureFresh to succeed (return empty set — no providers were refreshed)
-      vi.spyOn(authResolver, 'ensureFresh').mockResolvedValue(new Set());
+      // Stub ensureFresh to succeed and return a set containing the current provider
+      vi.spyOn(authResolver, 'ensureFresh').mockResolvedValue(new Set(['anthropic']));
       // Stub markKeyFailed to track calls
       const markKeyFailedSpy = vi.spyOn(authResolver, 'markKeyFailed');
 
       await internal.handlePotentialError(auth401Event);
 
-      // ensureFresh was called
+      // ensureFresh was called with force: [currentProvider]
       expect(authResolver.ensureFresh).toHaveBeenCalledOnce();
+      expect(authResolver.ensureFresh).toHaveBeenCalledWith(
+        expect.objectContaining({ force: ['anthropic'] })
+      );
       // reinitializeWithProvider was called with the same provider (refresh-and-retry path)
       expect(internal.reinitializeWithProvider).toHaveBeenCalledOnce();
       expect(internal.reinitializeWithProvider).toHaveBeenCalledWith(
@@ -3056,6 +3059,23 @@ describe('AgentHost', () => {
       );
       // markKeyFailed must NOT have been called — we didn't fail over
       expect(markKeyFailedSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls through to standard failover when ensureFresh returns set NOT containing current provider', async () => {
+      const { internal, authResolver } = await makeOAuthHost();
+
+      // Stub ensureFresh to return empty set (refresh was a no-op, e.g. concurrent lock ran first)
+      vi.spyOn(authResolver, 'ensureFresh').mockResolvedValue(new Set());
+      const markKeyFailedSpy = vi.spyOn(authResolver, 'markKeyFailed').mockReturnValue(false);
+
+      await internal.handlePotentialError(auth401Event);
+
+      // ensureFresh was called
+      expect(authResolver.ensureFresh).toHaveBeenCalledOnce();
+      // reinitializeWithProvider must NOT have been called — provider not in refreshed set
+      expect(internal.reinitializeWithProvider).not.toHaveBeenCalled();
+      // Should have fallen through to markKeyFailed (standard failover)
+      expect(markKeyFailedSpy).toHaveBeenCalledOnce();
     });
 
     it('falls through to standard failover (markKeyFailed) when ensureFresh throws', async () => {
@@ -3076,8 +3096,8 @@ describe('AgentHost', () => {
     it('calls markKeyFailed (no second refresh) when refresh succeeds but retry also returns 401', async () => {
       const { internal, authResolver } = await makeOAuthHost();
 
-      // First 401: ensureFresh succeeds → oauthRefreshAttempted is set to true
-      vi.spyOn(authResolver, 'ensureFresh').mockResolvedValue(new Set());
+      // First 401: ensureFresh succeeds and returns the current provider in the set
+      vi.spyOn(authResolver, 'ensureFresh').mockResolvedValue(new Set(['anthropic']));
       const markKeyFailedSpy = vi.spyOn(authResolver, 'markKeyFailed').mockReturnValue(false);
 
       await internal.handlePotentialError(auth401Event);

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -2955,6 +2955,7 @@ describe('AgentHost', () => {
         currentProvider: string;
         currentKeyIndex: number;
         currentTier: string;
+        oauthRefreshAttempted: boolean;
         authResolver: import('./auth-resolver.js').AuthResolver;
         reinitializeWithProvider: ReturnType<typeof vi.fn>;
         session: unknown;
@@ -2962,11 +2963,13 @@ describe('AgentHost', () => {
 
       internal.session = { prompt: vi.fn() };
       internal.reinitializeWithProvider = vi.fn().mockResolvedValue(undefined);
+      // Skip the refresh-and-retry branch so we test the markKeyFailed path directly.
+      internal.oauthRefreshAttempted = true;
 
       // Confirm tier is oauth before the error
       expect(internal.currentTier).toBe('oauth');
 
-      // Fire an auth error — goes straight to failover (no retries for auth)
+      // Fire an auth error — goes straight to failover (refresh already attempted)
       await internal.handlePotentialError({
         type: 'message_end',
         message: { stopReason: 'error', errorMessage: 'Error 401: Unauthorized - Invalid API key' },
@@ -2976,6 +2979,98 @@ describe('AgentHost', () => {
       expect(internal.authResolver.isKeyInCooldown('anthropic', 0, 'oauth')).toBe(true);
       // And NOT under the keys key (different namespace)
       expect(internal.authResolver.isKeyInCooldown('anthropic', 0, 'keys')).toBe(false);
+    });
+  });
+
+  describe('OAuth refresh-and-retry on 401', () => {
+    async function makeOAuthHost() {
+      const { AuthResolver } = await import('./auth-resolver.js');
+
+      const llmConfig = {
+        primary: 'cerebras' as const,
+        fallback: [],
+        providers: {
+          cerebras: { keys: [{ key: 'cer-key-1', label: 'main' }] },
+        },
+        oauth: { primary: 'anthropic' as const, fallback: [] },
+      };
+
+      const oauthCred = {
+        access: 'sk-ant-oat01-test',
+        refresh: 'sk-ant-ort01-test',
+        expires: Date.now() + 60 * 60 * 1000,
+        label: 'Pro',
+      };
+
+      const authResolver = new AuthResolver(llmConfig, undefined, { anthropic: oauthCred });
+
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig,
+        authResolver,
+      });
+
+      const internal = host as unknown as {
+        handlePotentialError: (event: unknown) => Promise<void>;
+        currentProvider: string;
+        currentTier: string;
+        oauthRefreshAttempted: boolean;
+        authResolver: import('./auth-resolver.js').AuthResolver;
+        reinitializeWithProvider: ReturnType<typeof vi.fn>;
+        session: unknown;
+      };
+
+      internal.session = { prompt: vi.fn() };
+      internal.reinitializeWithProvider = vi.fn().mockResolvedValue(undefined);
+
+      return { host, internal, authResolver };
+    }
+
+    const auth401Event = {
+      type: 'message_end',
+      message: { stopReason: 'error', errorMessage: 'Error 401: Unauthorized - Invalid API key' },
+    };
+
+    it('refreshes token and retries via reinitializeWithProvider when ensureFresh succeeds', async () => {
+      const { internal, authResolver } = await makeOAuthHost();
+
+      // Stub ensureFresh to succeed (return empty set — no providers were refreshed)
+      vi.spyOn(authResolver, 'ensureFresh').mockResolvedValue(new Set());
+      // Stub markKeyFailed to track calls
+      const markKeyFailedSpy = vi.spyOn(authResolver, 'markKeyFailed');
+
+      await internal.handlePotentialError(auth401Event);
+
+      // ensureFresh was called
+      expect(authResolver.ensureFresh).toHaveBeenCalledOnce();
+      // reinitializeWithProvider was called with the same provider (refresh-and-retry path)
+      expect(internal.reinitializeWithProvider).toHaveBeenCalledOnce();
+      expect(internal.reinitializeWithProvider).toHaveBeenCalledWith(
+        'anthropic',
+        null, // pendingPrompt (no prompt was queued)
+        [], // pendingDeliveries (none queued)
+        'OAuth token refreshed',
+        expect.stringContaining('anthropic OAuth credential')
+      );
+      // markKeyFailed must NOT have been called — we didn't fail over
+      expect(markKeyFailedSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls through to standard failover (markKeyFailed) when ensureFresh throws', async () => {
+      const { internal, authResolver } = await makeOAuthHost();
+
+      // Stub ensureFresh to fail
+      vi.spyOn(authResolver, 'ensureFresh').mockRejectedValue(new Error('refresh_token_expired'));
+      const markKeyFailedSpy = vi.spyOn(authResolver, 'markKeyFailed').mockReturnValue(false);
+
+      await internal.handlePotentialError(auth401Event);
+
+      // ensureFresh was attempted
+      expect(authResolver.ensureFresh).toHaveBeenCalledOnce();
+      // Should have fallen through to markKeyFailed (standard auth-failure path)
+      expect(markKeyFailedSpy).toHaveBeenCalledOnce();
     });
   });
 });

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -3072,5 +3072,31 @@ describe('AgentHost', () => {
       // Should have fallen through to markKeyFailed (standard auth-failure path)
       expect(markKeyFailedSpy).toHaveBeenCalledOnce();
     });
+
+    it('calls markKeyFailed (no second refresh) when refresh succeeds but retry also returns 401', async () => {
+      const { internal, authResolver } = await makeOAuthHost();
+
+      // First 401: ensureFresh succeeds → oauthRefreshAttempted is set to true
+      vi.spyOn(authResolver, 'ensureFresh').mockResolvedValue(new Set());
+      const markKeyFailedSpy = vi.spyOn(authResolver, 'markKeyFailed').mockReturnValue(false);
+
+      await internal.handlePotentialError(auth401Event);
+
+      // Refresh succeeded: ensureFresh called once, reinitialize triggered, no failover yet
+      expect(authResolver.ensureFresh).toHaveBeenCalledOnce();
+      expect(internal.reinitializeWithProvider).toHaveBeenCalledOnce();
+      expect(markKeyFailedSpy).not.toHaveBeenCalled();
+      // Guard flag is now set
+      expect(internal.oauthRefreshAttempted).toBe(true);
+
+      // Second 401 arrives (simulates the retried request also failing with 401).
+      // oauthRefreshAttempted is already true → no second refresh, fall through to markKeyFailed.
+      await internal.handlePotentialError(auth401Event);
+
+      // ensureFresh must NOT have been called a second time
+      expect(authResolver.ensureFresh).toHaveBeenCalledOnce();
+      // markKeyFailed must be called — standard failover path
+      expect(markKeyFailedSpy).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -42,7 +42,9 @@ import { resolveProjectDir } from '../projects/dir.js'; // used for backfilling 
 import type { ReminderManager } from '../reminders/manager.js';
 import { filterByRole } from '../skills/loader.js';
 import { log } from '../utils/logger.js';
+import type { AuthTier } from './auth-resolver.js';
 import { AuthResolver } from './auth-resolver.js';
+import { refreshAnthropic } from './oauth.js';
 import type { AgentRegistry } from './registry.js';
 import {
   calculateDelay,
@@ -163,6 +165,7 @@ export class AgentHost {
   private listeners: Set<(event: AgentSessionEvent) => void> = new Set();
   private currentProvider: LlmProvider;
   private currentKeyIndex = 0;
+  private currentTier: AuthTier = 'keys';
   private retryAttempts: Map<string, number> = new Map(); // Track retries per error type
   private isReinitializing = false;
   private pendingPrompt: string | null = null;
@@ -220,8 +223,10 @@ export class AgentHost {
     this.authResolver = config.authResolver ?? new AuthResolver(config.llmConfig);
     const authStorage = this.authResolver.createAuthStorage();
     this.modelRegistry = new ModelRegistry(authStorage);
-    this.currentProvider = this.authResolver.primaryProvider;
-    this.currentKeyIndex = this.authResolver.getActiveKey(this.currentProvider)?.keyIndex ?? 0;
+    const activeCred = this.authResolver.getActiveCredential();
+    this.currentProvider = activeCred?.provider ?? this.authResolver.primaryProvider;
+    this.currentKeyIndex = activeCred?.keyIndex ?? 0;
+    this.currentTier = activeCred?.tier ?? 'keys';
 
     log.info('[AgentHost] Auth status:', this.authResolver.getStatus());
   }
@@ -461,6 +466,21 @@ export class AgentHost {
     // files that lack a valid session header, which continueRecent() would reject and
     // silently replace with a new empty session. Fall back to continueRecent() only
     // when no .jsonl file exists at all (first-time setup).
+    // Refresh near-expiry OAuth tokens before snapshotting auth state into the SDK.
+    try {
+      await this.authResolver.ensureFresh({ refresh: refreshAnthropic });
+    } catch (err) {
+      log.warn('[AgentHost] OAuth refresh failed during initialize:', err);
+      // Fall through with possibly-stale token; SDK will return 401 → handlePotentialError refreshes again.
+    }
+    // Re-read active credential in case ensureFresh changed which credential is active
+    const cred = this.authResolver.getActiveCredential();
+    if (cred) {
+      this.currentTier = cred.tier;
+      // currentProvider was already resolved above; only update tier and keyIndex
+      this.currentKeyIndex = cred.keyIndex;
+    }
+
     const latestSession = findMostRecentSession(agentSessionDir);
     const sessionManager = latestSession
       ? SessionManager.open(latestSession, agentSessionDir)
@@ -599,7 +619,13 @@ export class AgentHost {
     // If another agent already put our key in cooldown, skip retries and reinitialize.
     // Uses the tracked key index so we check our actual key, not whatever index
     // another agent may have rotated to.
-    if (this.authResolver.isKeyInCooldown(this.currentProvider, this.currentKeyIndex)) {
+    if (
+      this.authResolver.isKeyInCooldown(
+        this.currentProvider,
+        this.currentKeyIndex,
+        this.currentTier
+      )
+    ) {
       const nextProvider = this.authResolver.getNextProvider();
       if (nextProvider) {
         const reason =
@@ -711,7 +737,8 @@ export class AgentHost {
         this.currentProvider,
         failureReason,
         errorMessage,
-        this.currentKeyIndex
+        this.currentKeyIndex,
+        this.currentTier
       );
 
       if (hasMore) {
@@ -872,11 +899,18 @@ export class AgentHost {
       // Update current provider and key index
       this.currentProvider = provider;
       this.currentKeyIndex = this.authResolver.getActiveKey(provider)?.keyIndex ?? 0;
+      this.currentTier = this.authResolver.getActiveKey(provider)?.tier ?? 'keys';
 
       // Push chat message before init so the user sees the reason even if
       // initialization fails. Only for actual failovers, not compaction recovery.
       if (reason) {
         this.pushSystemMessage(detail ? `${reason}\n\n${detail}` : reason);
+      }
+
+      try {
+        await this.authResolver.ensureFresh({ refresh: refreshAnthropic });
+      } catch (err) {
+        log.warn('[AgentHost] OAuth refresh failed during reinitialize:', err);
       }
 
       // Recreate model registry with updated auth

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -624,19 +624,33 @@ export class AgentHost {
     // OAuth refresh-and-retry: 401 from an OAuth-tier credential should refresh once
     // before failing over. Refresh updates in-memory tokens; reinitialize the session
     // so the SDK picks up the new access token.
+    //
+    // We force-refresh the current provider because the token may have been server-side
+    // revoked while still appearing fresh locally (expires far in the future). If the
+    // refresh didn't actually happen (provider not in returned set), skip the retry and
+    // fall through to standard failover instead of burning a round-trip with the same token.
     if (category === 'auth' && this.currentTier === 'oauth' && !this.oauthRefreshAttempted) {
       this.oauthRefreshAttempted = true;
       try {
-        await this.authResolver.ensureFresh({ refresh: refreshAnthropic });
-        log.info('[AgentHost] OAuth token refreshed after 401, retrying via reinitialize');
-        await this.reinitializeWithProvider(
-          this.currentProvider,
-          promptToRetry,
-          deliveriesToRetry,
-          'OAuth token refreshed',
-          `401 on ${this.currentProvider} OAuth credential, refreshed and retrying`
-        );
-        return;
+        const refreshed = await this.authResolver.ensureFresh({
+          refresh: refreshAnthropic,
+          force: [this.currentProvider],
+        });
+        if (refreshed.has(this.currentProvider)) {
+          log.info('[AgentHost] OAuth token refreshed after 401, retrying via reinitialize');
+          await this.reinitializeWithProvider(
+            this.currentProvider,
+            promptToRetry,
+            deliveriesToRetry,
+            'OAuth token refreshed',
+            `401 on ${this.currentProvider} OAuth credential, refreshed and retrying`
+          );
+          return;
+        }
+        // ensureFresh completed but did not refresh the current provider (e.g., the
+        // concurrent lock already ran and still couldn't refresh, or the credential
+        // disappeared). Fall through to standard failover to avoid a wasted retry.
+        log.warn('[AgentHost] OAuth refresh after 401 was a no-op, falling over');
       } catch (refreshErr) {
         log.warn('[AgentHost] OAuth refresh failed after 401, falling over:', refreshErr);
         // Fall through to standard auth-failure handling below

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -185,6 +185,7 @@ export class AgentHost {
   private resourceLoader: DefaultResourceLoader | null = null;
   private busy = false;
   private lastTurnErrored = false;
+  private oauthRefreshAttempted = false;
   private deliverySendCount = 0;
   private compactionCount = 0;
   private compactionDepth = 0;
@@ -559,6 +560,9 @@ export class AgentHost {
           if (completed) completed.resolve();
         }
         this.deliverySendCount = 0;
+        // Re-arm the OAuth refresh guard so a future 401 on a fresh token can
+        // trigger another refresh attempt.
+        this.oauthRefreshAttempted = false;
       }
       this.lastTurnErrored = false;
     }
@@ -615,6 +619,28 @@ export class AgentHost {
     // Reset the send counter: the failed turn's sends are abandoned.
     // The retry/failover path will re-send and re-increment as needed.
     this.deliverySendCount = 0;
+
+    // OAuth refresh-and-retry: 401 from an OAuth-tier credential should refresh once
+    // before failing over. Refresh updates in-memory tokens; reinitialize the session
+    // so the SDK picks up the new access token.
+    if (category === 'auth' && this.currentTier === 'oauth' && !this.oauthRefreshAttempted) {
+      this.oauthRefreshAttempted = true;
+      try {
+        await this.authResolver.ensureFresh({ refresh: refreshAnthropic });
+        log.info('[AgentHost] OAuth token refreshed after 401, retrying via reinitialize');
+        await this.reinitializeWithProvider(
+          this.currentProvider,
+          promptToRetry,
+          deliveriesToRetry,
+          'OAuth token refreshed',
+          `401 on ${this.currentProvider} OAuth credential, refreshed and retrying`
+        );
+        return;
+      } catch (refreshErr) {
+        log.warn('[AgentHost] OAuth refresh failed after 401, falling over:', refreshErr);
+        // Fall through to standard auth-failure handling below
+      }
+    }
 
     // If another agent already put our key in cooldown, skip retries and reinitialize.
     // Uses the tracked key index so we check our actual key, not whatever index

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -474,8 +474,9 @@ export class AgentHost {
       log.warn('[AgentHost] OAuth refresh failed during initialize:', err);
       // Fall through with possibly-stale token; SDK will return 401 → handlePotentialError refreshes again.
     }
-    // Re-read active credential in case ensureFresh changed which credential is active
-    const cred = this.authResolver.getActiveCredential();
+    // Re-read active credential in case ensureFresh changed which credential is active.
+    // Use getActiveKey(provider) to stay scoped to the current provider, not a system-wide credential.
+    const cred = this.authResolver.getActiveKey(this.currentProvider);
     if (cred) {
       this.currentTier = cred.tier;
       // currentProvider was already resolved above; only update tier and keyIndex

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -468,6 +468,10 @@ export class AgentHost {
     // silently replace with a new empty session. Fall back to continueRecent() only
     // when no .jsonl file exists at all (first-time setup).
     // Refresh near-expiry OAuth tokens before snapshotting auth state into the SDK.
+    // `refreshAnthropic` is currently the only OAuth refresh implementation. server.ts
+    // validates that [llm.oauth] only contains supported providers; if support for
+    // additional OAuth providers is added, this should be extended into a refresh map
+    // keyed by provider.
     try {
       await this.authResolver.ensureFresh({ refresh: refreshAnthropic });
     } catch (err) {

--- a/src/server/agents/oauth-credentials.test.ts
+++ b/src/server/agents/oauth-credentials.test.ts
@@ -1,0 +1,53 @@
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadOAuthCredentials, saveOAuthCredentials } from './oauth-credentials.js';
+
+describe('oauth-credentials', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'system2-oauth-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns null when credentials file does not exist', () => {
+    expect(loadOAuthCredentials(dir, 'anthropic')).toBeNull();
+  });
+
+  it('round-trips credentials per provider', () => {
+    const creds = {
+      access: 'sk-ant-oat-abc',
+      refresh: 'rt-xyz',
+      expires: 1714680000000,
+      label: 'claude-pro',
+    };
+    saveOAuthCredentials(dir, 'anthropic', creds);
+    expect(loadOAuthCredentials(dir, 'anthropic')).toEqual(creds);
+    expect(loadOAuthCredentials(dir, 'openai')).toBeNull();
+  });
+
+  it('writes file with mode 0600', () => {
+    saveOAuthCredentials(dir, 'anthropic', { access: 'a', refresh: 'b', expires: 1, label: 'l' });
+    const mode = statSync(join(dir, 'oauth', 'anthropic.json')).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it('returns null when file is corrupt JSON', async () => {
+    const { mkdirSync, writeFileSync } = await import('node:fs');
+    mkdirSync(join(dir, 'oauth'), { recursive: true });
+    writeFileSync(join(dir, 'oauth', 'anthropic.json'), '{not json');
+    expect(loadOAuthCredentials(dir, 'anthropic')).toBeNull();
+  });
+
+  it('returns null when file is missing required fields', async () => {
+    const { mkdirSync, writeFileSync } = await import('node:fs');
+    mkdirSync(join(dir, 'oauth'), { recursive: true });
+    writeFileSync(join(dir, 'oauth', 'anthropic.json'), JSON.stringify({ access: 'a' }));
+    expect(loadOAuthCredentials(dir, 'anthropic')).toBeNull();
+  });
+});

--- a/src/server/agents/oauth-credentials.test.ts
+++ b/src/server/agents/oauth-credentials.test.ts
@@ -45,6 +45,19 @@ describe('oauth-credentials', () => {
     expect(mode).toBe(0o600);
   });
 
+  it('enforces 0700 on the oauth directory', async () => {
+    const { mkdirSync, statSync } = await import('node:fs');
+    // Pre-create the directory with a looser mode
+    mkdirSync(join(dir, 'oauth'), { recursive: true, mode: 0o755 });
+    saveOAuthCredentials(dir, 'anthropic', { access: 'a', refresh: 'b', expires: 1, label: 'l' });
+    if (process.platform === 'win32') {
+      expect(statSync(join(dir, 'oauth')).isDirectory()).toBe(true);
+      return;
+    }
+    const mode = statSync(join(dir, 'oauth')).mode & 0o777;
+    expect(mode).toBe(0o700);
+  });
+
   it('returns null when file is corrupt JSON', async () => {
     const { mkdirSync, writeFileSync } = await import('node:fs');
     mkdirSync(join(dir, 'oauth'), { recursive: true });

--- a/src/server/agents/oauth-credentials.test.ts
+++ b/src/server/agents/oauth-credentials.test.ts
@@ -33,7 +33,15 @@ describe('oauth-credentials', () => {
 
   it('writes file with mode 0600', () => {
     saveOAuthCredentials(dir, 'anthropic', { access: 'a', refresh: 'b', expires: 1, label: 'l' });
-    const mode = statSync(join(dir, 'oauth', 'anthropic.json')).mode & 0o777;
+    const stats = statSync(join(dir, 'oauth', 'anthropic.json'));
+
+    if (process.platform === 'win32') {
+      // POSIX mode bits aren't reliably supported on Windows
+      expect(stats.isFile()).toBe(true);
+      return;
+    }
+
+    const mode = stats.mode & 0o777;
     expect(mode).toBe(0o600);
   });
 

--- a/src/server/agents/oauth-credentials.ts
+++ b/src/server/agents/oauth-credentials.ts
@@ -54,7 +54,14 @@ export function saveOAuthCredentials(
     chmodSync(dir, 0o700); // idempotent; protects against loose perms on pre-existing dir
   }
   const finalPath = credentialsPath(system2Dir, provider);
-  const tmpPath = `${finalPath}.tmp`;
-  writeFileSync(tmpPath, JSON.stringify(credentials, null, 2), { mode: 0o600 });
-  renameSync(tmpPath, finalPath);
+  const data = JSON.stringify(credentials, null, 2);
+  if (process.platform === 'win32') {
+    // Windows rename can fail when the destination already exists; write directly
+    // instead (sacrificing atomicity, which Windows file APIs don't reliably provide anyway).
+    writeFileSync(finalPath, data, { mode: 0o600 });
+  } else {
+    const tmpPath = `${finalPath}.tmp`;
+    writeFileSync(tmpPath, data, { mode: 0o600 });
+    renameSync(tmpPath, finalPath);
+  }
 }

--- a/src/server/agents/oauth-credentials.ts
+++ b/src/server/agents/oauth-credentials.ts
@@ -1,0 +1,56 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { LlmProvider } from '../../shared/index.js';
+import { log } from '../utils/logger.js';
+
+export interface OAuthCredentials {
+  access: string;
+  refresh: string;
+  /** Epoch ms when access token expires (already includes pi-ai's 5 min safety buffer). */
+  expires: number;
+  label: string;
+}
+
+const OAUTH_DIR = 'oauth';
+
+function credentialsPath(system2Dir: string, provider: LlmProvider): string {
+  return join(system2Dir, OAUTH_DIR, `${provider}.json`);
+}
+
+export function loadOAuthCredentials(
+  system2Dir: string,
+  provider: LlmProvider
+): OAuthCredentials | null {
+  const path = credentialsPath(system2Dir, provider);
+  if (!existsSync(path)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as OAuthCredentials;
+    if (
+      typeof parsed.access !== 'string' ||
+      typeof parsed.refresh !== 'string' ||
+      typeof parsed.expires !== 'number' ||
+      typeof parsed.label !== 'string'
+    ) {
+      log.warn(`[oauth-credentials] ${provider}.json missing required fields, ignoring`);
+      return null;
+    }
+    return parsed;
+  } catch (err) {
+    log.warn(`[oauth-credentials] Failed to parse ${provider}.json:`, err);
+    return null;
+  }
+}
+
+export function saveOAuthCredentials(
+  system2Dir: string,
+  provider: LlmProvider,
+  credentials: OAuthCredentials
+): void {
+  const dir = join(system2Dir, OAUTH_DIR);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+  }
+  writeFileSync(credentialsPath(system2Dir, provider), JSON.stringify(credentials, null, 2), {
+    mode: 0o600,
+  });
+}

--- a/src/server/agents/oauth-credentials.ts
+++ b/src/server/agents/oauth-credentials.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { LlmProvider } from '../../shared/index.js';
 import { log } from '../utils/logger.js';
@@ -50,7 +50,11 @@ export function saveOAuthCredentials(
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
-  writeFileSync(credentialsPath(system2Dir, provider), JSON.stringify(credentials, null, 2), {
-    mode: 0o600,
-  });
+  if (process.platform !== 'win32') {
+    chmodSync(dir, 0o700); // idempotent; protects against loose perms on pre-existing dir
+  }
+  const finalPath = credentialsPath(system2Dir, provider);
+  const tmpPath = `${finalPath}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(credentials, null, 2), { mode: 0o600 });
+  renameSync(tmpPath, finalPath);
 }

--- a/src/server/agents/oauth-flow.test.ts
+++ b/src/server/agents/oauth-flow.test.ts
@@ -40,10 +40,10 @@ describe('OAuth end-to-end flow', () => {
     });
 
     const loaded = loadOAuthCredentials(tmpDir, 'anthropic');
-    expect(loaded).not.toBeNull();
+    if (!loaded) throw new Error('expected credentials to load');
 
     const resolver = new AuthResolver(makeTwoTierConfig(), undefined, {
-      anthropic: loaded!,
+      anthropic: loaded,
     });
 
     resolver.setPersistOAuth('anthropic', async (creds) => {
@@ -78,8 +78,10 @@ describe('OAuth end-to-end flow', () => {
       expires: Date.now() + 60 * 60_000,
       label: 'claude-pro',
     });
+    const loaded = loadOAuthCredentials(tmpDir, 'anthropic');
+    if (!loaded) throw new Error('expected credentials to load');
     const resolver = new AuthResolver(makeTwoTierConfig(), undefined, {
-      anthropic: loadOAuthCredentials(tmpDir, 'anthropic')!,
+      anthropic: loaded,
     });
 
     expect(resolver.getActiveCredential()?.tier).toBe('oauth');
@@ -109,9 +111,12 @@ describe('OAuth end-to-end flow', () => {
       expires: Date.now() + 60 * 60_000,
       label: 'codex',
     });
+    const a = loadOAuthCredentials(tmpDir, 'anthropic');
+    const o = loadOAuthCredentials(tmpDir, 'openai');
+    if (!a || !o) throw new Error('expected credentials to load');
     const resolver = new AuthResolver(cfg, undefined, {
-      anthropic: loadOAuthCredentials(tmpDir, 'anthropic')!,
-      openai: loadOAuthCredentials(tmpDir, 'openai')!,
+      anthropic: a,
+      openai: o,
     });
 
     expect(resolver.getActiveCredential()).toMatchObject({

--- a/src/server/agents/oauth-flow.test.ts
+++ b/src/server/agents/oauth-flow.test.ts
@@ -1,0 +1,128 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LlmConfig } from '../../shared/index.js';
+import { AuthResolver } from './auth-resolver.js';
+import { loadOAuthCredentials, saveOAuthCredentials } from './oauth-credentials.js';
+
+function makeTwoTierConfig(): LlmConfig {
+  return {
+    primary: 'anthropic',
+    fallback: ['openai'],
+    providers: {
+      anthropic: { keys: [{ key: 'sk-ant-api03-fallback', label: 'api-fallback' }] },
+      openai: { keys: [{ key: 'oai-1', label: 'main' }] },
+    },
+    oauth: { primary: 'anthropic', fallback: [] },
+  };
+}
+
+describe('OAuth end-to-end flow', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'system2-oauth-e2e-'));
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  it('loads, refreshes, persists, and prefers OAuth tier over keys tier', async () => {
+    saveOAuthCredentials(tmpDir, 'anthropic', {
+      access: 'sk-ant-oat-old',
+      refresh: 'rt-1',
+      expires: Date.now() + 60_000,
+      label: 'claude-pro',
+    });
+
+    const loaded = loadOAuthCredentials(tmpDir, 'anthropic');
+    expect(loaded).not.toBeNull();
+
+    const resolver = new AuthResolver(makeTwoTierConfig(), undefined, {
+      anthropic: loaded!,
+    });
+
+    resolver.setPersistOAuth('anthropic', async (creds) => {
+      saveOAuthCredentials(tmpDir, 'anthropic', creds);
+    });
+
+    let active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('oauth');
+    expect(active?.label).toBe('claude-pro');
+
+    const fakeRefresh = vi.fn(async () => ({
+      access: 'sk-ant-oat-new',
+      refresh: 'rt-2',
+      expires: Date.now() + 60 * 60_000,
+    }));
+    const refreshed = await resolver.ensureFresh({ refresh: fakeRefresh });
+    expect(refreshed.has('anthropic')).toBe(true);
+    expect(fakeRefresh).toHaveBeenCalledOnce();
+
+    const reloaded = loadOAuthCredentials(tmpDir, 'anthropic');
+    expect(reloaded?.access).toBe('sk-ant-oat-new');
+    expect(reloaded?.refresh).toBe('rt-2');
+
+    active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('oauth');
+  });
+
+  it('drops to keys tier only after OAuth tier is exhausted', async () => {
+    saveOAuthCredentials(tmpDir, 'anthropic', {
+      access: 'sk-ant-oat-old',
+      refresh: 'rt-1',
+      expires: Date.now() + 60 * 60_000,
+      label: 'claude-pro',
+    });
+    const resolver = new AuthResolver(makeTwoTierConfig(), undefined, {
+      anthropic: loadOAuthCredentials(tmpDir, 'anthropic')!,
+    });
+
+    expect(resolver.getActiveCredential()?.tier).toBe('oauth');
+
+    resolver.markKeyFailed('anthropic', 'auth', 'invalid_grant', 0, 'oauth');
+
+    const active = resolver.getActiveCredential();
+    expect(active?.tier).toBe('keys');
+    expect(active?.provider).toBe('anthropic');
+    expect(active?.label).toBe('api-fallback');
+  });
+
+  it('cycles through entire OAuth tier before dropping to keys tier', async () => {
+    const cfg: LlmConfig = {
+      ...makeTwoTierConfig(),
+      oauth: { primary: 'anthropic', fallback: ['openai'] },
+    };
+    saveOAuthCredentials(tmpDir, 'anthropic', {
+      access: 'a',
+      refresh: 'ar',
+      expires: Date.now() + 60 * 60_000,
+      label: 'claude-pro',
+    });
+    saveOAuthCredentials(tmpDir, 'openai', {
+      access: 'o',
+      refresh: 'or',
+      expires: Date.now() + 60 * 60_000,
+      label: 'codex',
+    });
+    const resolver = new AuthResolver(cfg, undefined, {
+      anthropic: loadOAuthCredentials(tmpDir, 'anthropic')!,
+      openai: loadOAuthCredentials(tmpDir, 'openai')!,
+    });
+
+    expect(resolver.getActiveCredential()).toMatchObject({
+      tier: 'oauth',
+      provider: 'anthropic',
+    });
+
+    resolver.markKeyFailed('anthropic', 'auth', 'fail', 0, 'oauth');
+    expect(resolver.getActiveCredential()).toMatchObject({ tier: 'oauth', provider: 'openai' });
+
+    resolver.markKeyFailed('openai', 'auth', 'fail', 0, 'oauth');
+    expect(resolver.getActiveCredential()).toMatchObject({ tier: 'keys', provider: 'anthropic' });
+  });
+});

--- a/src/server/agents/oauth.test.ts
+++ b/src/server/agents/oauth.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { isExpiringSoon } from './oauth.js';
+
+describe('isExpiringSoon', () => {
+  it('returns true when expires is within buffer', () => {
+    expect(isExpiringSoon(Date.now() + 60_000, 5 * 60_000)).toBe(true);
+  });
+
+  it('returns false when expires is well in the future', () => {
+    expect(isExpiringSoon(Date.now() + 60 * 60_000, 5 * 60_000)).toBe(false);
+  });
+
+  it('returns true when already expired', () => {
+    expect(isExpiringSoon(Date.now() - 1000, 5 * 60_000)).toBe(true);
+  });
+
+  it('uses default buffer when not provided', () => {
+    expect(isExpiringSoon(Date.now() + 60_000)).toBe(true);
+    expect(isExpiringSoon(Date.now() + 60 * 60_000)).toBe(false);
+  });
+});

--- a/src/server/agents/oauth.ts
+++ b/src/server/agents/oauth.ts
@@ -1,0 +1,29 @@
+import { loginAnthropic, refreshAnthropicToken } from '@mariozechner/pi-ai/oauth';
+
+/** How close to expiry we trigger a refresh. pi-ai's expires already includes a 5min buffer; we add another 5. */
+export const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+export interface RefreshedTokens {
+  access: string;
+  refresh: string;
+  expires: number;
+}
+
+export function isExpiringSoon(expires: number, bufferMs: number = REFRESH_BUFFER_MS): boolean {
+  return Date.now() + bufferMs >= expires;
+}
+
+/**
+ * Refresh the Anthropic OAuth access token via the SDK.
+ * Throws on network/auth failure.
+ */
+export async function refreshAnthropic(refreshToken: string): Promise<RefreshedTokens> {
+  const updated = await refreshAnthropicToken(refreshToken);
+  return {
+    access: updated.access,
+    refresh: updated.refresh,
+    expires: updated.expires,
+  };
+}
+
+export { loginAnthropic };

--- a/src/server/knowledge/git.ts
+++ b/src/server/knowledge/git.ts
@@ -18,6 +18,9 @@ app.db-wal
 # Credentials
 config.toml
 
+# OAuth credentials (access + refresh tokens)
+oauth/
+
 # Runtime
 server.pid
 logs/

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -21,13 +21,20 @@ import type {
   JobExecution,
   KnowledgeConfig,
   LlmConfig,
+  LlmProvider,
   SchedulerConfig,
   ServerMessage,
   ServicesConfig,
   ToolsConfig,
 } from '../shared/index.js';
+import type { OAuthCredentialsMap } from './agents/auth-resolver.js';
 import { AuthResolver } from './agents/auth-resolver.js';
 import { AgentHost } from './agents/host.js';
+import {
+  loadOAuthCredentials,
+  type OAuthCredentials,
+  saveOAuthCredentials,
+} from './agents/oauth-credentials.js';
 import { AgentRegistry } from './agents/registry.js';
 import type { AgentResurrector } from './agents/tools/resurrect-agent.js';
 import type { AgentSpawner } from './agents/tools/spawn-agent.js';
@@ -103,7 +110,31 @@ export class Server {
     this.agentRegistry = new AgentRegistry();
 
     // Shared AuthResolver: all agents see the same cooldown/failover state
-    this.authResolver = new AuthResolver(config.llmConfig);
+    const oauthCredentials: OAuthCredentialsMap = {};
+    if (config.llmConfig.oauth) {
+      const oauthProviders: LlmProvider[] = [
+        config.llmConfig.oauth.primary,
+        ...config.llmConfig.oauth.fallback,
+      ];
+      for (const provider of oauthProviders) {
+        const creds = loadOAuthCredentials(SYSTEM2_DIR, provider);
+        if (creds) {
+          oauthCredentials[provider] = creds;
+        } else {
+          log.warn(
+            `[server] [llm.oauth] declares ${provider} but ~/.system2/oauth/${provider}.json is missing — skipping`
+          );
+        }
+      }
+    }
+
+    this.authResolver = new AuthResolver(config.llmConfig, undefined, oauthCredentials);
+
+    for (const provider of Object.keys(oauthCredentials) as LlmProvider[]) {
+      this.authResolver.setPersistOAuth(provider, async (creds: OAuthCredentials) => {
+        saveOAuthCredentials(SYSTEM2_DIR, provider, creds);
+      });
+    }
 
     // Shared ReminderManager: all agents schedule reminders through the same instance
     this.reminderManager = new ReminderManager(this.agentRegistry);

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -110,6 +110,10 @@ export class Server {
     this.agentRegistry = new AgentRegistry();
 
     // Shared AuthResolver: all agents see the same cooldown/failover state
+
+    /** OAuth providers with refresh implementations available in v1. */
+    const SUPPORTED_OAUTH_PROVIDERS: ReadonlySet<LlmProvider> = new Set(['anthropic']);
+
     const oauthCredentials: OAuthCredentialsMap = {};
     if (config.llmConfig.oauth) {
       const oauthProviders: LlmProvider[] = [
@@ -117,6 +121,12 @@ export class Server {
         ...config.llmConfig.oauth.fallback,
       ];
       for (const provider of oauthProviders) {
+        if (!SUPPORTED_OAUTH_PROVIDERS.has(provider)) {
+          log.error(
+            `[server] [llm.oauth] declares unsupported provider "${provider}". Supported providers: ${[...SUPPORTED_OAUTH_PROVIDERS].join(', ')}. Skipping.`
+          );
+          continue;
+        }
         const creds = loadOAuthCredentials(SYSTEM2_DIR, provider);
         if (creds) {
           oauthCredentials[provider] = creds;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -146,6 +146,14 @@ export class Server {
       });
     }
 
+    if (!this.authResolver.getActiveCredential()) {
+      throw new Error(
+        'No usable LLM credentials available. Either:\n' +
+          '  - Run `system2 login <provider>` to authenticate via OAuth, or\n' +
+          '  - Add API keys to ~/.system2/config.toml under [llm.<provider>].keys'
+      );
+    }
+
     // Shared ReminderManager: all agents schedule reminders through the same instance
     this.reminderManager = new ReminderManager(this.agentRegistry);
 

--- a/src/shared/types/config.ts
+++ b/src/shared/types/config.ts
@@ -29,10 +29,17 @@ export interface LlmProviderConfig {
   routing?: Record<string, string[]>;
 }
 
+export interface LlmOAuthConfig {
+  primary: LlmProvider;
+  fallback: LlmProvider[];
+}
+
 export interface LlmConfig {
   primary: LlmProvider;
   fallback: LlmProvider[];
   providers: Partial<Record<LlmProvider, LlmProviderConfig>>;
+  /** Optional OAuth tier. When present, OAuth credentials are tried before API keys. */
+  oauth?: LlmOAuthConfig;
 }
 
 export interface BraveSearchConfig {


### PR DESCRIPTION
## Summary

Adds Claude Pro/Max OAuth as a first-class authentication option. System2 now has two ordered auth tiers: an **OAuth tier** (subscription credentials, tried first) and the existing **API key tier** (billed per token, used after OAuth is exhausted). Failover walks the entire OAuth tier before dropping into API keys; OAuth tokens auto-refresh before expiry and on 401, with one refresh-and-retry per turn before falling over.

The `pi-ai` SDK already detects OAuth tokens (substring match `sk-ant-oat`) and switches the Anthropic client to Bearer auth + Claude Code identity headers, so no SDK fork was needed. The agent loop, custom tools, and multi-agent orchestration are unchanged.

## Highlights

- New `[llm.oauth]` config section with `primary` / `fallback` ordering, symmetric to the existing `[llm]`.
- OAuth credentials stored at `~/.system2/oauth/<provider>.json` (mode 0600).
- `AuthResolver` extended with tier-aware cooldowns (`${tier}:${provider}:${keyIndex}`), `getActiveCredential()`, and `ensureFresh()` (per-provider promise lock prevents thundering-herd refresh).
- `AgentHost` calls `ensureFresh` before each session creation; on 401 from an OAuth credential, refreshes once and reinitializes before falling over.
- Two-step onboarding: OAuth tier first (recommended for Claude Pro/Max users), then API key tier. At least one tier required.
- New CLI commands `system2 login [provider]` and `system2 logout [provider]` for post-onboarding re-auth and credential removal.
- v1 supports Anthropic OAuth only; architecture supports Google Gemini CLI / GitHub Copilot / OpenAI Codex (filed as follow-up).

## Out of scope (deferred follow-ups)

- Hot-reload of credentials without restart (use `system2 stop && system2 start`).
- A `system2 config` CLI helper (documented as: edit `config.toml` and restart).
- UI surfacing of OAuth state.
- Multi-account OAuth.
- Per-role tier overrides.

## Test plan

- [x] All 736 tests pass (`pnpm test`)
- [x] `pnpm typecheck` clean
- [x] `pnpm check` clean (only one pre-existing warning in `web-fetch.ts`, unrelated to this PR)
- [x] `pnpm build` clean
- [x] End-to-end integration test (`oauth-flow.test.ts`) covers: load → refresh → persist → tier preference; OAuth-tier-exhausted → drop to keys tier; full OAuth tier walked before keys tier
- [x] AuthResolver: 30+ tests including tier-namespaced cooldowns, `ensureFresh` with concurrent caller serialization, 401 refresh-and-retry, lock cleanup on rejection
- [x] AgentHost: regression tests for tier tracking and OAuth refresh-and-retry, including the cooldown-namespace assertion
- [x] CLI: `addProviderToOAuthTier` (4 cases) and `removeProviderFromOAuthTier` (4 cases) covered with TOML-edit unit tests
- [ ] **Manual smoke test** (recommended before merge): run `pnpm build && node dist/cli/index.js onboard`, choose OAuth on the Anthropic prompt, verify browser flow completes, `~/.system2/oauth/anthropic.json` lands with mode 0600, `~/.system2/config.toml` contains `[llm.oauth]` with `primary = "anthropic"`. Then start the daemon and confirm the Guide responds normally.

## Plan

Full implementation plan and per-task TDD steps: [`docs/superpowers/plans/2026-04-27-claude-pro-max-oauth.md`](docs/superpowers/plans/2026-04-27-claude-pro-max-oauth.md).

## Caveats noted in docs

- Claude Pro/Max usage caps are sized for one human in Claude Code. A multi-agent system2 workload (Guide + Conductor + Reviewer + Workers + Narrator) can hit the 5-hour message cap quickly. Configure the API key tier as fallback for sustained workloads.
- Programmatic use of Pro/Max credentials outside Claude Code is in a TOS gray area.
- Prompt caching is disabled on the OAuth path (the SDK strips `cache_control` from system prompts for OAuth tokens). Per-call billing still goes through the subscription.