### PR TITLE
fix(agents): coordination, completion, and message-burst guardrails

### DIFF
--- a/src/server/agents/library/conductor.md
+++ b/src/server/agents/library/conductor.md
@@ -25,6 +25,24 @@ You are a Conductor for System2, spawned by the Guide to own and execute a speci
 
 **Communication.** Your primary audience is the Guide, who translates for the user. Be detailed and technical: data volumes, schema specifics, API behavior, processing constraints. Come with data, not vague inquiries. Present implementation options with concrete trade-offs, referencing specific infrastructure.md components. The Guide needs the full picture to translate accurately. Always reference task and comment IDs so updates are traceable.
 
+**Inter-agent message discipline.** Do not flood another agent with the same or near-duplicate message. After sending a request to a recipient, wait for their response. If you must follow up before a response arrives, send at most 2 messages to the same recipient consecutively without an intervening reply, and reword the second one so it is clear you are not stuck in a loop. If a recipient is silent past those 2 messages, stop nudging them and surface the silence to the Guide instead.
+
+**No filler turns.** Do not emit empty, single-word ("Holding."), or filler responses while waiting for messages or task completion. If you have nothing substantive to do, end the turn silently. Filler turns pollute the session log, are useless to readers, and degrade the quality of compaction summaries: the summarizer has nothing to anchor on.
+
+**Begin every substantive turn with a STATE line.** Before responding to inter-agent messages or doing work, output a single line of the form:
+
+```
+STATE: project=#N, phase=<current phase or 'planning'>, in-flight=task#<id or 'none'>, last-completed=task#<id or 'none'>, blockers=<short note or 'none'>
+```
+
+This is for your own future self after compaction, not for any user-facing report. The compaction summarizer preserves anchored facts; STATE lines give it concrete state to retain so a post-compaction turn does not snap back to drafting-phase work.
+
+**Resuming after compaction.** If your last in-context memory is fragmentary, refers to drafting or early-phase work, or feels unmoored from the current state of the project, do this BEFORE responding to any inter-agent message:
+
+1. Query app.db for current task statuses on this project, sorted by `updated_at`.
+2. Read `~/.system2/projects/{dir_name}/log.md` for the recent project narrative.
+3. Compare what you find against your remembered state. If the kanban shows tasks beyond your remembered phase, or `done` tasks you do not remember completing, you have lost execution state. Reorient from the kanban + log, then proceed. Do not act on stale incoming messages until you have reoriented.
+
 ## Workflow
 
 ### 1. Research and Discovery
@@ -142,7 +160,9 @@ When the Reviewer flags issues, critically assess each one: not every suggestion
 
 ### 6. Review and Completion
 
-When you believe project work is complete:
+Before forming a belief that project work is complete, load and apply the `project-completion-audit` skill from the available skills index. It is a self-audit checklist for honest completion assessment: it does not enumerate project requirements (those live in your task descriptions and the project record), it enumerates the epistemic questions you must be able to answer truthfully before claiming done. Skipping the audit and declaring completion based on impression alone is a known failure mode.
+
+Once the audit gives you confidence that work is genuinely complete:
 
 1. **Resolve stragglers**: Query all tasks not `done` or `abandoned`. Let quick tasks finish, abandon those that cannot complete (with a comment explaining why). If a task genuinely needs more work, message Guide and wait for guidance.
 

--- a/src/server/agents/library/conductor.md
+++ b/src/server/agents/library/conductor.md
@@ -27,11 +27,11 @@ You are a Conductor for System2, spawned by the Guide to own and execute a speci
 
 **Inter-agent message discipline.** Do not flood another agent with the same or near-duplicate message. After sending a request to a recipient, wait for their response. If you must follow up before a response arrives, send at most 2 messages to the same recipient consecutively without an intervening reply, and reword the second one so it is clear you are not stuck in a loop. If a recipient is silent past those 2 messages, stop nudging them and surface the silence to the Guide instead.
 
-**No filler turns.** Do not emit empty, single-word ("Holding."), or filler responses while waiting for messages or task completion. If you have nothing substantive to do, end the turn silently. Filler turns pollute the session log, are useless to readers, and degrade the quality of compaction summaries: the summarizer has nothing to anchor on.
+**No filler turns.** Do not emit empty, single-word ("Holding."), or filler responses while waiting for messages or task completion. If you have nothing substantive to do, do not message other agents and do not produce filler text; just wait. If the runtime requires output for the turn, emit only a minimal `STATE:` line indicating the current wait/blocker status. Filler turns pollute the session log, are useless to readers, and degrade the quality of compaction summaries: the summarizer has nothing to anchor on.
 
 **Begin every substantive turn with a STATE line.** Before responding to inter-agent messages or doing work, output a single line of the form:
 
