### PR TITLE
fix(cli): show target provider in oauth login/logout intro

### DIFF
--- a/src/cli/commands/login.ts
+++ b/src/cli/commands/login.ts
@@ -102,14 +102,15 @@ export function addProviderToOAuthTier(
 
 export async function login(provider?: string): Promise<void> {
   console.clear();
-  p.intro('🧠 System2 OAuth login');
 
   if (!existsSync(CONFIG_FILE)) {
+    p.intro('🧠 System2 OAuth login');
     p.cancel(`No System2 installation found at ${SYSTEM2_DIR}. Run "system2 onboard" first.`);
     process.exit(1);
   }
 
   if (isDaemonRunning()) {
+    p.intro('🧠 System2 OAuth login');
     p.cancel('System2 daemon is running. Stop it first with: system2 stop');
     process.exit(1);
   }
@@ -117,6 +118,7 @@ export async function login(provider?: string): Promise<void> {
   let target: LlmProvider;
   if (provider) {
     if (!OAUTH_PROVIDERS.includes(provider as LlmProvider)) {
+      p.intro('🧠 System2 OAuth login');
       p.cancel(
         `OAuth login for "${provider}" is not supported. Supported: ${OAUTH_PROVIDERS.join(', ')}`
       );
@@ -127,6 +129,7 @@ export async function login(provider?: string): Promise<void> {
     if (OAUTH_PROVIDERS.length === 1) {
       target = OAUTH_PROVIDERS[0];
     } else {
+      p.intro('🧠 System2 OAuth login');
       target = (await p.select({
         message: 'Which OAuth provider?',
         options: OAUTH_PROVIDERS.map((id) => ({ value: id, label: id })),
@@ -137,6 +140,8 @@ export async function login(provider?: string): Promise<void> {
       }
     }
   }
+
+  p.intro(`🧠 System2 OAuth login — ${target}`);
 
   const label = (await p.text({
     message: 'Label for this OAuth credential:',

--- a/src/cli/commands/logout.ts
+++ b/src/cli/commands/logout.ts
@@ -75,14 +75,15 @@ export function removeProviderFromOAuthTier(
 
 export async function logout(provider?: string): Promise<void> {
   console.clear();
-  p.intro('🧠 System2 OAuth logout');
 
   if (!existsSync(CONFIG_FILE)) {
+    p.intro('🧠 System2 OAuth logout');
     p.cancel(`No System2 installation found at ${SYSTEM2_DIR}.`);
     process.exit(1);
   }
 
   if (isDaemonRunning()) {
+    p.intro('🧠 System2 OAuth logout');
     p.cancel('System2 daemon is running. Stop it first with: system2 stop');
     process.exit(1);
   }
@@ -90,6 +91,7 @@ export async function logout(provider?: string): Promise<void> {
   let target: LlmProvider;
   if (provider) {
     if (!OAUTH_PROVIDERS.includes(provider as LlmProvider)) {
+      p.intro('🧠 System2 OAuth logout');
       p.cancel(
         `OAuth logout for "${provider}" is not supported. Supported: ${OAUTH_PROVIDERS.join(', ')}`
       );
@@ -99,6 +101,8 @@ export async function logout(provider?: string): Promise<void> {
   } else {
     target = OAUTH_PROVIDERS[0];
   }
+
+  p.intro(`🧠 System2 OAuth logout — ${target}`);
 
   const credPath = join(SYSTEM2_DIR, 'oauth', `${target}.json`);
   const fileExists = existsSync(credPath);


### PR DESCRIPTION
## Summary

Small UX fix: the intro line for `system2 login` and `system2 logout` now shows the target provider once it's resolved.

Before:
```
🧠 System2 OAuth login
```

After:
```
🧠 System2 OAuth login — anthropic
```

The intro is deferred until after the target provider is resolved (CLI arg, single-supported-provider auto-pick, or interactive select). Pre-resolution failure paths (no install, daemon running, unsupported provider arg) still print the generic intro before the cancellation message so the cancel banner has a header to render under.

## Test plan
- [x] `pnpm check` clean (1 pre-existing unrelated warning)
- [x] `pnpm typecheck` clean
- [x] `pnpm test` 748/748 pass
- [x] `pnpm build` clean