### PR TITLE
docs(readme): add login/logout commands; fix(cli): OAuth-aware startup banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ system2 stop             # shut down gracefully
 When you are done for the day, run `system2 stop`. Agent work in progress is saved, and a backup is created automatically on the next start.
 
 ```bash
+system2 login            # add or refresh a Claude Pro/Max OAuth credential
+```
+
+```bash
+system2 logout           # remove an OAuth credential
+```
+
+`system2 login` runs the Claude.ai OAuth flow, persists tokens to `~/.system2/oauth/<provider>.json` (mode 0600), and (if needed) adds `[llm.oauth]` to `config.toml`. Use it to switch on OAuth after a key-only onboarding, or to re-authenticate after a refresh-token expiry. `system2 logout` reverses both. Both commands require the daemon to be stopped first, and you must restart it afterward to pick up the change.
+
+```bash
 pnpm update -g @diegoscarabelli/system2   # upgrade System2 to the latest release
 ```
 

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -51,6 +51,7 @@ export async function start(options: {
   }
 
   const primaryProvider = config.llm.primary;
+  const oauthPrimary = config.llm.oauth?.primary;
 
   if (!primaryProvider) {
     console.error('Error: No primary provider configured in config.toml');
@@ -65,7 +66,12 @@ export async function start(options: {
   }
 
   console.log('Starting System2 Gateway...');
-  console.log(`  Provider: ${primaryProvider}`);
+  if (oauthPrimary) {
+    console.log(`  OAuth tier:   ${oauthPrimary}`);
+    console.log(`  API key tier: ${primaryProvider}`);
+  } else {
+    console.log(`  Provider: ${primaryProvider}`);
+  }
   console.log(`  Port: ${port}`);
   console.log('');
 


### PR DESCRIPTION
## Summary

Two small follow-ups to PR #145 surfaced while testing the OAuth flow on a real install.

### docs(readme): document `system2 login` / `system2 logout`

The README's "Managing and updating" section listed `system2 status` and `system2 stop` but not the new `login`/`logout` commands. Added them between stop and the upgrade command, with one paragraph describing when each is used and the daemon-stopped + restart constraints.

### fix(cli): OAuth-aware startup banner

`system2 start` printed `Provider: <X>` using `config.llm.primary` directly — which displays the API-key-tier primary even when an OAuth tier is configured and active. Surprising for users like:

```toml
[llm.oauth]
primary = "anthropic"

[llm]
primary = "openrouter"
fallback = ["google", "anthropic", ...]
```

Banner used to say `Provider: openrouter` despite OAuth being the active credential. Now shows:

```
OAuth tier:   anthropic
API key tier: openrouter
```

When no OAuth tier is configured, the banner is unchanged (`Provider: openrouter`).

## Test plan
- [x] `pnpm check` clean (1 pre-existing unrelated warning)
- [x] `pnpm typecheck` clean
- [x] `pnpm test` 748/748 pass
- [x] Manually verified the new banner against an OAuth-configured install