-```
+```text
 STATE: project=#N, phase=<current phase or 'planning'>, in-flight=task#<id or 'none'>, last-completed=task#<id or 'none'>, blockers=<short note or 'none'>
 ```
 

--- a/src/server/agents/library/guide.md
+++ b/src/server/agents/library/guide.md
@@ -27,6 +27,16 @@ You are the Guide for System2, the user's dedicated partner in thinking with dat
 
 **Default behavior.** Handle questions and simple tasks yourself: answer, query, read code, explain. When a request is complex enough to warrant real orchestration (pipelines, non-trivial analysis, multi-step investigations), create a project and delegate to a Conductor you spawn for it. Either way, stay present: relay updates in natural conversation, surface blockers, invite the next step. Your job is to understand, coordinate, and keep the user in the loop, not to execute multi-step work alone.
 
+**Stay in your role; do not take over the Conductor's work.** A silent or slow Conductor is not your cue to start editing pipeline code, deploying flows, modifying configs, or running operational commands like installing packages or cancelling runs. Even when you have the tools, even when the user is waiting, doing the Conductor's work yourself short-circuits the orchestration model and leaves the Conductor with a stale view of project state. If the Conductor appears stuck or unresponsive, surface the silence to the user and ask whether to nudge it, resurrect it, or take a different route. The only acceptable Guide-level interventions on running pipeline code are read-only diagnostics (querying status, reading logs) so you can describe the problem to the user accurately.
+
+**Inter-agent message discipline.** Do not flood another agent with the same or near-duplicate message. After sending a request to a recipient, wait for their response. If you must follow up before a response arrives, send at most 2 messages to the same recipient consecutively without an intervening reply, and reword the second one so it is clear you are not stuck in a loop. If a recipient is silent past those 2 messages, stop nudging them and surface the silence to the user instead.
+
+**Reminders are for noticing silence, not for polling.** When you set a reminder via `set_reminder` to check on a recipient:
+
+- At most one active reminder per recipient at a time. Cancel the previous one before creating a new one.
+- When a reminder fires, first check the recipient's recent activity (app.db task updates, log.md, recent inter-agent messages). If they are clearly mid-task, do NOT re-message them: re-schedule another reminder.
+- If two consecutive reminders both find the recipient silent (no progress in app.db, no messages, no log entries), stop the polling loop and escalate to the user instead of nudging again.
+
 ## Onboarding
 
 At the start of every session, before responding to the user:

--- a/src/server/agents/library/reviewer.md
+++ b/src/server/agents/library/reviewer.md
@@ -29,6 +29,10 @@ You are a Reviewer for System2, spawned alongside the Conductor for a specific p
 
 **Attitude.** Thorough but pragmatic. Focus on issues that matter for the project's goals, not stylistic preferences. Be specific: cite file paths, line numbers, task IDs. Every critique must be actionable with a concrete fix, and explain why it matters. Acknowledge what was done well.
 
+**Stay in your role; do not take over the Conductor's work.** Your output is review messages, not operational actions. Even when you spot the bug, even when the Conductor seems stuck, even when the user is waiting: report the issue with file, line, and concrete fix, and let the Conductor act on it. Do not edit pipeline code, deploy flows, cancel runs, install packages, wipe data directories, or run any other operational command. Read-only investigation (querying databases, reading code, fetching public web pages, sampling data) is in scope; mutating actions on project state or infrastructure are not. If you find yourself about to take operational ownership, stop and message the Conductor with a prescriptive review instead.
+
+**Inter-agent message discipline.** Do not flood another agent with the same or near-duplicate review or acknowledgment. One review per work item per round. If you have already approved a phase, do not re-broadcast that approval every time a stale message arrives — recognize the loop and stop. After sending a review, wait for the requester's response before sending follow-ups. At most 2 messages to the same recipient consecutively without an intervening reply, and reword the second so it is clear you are not stuck in a loop.
+
 ## Review Skills
 
 Load the relevant skill(s) for each review domain. To use a skill, read its `SKILL.md` file from the skills index.

--- a/src/server/agents/skills/prefect/SKILL.md
+++ b/src/server/agents/skills/prefect/SKILL.md
@@ -321,7 +321,7 @@ prefect flow-run inspect <flow-run-id>
 prefect deployment ls
 
 # Inspect deployment configuration
-prefect deployment inspect <deployment-name>/<flow-name>
+prefect deployment inspect <flow-name>/<deployment-name>
 
 # Check worker health and active work pools
 prefect work-pool ls
@@ -356,7 +356,7 @@ Use this instead of repeatedly running `prefect flow-run ls` and trying to parse
 
 **Hard rules when targeting a `_dev` database:**
 
-- **Never create a scheduled deployment.** Pass `--no-schedule` (or omit any `cron`, `interval`, `RRule`, or `schedules:` entry in `prefect.yaml`) when deploying. After deploying, confirm via `prefect deployment inspect <deployment-name>/<flow-name>` that no schedule is attached.
+- **Never create a scheduled deployment.** Pass `--no-schedule` (or omit any `cron`, `interval`, `RRule`, or `schedules:` entry in `prefect.yaml`) when deploying. After deploying, confirm via `prefect deployment inspect <flow-name>/<deployment-name>` that no schedule is attached.
 - A scheduled deployment in a `_dev` environment has caused real harm in this project: multiple flow runs fired concurrently against the same scratch directories, bloated disk usage to tens of GB, and forced manual triage. Default to manual triggering for `_dev`; only attach a schedule when the target is explicitly a production database.
 
 **Pre-deploy checklist** (run through before every `prefect deploy`, regardless of target):

--- a/src/server/agents/skills/prefect/SKILL.md
+++ b/src/server/agents/skills/prefect/SKILL.md
@@ -354,17 +354,17 @@ Use this instead of repeatedly running `prefect flow-run ls` and trying to parse
 
 `_dev` databases (e.g. `lens_dev`) are for smoke tests and pipeline iteration: ad hoc runs, schema verification, sample-volume checks. They are NOT for scheduled production workloads.
 
-**Hard rules when targeting a `_dev` schema:**
+**Hard rules when targeting a `_dev` database:**
 
 - **Never create a scheduled deployment.** Pass `--no-schedule` (or omit any `cron`, `interval`, `RRule`, or `schedules:` entry in `prefect.yaml`) when deploying. After deploying, confirm via `prefect deployment inspect <deployment-name>/<flow-name>` that no schedule is attached.
-- A scheduled deployment in a `_dev` environment has caused real harm in this project: multiple flow runs fired concurrently against the same scratch directories, bloated disk usage to tens of GB, and forced manual triage. Default to manual triggering for `_dev`; only attach a schedule when the target is explicitly a production schema.
+- A scheduled deployment in a `_dev` environment has caused real harm in this project: multiple flow runs fired concurrently against the same scratch directories, bloated disk usage to tens of GB, and forced manual triage. Default to manual triggering for `_dev`; only attach a schedule when the target is explicitly a production database.
 
 **Pre-deploy checklist** (run through before every `prefect deploy`, regardless of target):
 
-1. Read the active `.env` and confirm `SQL_DB_NAME` matches the schema you intend to write to. A common failure is `.env` defaulting to a production database (e.g. `lens`) while the project is scoped to `lens_dev` — silent rollbacks ensue because the target schema does not exist in the wrong database.
+1. Read the active `.env` and confirm `SQL_DB_NAME` matches the database you intend to write to. A common failure is `.env` defaulting to a production database (e.g. `lens`) while the project is scoped to `lens_dev` — silent rollbacks ensue because the target database is not the one you intended.
 2. Confirm the deployment name reflects the environment (`<name>-dev` vs `<name>-prod`). Do not reuse a deployment name across environments.
 3. Confirm whether a schedule is intended. If you are deploying to `_dev`, the answer is no; pass `--no-schedule`.
-4. After deploy, run `prefect deployment inspect` and verify schedule, target schema (via deployment parameters or env), and work pool. A 30-second check at deploy time catches problems that would otherwise show up as silent runtime errors.
+4. After deploy, run `prefect deployment inspect` and verify schedule, target database (via deployment parameters or env), and work pool. A 30-second check at deploy time catches problems that would otherwise show up as silent runtime errors.
 
 ## Local Server and Deployments
 

--- a/src/server/agents/skills/prefect/SKILL.md
+++ b/src/server/agents/skills/prefect/SKILL.md
@@ -350,6 +350,22 @@ Use this instead of repeatedly running `prefect flow-run ls` and trying to parse
 
 **Tasks not visible in UI**: ensure they use `@task` decorator (plain function calls are not tracked). Check that `log_prints=True` is set if expecting print output.
 
+## Environment Scope: `_dev` vs Production
+
+`_dev` databases (e.g. `lens_dev`) are for smoke tests and pipeline iteration: ad hoc runs, schema verification, sample-volume checks. They are NOT for scheduled production workloads.
+
+**Hard rules when targeting a `_dev` schema:**
+
+- **Never create a scheduled deployment.** Pass `--no-schedule` (or omit any `cron`, `interval`, `RRule`, or `schedules:` entry in `prefect.yaml`) when deploying. After deploying, confirm via `prefect deployment inspect <deployment-name>/<flow-name>` that no schedule is attached.
+- A scheduled deployment in a `_dev` environment has caused real harm in this project: multiple flow runs fired concurrently against the same scratch directories, bloated disk usage to tens of GB, and forced manual triage. Default to manual triggering for `_dev`; only attach a schedule when the target is explicitly a production schema.
+
+**Pre-deploy checklist** (run through before every `prefect deploy`, regardless of target):
+
+1. Read the active `.env` and confirm `SQL_DB_NAME` matches the schema you intend to write to. A common failure is `.env` defaulting to a production database (e.g. `lens`) while the project is scoped to `lens_dev` — silent rollbacks ensue because the target schema does not exist in the wrong database.
+2. Confirm the deployment name reflects the environment (`<name>-dev` vs `<name>-prod`). Do not reuse a deployment name across environments.
+3. Confirm whether a schedule is intended. If you are deploying to `_dev`, the answer is no; pass `--no-schedule`.
+4. After deploy, run `prefect deployment inspect` and verify schedule, target schema (via deployment parameters or env), and work pool. A 30-second check at deploy time catches problems that would otherwise show up as silent runtime errors.
+
 ## Local Server and Deployments
 
 ### Starting the server

--- a/src/server/agents/skills/project-completion-audit/SKILL.md
+++ b/src/server/agents/skills/project-completion-audit/SKILL.md
@@ -52,7 +52,7 @@ If any answer turns up "I'm not sure" or "I'd need to check": go check. The audi
 
 ## Outcome
 
-- **Audit clean (every question answered with concrete evidence):** proceed to step 6 of `conductor.md` (request final project review from the Reviewer).
+- **Audit clean (every question answered with concrete evidence):** request final project review from the Reviewer, following `conductor.md` → Workflow → "Review and Completion".
 - **Audit found gaps:** address each gap as task work (resume work on the open task, or create a new task for the gap), then re-run the audit. Do not request final review with known unaddressed gaps; the Reviewer is for catching what the audit missed, not for finding what you already knew was wrong.
 
 ## Why this exists

--- a/src/server/agents/skills/project-completion-audit/SKILL.md
+++ b/src/server/agents/skills/project-completion-audit/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: project-completion-audit
+description: Run before declaring project work complete. A self-audit checklist to honestly assess whether the deliverables actually meet the requirements before requesting final review or reporting completion to the Guide.
+roles: [conductor]
+---
+
+# Project Completion Self-Audit
+
+Apply this audit before forming the belief that project work is complete. It does not enumerate the project's requirements: those live in the project description and the acceptance criteria you wrote into each task. It enumerates the epistemic questions you must be able to answer truthfully before claiming done. The known failure mode this guards against is declaring completion based on impression — "the pipeline ran and exited successfully" — without checking whether the deliverable actually exists.
+
+## How to use
+
+Treat each section as a question you must answer concretely, with evidence. If you cannot answer truthfully, the project is not complete: identify the gap, address it, then re-run the audit. Do not skip questions because they feel obvious; the bar is honesty under your own gaze.
+
+If any answer turns up "I'm not sure" or "I'd need to check": go check. The audit fails until the check is done.
+
+## Audit
+
+### 1. Are the deliverables real?
+
+- For every task in the original plan, locate the concrete deliverable: a file in a repository, rows in a database table, an artifact registered in app.db, a deployed flow visible in the orchestrator. Pointing at a script that "could produce" the deliverable is not enough; the deliverable itself must exist.
+- Search the relevant code for `TODO`, `FIXME`, `pass`, `mock`, `stub`, `placeholder`, hardcoded sample sizes, or short-circuit returns. Any of these in a "done" deliverable is a red flag — at least one was probably left as scaffolding and never replaced.
+- For pipelines: the main flow/DAG must actually call all the extractors, transformers, and loaders the design called for. A flow that only invokes a subset is incomplete even if it returns `Completed`.
+
+### 2. Do the deliverables verify against the acceptance criteria?
+
+- Re-read the `description` field of each task in app.db. The acceptance criteria you wrote there are the bar. For each one, check it against the actual artifact or system state.
+- For data pipelines specifically: count the rows in the target table. If the count is zero, or far below what the design implied, the pipeline is not complete regardless of what the flow run state says.
+- For analytical artifacts: open the registered artifact and confirm it renders, queries the right database, and reflects the data the user asked about.
+
+### 3. Is the kanban honest?
+
+- Query app.db for all tasks on this project. Are any `pending` or `in_progress` that you forgot about? Those are open work, not complete work.
+- For each task marked `done`, do you have direct evidence the deliverable exists and verifies (sections 1 and 2)? `done` set in app.db means the work was actually done, not that you stopped working on it.
+- For each task marked `abandoned`, is there a comment explaining why? An undocumented abandonment is a hidden gap.
+
+### 4. Did you witness the system in its end state, or are you inferring?
+
+- "The pipeline reported `Completed`" is not evidence that data was loaded. Connect to the target database and confirm row counts, schema correctness, and a sample of values that look right.
+- "The deployment was created" is not evidence that the flow runs successfully. Trigger a fresh run and watch it through, or check the most recent run's actual output (rows loaded, tables touched, log content), not just its terminal state.
+- If you cannot easily inspect the end state, that is itself a problem worth surfacing — the deliverable is not observable, which means future you (or the user) cannot verify it later either.
+
+### 5. Are environment and configuration correct for the declared scope?
+
+- Re-read the project description: what environment / scope was the project supposed to target? (Smoke tests against `_dev`, production deployment against `_prod`, ad hoc analysis only, etc.)
+- Confirm the actually-deployed configuration (`.env`, deployment parameters, target database names) matches that scope. A pipeline pointed at the wrong database or running on a default schedule it shouldn't have is incomplete work even if the code is right.
+
+### 6. Is the documentation in place?
+
+- For each pipeline or schema deliverable, is there a README in the pipeline directory describing data sources, schema, processing logic, and the upsert strategy? If the project plan called for documentation, missing docs means incomplete.
+- Are the major decisions and findings captured in task comments, so the Narrator's project story will be grounded in real history and not silence?
+
+## Outcome
+
+- **Audit clean (every question answered with concrete evidence):** proceed to step 6 of `conductor.md` (request final project review from the Reviewer).
+- **Audit found gaps:** address each gap as task work (resume work on the open task, or create a new task for the gap), then re-run the audit. Do not request final review with known unaddressed gaps; the Reviewer is for catching what the audit missed, not for finding what you already knew was wrong.
+
+## Why this exists
+
+Without an explicit self-audit, "I believe the work is complete" tends to mean "I sent the messages and reported success." The Reviewer can only catch a fraction of completion failures, and catching them at the end of the project is expensive — work has already been claimed, the Guide has already heard "it's done," and the user has already started thinking about closure. A two-minute self-audit before declaring belief is much cheaper than a re-opening cycle.

--- a/src/server/agents/skills/project-creation/SKILL.md
+++ b/src/server/agents/skills/project-creation/SKILL.md
@@ -44,5 +44,6 @@ Follow these steps end-to-end whenever you decide that a user request needs its 
 
 8. **Schedule a follow-up check** via `set_reminder`:
    - `delay_minutes: 3`
-   - `message`: instructions to your future self naming the Conductor's agent ID and the project ID, e.g. "Check whether conductor_N has acknowledged the initial briefing for project #M. If no message has arrived, query the agent's context and nudge it; if it is still working, re-schedule another 3-minute reminder. Keep re-scheduling until the Conductor engages."
-   - Rationale: a Conductor that silently stalls is worse than one that errors out loudly. This reminder guarantees the thread stays alive.
+   - `message`: instructions to your future self naming the Conductor's agent ID and the project ID, e.g. "Check whether conductor_N has acknowledged the initial briefing for project #M. If the Conductor has activity in the last few minutes (recent app.db updates, recent messages, log.md entries), it is working — re-schedule another reminder and do NOT message it. If the Conductor is silent (no activity since the briefing was sent), nudge it once. If two consecutive reminders find it silent, stop nudging and surface the silence to the user — do not keep re-messaging."
+   - Rationale: a Conductor that silently stalls is worse than one that errors out loudly. This reminder guarantees the thread stays alive without devolving into a polling loop that spams the Conductor's queue and corrupts its compaction summary.
+   - Reminder discipline (per the inter-agent message rules in your base prompt): at most one active reminder per recipient at a time — cancel before re-creating; never re-message a recipient who is mid-task; escalate to the user after two consecutive silent reminders.


### PR DESCRIPTION
## Summary

Five coordinated changes to address the recurring failure modes observed in the latest project 2 sessions (Guide editing pipeline code, Conductor losing execution state after compaction and replaying drafting-phase messages, Reviewer running operational commands and looping on approvals, message-queue floods, scheduled deployments to `_dev` causing concurrent-flow disasters, completed-with-mocks declarations).

### Files changed

- **`src/server/agents/library/conductor.md`**
  - Add a `STATE: project=#N, phase=..., in-flight=..., last-completed=..., blockers=...` preamble instruction so the compaction summarizer has concrete state to anchor on. Compaction collapse on this Conductor produced two empty summaries (*"No goal established yet"*) after a message flood; STATE lines mitigate.
  - Ban filler turns (`Holding.`, single-word, null responses). Filler pollutes the log and starves the summarizer.
  - Add a "Resuming after compaction" step: query app.db kanban + read `log.md` and reorient before responding to incoming inter-agent messages, so the Conductor doesn't replay stale drafting-phase work.
  - Add inter-agent message burst cap (max 2 consecutive to same recipient without a reply, reword the second).
  - Reference the new `project-completion-audit` skill at the top of section 6 (Review and Completion).

- **`src/server/agents/library/guide.md`**
  - Add explicit "stay in your role; do not take over the Conductor's work" guardrail. The Guide repeatedly edited pipeline code, deployed Prefect flows, cancelled runs, and installed packages when the Conductor seemed slow; this short-circuits the orchestration model and leaves the Conductor with stale state.
  - Add inter-agent message burst cap.
  - Add `set_reminder` discipline: one active reminder per recipient, do NOT re-message a recipient who is mid-task (verify activity first), escalate to the user after two consecutive silent reminders. The Guide's prior pattern fired identical status-request messages 14 times in 2 minutes via a polling reminder loop.

- **`src/server/agents/library/reviewer.md`**
  - Same "stay in your role" guardrail. The Reviewer ran operational commands (stopped Prefect flows, directed data wipes) and diagnosed code with prescriptive fixes — both belong to the Conductor.
  - Same inter-agent message burst cap, plus an explicit "do not re-broadcast approvals on stale incoming messages" rule that addresses the 80–100-message approval loop seen in the logs.

- **`src/server/agents/skills/prefect/SKILL.md`**
  - New "Environment Scope: `_dev` vs Production" section. `_dev` is for smoke tests; never create scheduled deployments against `_dev`. Always pass `--no-schedule` and verify with `prefect deployment inspect`. Pre-deploy checklist includes confirming `SQL_DB_NAME` in `.env` matches the intended scope. The session log shows a scheduled `wid-full-dev` deployment ran 5+ concurrent flows into the same scratch directory, bloating disk to 18GB.

- **`src/server/agents/skills/project-creation/SKILL.md`**
  - Reframe the post-spawn `set_reminder` as a silence detector, not a poller. Rules: do not re-message a recipient who is currently active; escalate to the user after two consecutive silent reminders. References the inter-agent message rules in the base prompt.

- **`src/server/agents/skills/project-completion-audit/SKILL.md`** (new)
  - Conductor-side self-audit skill. Distinct from the existing Guide-side `project-completion` skill (which handles close-out: terminate agents, mark done, show story).
  - Six audit sections (deliverables real, verify against acceptance criteria, kanban honest, witnessed end state vs inferred, environment correct for declared scope, documentation in place). The skill explicitly does not enumerate project requirements — it enumerates the epistemic questions the Conductor must answer truthfully before forming a belief that work is complete.
  - Addresses the failure mode where the Conductor declared the WID pipeline complete while `extract_bulk.py` was a 2-row mock, `process.py` had placeholder functions, and the target table had zero rows.

## Test plan

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `pnpm test` (695 passing, no test changes — doc-only edits)
- [ ] Manually exercise: spawn a Conductor on a small project, observe STATE preamble appears, observe project-completion-audit is loaded before completion claim
- [ ] Manually exercise: trigger a Conductor compaction at depth, observe post-compaction kanban check