### PR TITLE
feat(narrator): reset session JSONL after scheduled tasks

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -241,6 +241,8 @@ Agent sessions are persisted as JSONL files in `~/.system2/sessions/{role}_{id}/
 
 **Session rotation** (`session-rotation.ts`): when a JSONL file exceeds 10MB at initialization, a new file is created carrying over the compacted history. The old file is renamed to `.jsonl.archived` so it is no longer picked up as a continuation candidate. Rotation only runs on cold start (when no prior session exists in memory), before a `SessionManager` is created. It is skipped during failover re-initialization because the outgoing SDK session still holds an open reference to the file and would recreate it without a header on the next append.
 
+**Per-task session reset** (Narrator-only): agents can opt in via `reset_session_after_scheduled_task: true` in their library frontmatter. When enabled, after `agent_end` for any delivery whose content starts with `[Scheduled task: ...]`, the active JSONL is archived and replaced with a fresh header-only file, and the in-memory session is cleared and reinitialized asynchronously. The Narrator runs on a 30-minute cron and does stateless "summarize this window" work: its durable memory lives in `daily_summaries/*.md`, `memory.md`, and per-project `log.md`, never in its session JSONL. Without reset, each tick's restored session keeps the prior writeup plus tool-call traces, and the next tick's catch-up delivery plus system prompt routinely exceeds Haiku's 200K context limit, triggering a context-overflow loop. Other agents (Guide, Conductor, Reviewer) keep their conversational sessions because they need cross-turn memory.
+
 See the [pi-coding-agent session format docs](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/session.md) for details.
 
 ## Agent Lifecycle: Spawn and Terminate

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -69,6 +69,14 @@ Each project log is a single continuous file per project lifetime (unlike daily 
 
 The Narrator synthesizes each section into narrative summaries, avoiding repetition of project-specific content already covered in project-log entries (which are processed first).
 
+## Narrator Session Reset
+
+After each scheduled-task delivery completes (`agent_end` for content starting with `[Scheduled task: ...]`), the AgentHost truncates the Narrator's session JSONL to a fresh session header and reinitializes the SDK session. The Narrator's durable memory lives in the knowledge files it writes (daily summaries, `memory.md`, project logs), not in its session. This prevents accumulating context over scheduled-task cycles, which previously caused 200K-token overflows on the Narrator's Haiku 4.5 model when restored-session + system-prompt + delivery exceeded the limit.
+
+The reset always fires on the trailing scheduled-task `agent_end`, even if other deliveries (catch-up storms, daily-summary + memory-update overlap) are queued. After reinitialize() resolves, queued deliveries are replayed against the fresh session via `sendCustomMessage`, so no work is lost. Compaction state (`compactionCount` plus the persisted `.compaction-count` file) is also reset so the pruning trigger does not fire spuriously against the new empty session.
+
+Controlled by the agent library frontmatter `reset_session_after_scheduled_task: true` (set on Narrator only). See `resetSessionToHeader()` in `src/server/agents/host.ts`.
+
 ## Memory Update Pipeline
 
 `buildAndDeliverMemoryUpdate()` runs daily at 11 AM:

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -3697,6 +3697,8 @@ describe('AgentHost', () => {
       resetSessionAfterScheduledTask: boolean;
       agentRole: string | null;
       unsubscribeSession: (() => void) | null;
+      compactionCount: number;
+      lastTurnErrored: boolean;
       handleSessionEvent: (event: Record<string, unknown>) => void;
       handlePotentialError: ReturnType<typeof vi.fn>;
       handleCompactionTracking: ReturnType<typeof vi.fn>;
@@ -3833,6 +3835,105 @@ describe('AgentHost', () => {
       expect(archived.length).toBe(0);
       expect(internal.session).toBe(sessionBefore);
       expect(internal.initialize).not.toHaveBeenCalled();
+    });
+
+    it('replays queued deliveries against the fresh session after reset', async () => {
+      const { internal } = makeHostWithSessionDir({ reset: true });
+
+      // After reset clears `this.session = null`, the production code awaits initialize()
+      // which rebuilds the session. The test stub doesn't really call initialize, so we
+      // simulate the side effect: when initialize resolves, install a fresh session mock
+      // (with its own sendCustomMessage spy) that the replay loop can write to.
+      const freshSendCustomMessage = vi.fn().mockResolvedValue(undefined);
+      internal.initialize = vi.fn().mockImplementation(async () => {
+        internal.session = { sendCustomMessage: freshSendCustomMessage };
+      });
+
+      const details = { sender: 1, receiver: 2, timestamp: Date.now() };
+
+      // Two scheduled-task deliveries pending: A is the one whose agent_end we are about
+      // to fire, B was queued behind it (e.g. memory-update piled up while daily-summary
+      // was running, or two cron ticks queued during a startup catch-up storm). Without
+      // replay, B would be stranded once resetSessionToHeader nulls out the session.
+      const resolveA = vi.fn();
+      const resolveB = vi.fn();
+      internal.pendingDeliveries = [
+        {
+          content: '[Scheduled task: daily-summary]\n\nfile: /a',
+          details,
+          scheduledTask: true,
+          resolve: resolveA,
+          reject: vi.fn(),
+        },
+        {
+          content: '[Scheduled task: memory-update]\n\nfile: /b',
+          details,
+          scheduledTask: true,
+          resolve: resolveB,
+          reject: vi.fn(),
+        },
+      ];
+      // Only A's send has been counted: B is queued but not yet flushed to the SDK because
+      // the session is busy on A. `agent_end` for A will shift A and leave B in the queue.
+      internal.deliverySendCount = 1;
+
+      internal.handleSessionEvent({ type: 'agent_end' });
+
+      // A's promise resolved as part of the pre-reset cleanup
+      expect(resolveA).toHaveBeenCalledOnce();
+      expect(resolveB).not.toHaveBeenCalled();
+
+      // Reset HAPPENED even though B is still queued — this is the round-1 fix.
+      const archived = readdirSync(testDir).filter((f) => f.endsWith('.jsonl.archived'));
+      expect(archived.length).toBe(1);
+      // Briefly null between resetSessionToHeader and initialize().then(), but after the
+      // microtask flush below the freshSendCustomMessage stub will be in place.
+
+      // Reinit was scheduled.
+      expect(internal.initialize).toHaveBeenCalledOnce();
+
+      // Flush microtasks so the void initialize().then(replay) chain runs.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // Fresh session is installed and B was replayed against it via sendCustomMessage.
+      expect(internal.session).not.toBeNull();
+      expect(freshSendCustomMessage).toHaveBeenCalledTimes(1);
+      const callArg = freshSendCustomMessage.mock.calls[0][0] as { content: string };
+      expect(callArg.content).toBe('[Scheduled task: memory-update]\n\nfile: /b');
+
+      // B is still in pendingDeliveries — replay does not pop, agent_end does on the next turn.
+      expect(internal.pendingDeliveries).toHaveLength(1);
+      expect(internal.pendingDeliveries[0].content).toContain('memory-update');
+    });
+
+    it('resets compactionCount (in-memory and persisted) on reset', () => {
+      const { internal } = makeHostWithSessionDir({ reset: true });
+
+      // Seed a non-zero compaction count to simulate a long-running narrator session.
+      internal.compactionCount = 241;
+      // Pre-write the persisted file so we can verify it gets clobbered to 0.
+      const countFile = join(testDir, '.compaction-count');
+      writeFileSync(countFile, '241');
+
+      const details = { sender: 1, receiver: 2, timestamp: Date.now() };
+      internal.pendingDeliveries = [
+        {
+          content: '[Scheduled task: daily-summary]\n\nfile: /x',
+          details,
+          scheduledTask: true,
+          resolve: vi.fn(),
+          reject: vi.fn(),
+        },
+      ];
+      internal.deliverySendCount = 1;
+      internal.lastTurnErrored = false;
+
+      internal.handleSessionEvent({ type: 'agent_end' });
+
+      expect(internal.compactionCount).toBe(0);
+      expect(readFileSync(countFile, 'utf-8').trim()).toBe('0');
+      expect(internal.lastTurnErrored).toBe(false);
     });
 
     it('deliverMessage marks scheduled-task content with scheduledTask flag', () => {

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -3718,7 +3718,8 @@ describe('AgentHost', () => {
         resetSessionAfterScheduledTask: opts.reset,
       });
       const internal = host as unknown as ResetInternal;
-      internal.session = { sendCustomMessage: vi.fn() };
+      // Stub dispose so resetSessionToHeader can call it before rotating the JSONL.
+      internal.session = { sendCustomMessage: vi.fn(), dispose: vi.fn() };
       internal._sessionDir = testDir;
       internal._chatCache = null;
       internal.agentRole = 'narrator';
@@ -3837,6 +3838,115 @@ describe('AgentHost', () => {
       expect(internal.initialize).not.toHaveBeenCalled();
     });
 
+    it('explicit caller-provided false beats frontmatter true (override-presence wins)', () => {
+      // Reproduce the precedence merge that initialize() runs at line 377-379:
+      //   if (!resetSessionAfterScheduledTaskOverridden) { reset = frontmatter === true; }
+      // With the override-presence flag, an explicit `false` from the caller must NOT be
+      // silently overridden by frontmatter `true`. Without the flag, this test would
+      // demonstrate the round-1 bug: frontmatter `true` flipping a caller-disabled `false`
+      // back on.
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+        resetSessionAfterScheduledTask: false,
+      });
+      const internal = host as unknown as {
+        resetSessionAfterScheduledTask: boolean;
+        resetSessionAfterScheduledTaskOverridden: boolean;
+      };
+      // Constructor should have captured the explicit override.
+      expect(internal.resetSessionAfterScheduledTaskOverridden).toBe(true);
+      expect(internal.resetSessionAfterScheduledTask).toBe(false);
+
+      // Mimic the initialize() merge with frontmatter saying `true`.
+      const frontmatterValue = true;
+      if (!internal.resetSessionAfterScheduledTaskOverridden) {
+        internal.resetSessionAfterScheduledTask = frontmatterValue === true;
+      }
+
+      // Override wins: stays false despite frontmatter `true`.
+      expect(internal.resetSessionAfterScheduledTask).toBe(false);
+    });
+
+    it('frontmatter true is honored when caller did not override', () => {
+      // No `resetSessionAfterScheduledTask` in config — so the override-presence flag is false
+      // and initialize()'s merge consults frontmatter.
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+      const internal = host as unknown as {
+        resetSessionAfterScheduledTask: boolean;
+        resetSessionAfterScheduledTaskOverridden: boolean;
+      };
+      expect(internal.resetSessionAfterScheduledTaskOverridden).toBe(false);
+      expect(internal.resetSessionAfterScheduledTask).toBe(false);
+
+      // Mimic the initialize() merge with frontmatter saying `true`.
+      const frontmatterValue = true;
+      if (!internal.resetSessionAfterScheduledTaskOverridden) {
+        internal.resetSessionAfterScheduledTask = frontmatterValue === true;
+      }
+
+      // Caller didn't override, so frontmatter wins.
+      expect(internal.resetSessionAfterScheduledTask).toBe(true);
+    });
+
+    it('sets isReinitializing during reset+reinit window so concurrent deliveries are rejected', async () => {
+      const { internal } = makeHostWithSessionDir({ reset: true });
+      const host = internal as unknown as AgentHost;
+
+      // Hold initialize() in flight so we can observe the in-window state.
+      let resolveInit!: () => void;
+      const initPromise = new Promise<void>((resolve) => {
+        resolveInit = resolve;
+      });
+      internal.initialize = vi.fn().mockImplementation(() => initPromise);
+
+      const details = { sender: 1, receiver: 2, timestamp: Date.now() };
+      internal.pendingDeliveries = [
+        {
+          content: '[Scheduled task: daily-summary]\n\nfile: /x',
+          details,
+          scheduledTask: true,
+          resolve: vi.fn(),
+          reject: vi.fn(),
+        },
+      ];
+      internal.deliverySendCount = 1;
+
+      // Trigger the reset+reinit path. After this returns, isReinitializing should be true.
+      internal.handleSessionEvent({ type: 'agent_end' });
+
+      const reinitFlag = (internal as unknown as { isReinitializing: boolean }).isReinitializing;
+      expect(reinitFlag).toBe(true);
+
+      // A delivery landing during the reinit window must be rejected with the cleaner
+      // "Agent is reinitializing" error, NOT the generic "not initialized" error. Even though
+      // resetSessionToHeader nulled `internal.session`, deliverMessage checks isReinitializing
+      // first so the more specific error wins.
+      await expect(
+        host.deliverMessage('[Message from guide agent (id=1)]\n\nhi', {
+          sender: 1,
+          receiver: 2,
+          timestamp: Date.now(),
+        })
+      ).rejects.toThrow(/Agent is reinitializing/);
+
+      // Let initialize() resolve and confirm the flag clears via the .finally hook.
+      resolveInit();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      const reinitFlagAfter = (internal as unknown as { isReinitializing: boolean })
+        .isReinitializing;
+      expect(reinitFlagAfter).toBe(false);
+    });
+
     it('replays queued deliveries against the fresh session after reset', async () => {
       const { internal } = makeHostWithSessionDir({ reset: true });
 
@@ -3846,7 +3956,7 @@ describe('AgentHost', () => {
       // (with its own sendCustomMessage spy) that the replay loop can write to.
       const freshSendCustomMessage = vi.fn().mockResolvedValue(undefined);
       internal.initialize = vi.fn().mockImplementation(async () => {
-        internal.session = { sendCustomMessage: freshSendCustomMessage };
+        internal.session = { sendCustomMessage: freshSendCustomMessage, dispose: vi.fn() };
       });
 
       const details = { sender: 1, receiver: 2, timestamp: Date.now() };

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -6,7 +6,7 @@
  * session.prompt() resolves.
  */
 
-import { mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -3663,6 +3663,209 @@ describe('AgentHost', () => {
       // The notice marker is the activity-log one, NOT the curated-file one
       expect(result).toContain('dropped oldest content from this activity log');
       expect(result).not.toContain('file exceeds');
+    });
+  });
+
+  describe('reset session after scheduled task', () => {
+    let testDir: string;
+
+    beforeEach(() => {
+      testDir = join(
+        tmpdir(),
+        `system2-test-reset-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
+      );
+      mkdirSync(testDir, { recursive: true });
+    });
+
+    afterEach(() => {
+      rmSync(testDir, { recursive: true, force: true });
+    });
+
+    type ResetInternal = {
+      pendingDeliveries: Array<{
+        content: string;
+        details: { sender: number; receiver: number; timestamp: number };
+        urgent?: boolean;
+        scheduledTask?: boolean;
+        resolve: () => void;
+        reject: (reason: Error) => void;
+      }>;
+      deliverySendCount: number;
+      session: unknown;
+      _sessionDir: string | null;
+      _chatCache: null;
+      resetSessionAfterScheduledTask: boolean;
+      agentRole: string | null;
+      unsubscribeSession: (() => void) | null;
+      handleSessionEvent: (event: Record<string, unknown>) => void;
+      handlePotentialError: ReturnType<typeof vi.fn>;
+      handleCompactionTracking: ReturnType<typeof vi.fn>;
+      initialize: ReturnType<typeof vi.fn>;
+    };
+
+    /** Build a host with stubbed lifecycle methods, ready for handleSessionEvent('agent_end'). */
+    function makeHostWithSessionDir(opts: { reset: boolean; sessionFile?: string }): {
+      host: AgentHost;
+      internal: ResetInternal;
+    } {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+        resetSessionAfterScheduledTask: opts.reset,
+      });
+      const internal = host as unknown as ResetInternal;
+      internal.session = { sendCustomMessage: vi.fn() };
+      internal._sessionDir = testDir;
+      internal._chatCache = null;
+      internal.agentRole = 'narrator';
+      internal.unsubscribeSession = null;
+      internal.handlePotentialError = vi.fn().mockResolvedValue(undefined);
+      internal.handleCompactionTracking = vi.fn();
+      // Stub initialize so the post-reset reinit doesn't try to load real config
+      internal.initialize = vi.fn().mockResolvedValue(undefined);
+
+      // Seed an existing JSONL with prior session state (header + a tool-call line)
+      const filename = opts.sessionFile ?? `${Date.now()}_seed.jsonl`;
+      const filePath = join(testDir, filename);
+      const seedLines = [
+        JSON.stringify({ type: 'session', version: 3, id: 'old-id', cwd: '/some/cwd' }),
+        JSON.stringify({ type: 'message', message: { role: 'user', content: 'hi' } }),
+        JSON.stringify({ type: 'message', message: { role: 'assistant', content: 'hello' } }),
+      ];
+      writeFileSync(filePath, `${seedLines.join('\n')}\n`);
+
+      return { host, internal };
+    }
+
+    it('truncates JSONL to fresh header and clears session after scheduled-task delivery', () => {
+      const { internal } = makeHostWithSessionDir({ reset: true });
+
+      const details = { sender: 1, receiver: 2, timestamp: Date.now() };
+      const resolveDelivery = vi.fn();
+      internal.pendingDeliveries = [
+        {
+          content: '[Scheduled task: daily-summary]\n\nfile: /x',
+          details,
+          scheduledTask: true,
+          resolve: resolveDelivery,
+          reject: vi.fn(),
+        },
+      ];
+      internal.deliverySendCount = 1;
+
+      internal.handleSessionEvent({ type: 'agent_end' });
+
+      // Delivery promise resolved (cleanup happened before reset)
+      expect(resolveDelivery).toHaveBeenCalledOnce();
+
+      // Old file archived
+      const files = readdirSync(testDir);
+      const archived = files.filter((f) => f.endsWith('.jsonl.archived'));
+      expect(archived.length).toBe(1);
+
+      // Active JSONL contains exactly one line: a fresh session header
+      const active = files.filter((f) => f.endsWith('.jsonl'));
+      expect(active.length).toBe(1);
+      const activePath = join(testDir, active[0]);
+      const lines = readFileSync(activePath, 'utf-8')
+        .split('\n')
+        .filter((l) => l.length > 0);
+      expect(lines).toHaveLength(1);
+      const header = JSON.parse(lines[0]);
+      expect(header.type).toBe('session');
+      expect(header.version).toBe(3);
+      expect(header.id).toBeTruthy();
+      // Header is fresh, not the seeded one
+      expect(header.id).not.toBe('old-id');
+
+      // In-memory session was cleared so the next prompt forces reinit
+      expect(internal.session).toBeNull();
+
+      // Reinit was kicked off asynchronously
+      expect(internal.initialize).toHaveBeenCalledOnce();
+    });
+
+    it('does not reset when delivery content lacks the [Scheduled task: prefix', () => {
+      const { internal } = makeHostWithSessionDir({ reset: true });
+
+      const details = { sender: 1, receiver: 2, timestamp: Date.now() };
+      internal.pendingDeliveries = [
+        {
+          content: '[Message from guide agent (id=1)]\n\nplease look at this',
+          details,
+          scheduledTask: false,
+          resolve: vi.fn(),
+          reject: vi.fn(),
+        },
+      ];
+      internal.deliverySendCount = 1;
+
+      const sessionBefore = internal.session;
+      internal.handleSessionEvent({ type: 'agent_end' });
+
+      const archived = readdirSync(testDir).filter((f) => f.endsWith('.archived'));
+      expect(archived.length).toBe(0);
+      expect(internal.session).toBe(sessionBefore);
+      expect(internal.initialize).not.toHaveBeenCalled();
+    });
+
+    it('does not reset when resetSessionAfterScheduledTask is false', () => {
+      const { internal } = makeHostWithSessionDir({ reset: false });
+
+      const details = { sender: 1, receiver: 2, timestamp: Date.now() };
+      internal.pendingDeliveries = [
+        {
+          content: '[Scheduled task: daily-summary]\n\nfile: /x',
+          details,
+          scheduledTask: true,
+          resolve: vi.fn(),
+          reject: vi.fn(),
+        },
+      ];
+      internal.deliverySendCount = 1;
+
+      const sessionBefore = internal.session;
+      internal.handleSessionEvent({ type: 'agent_end' });
+
+      const archived = readdirSync(testDir).filter((f) => f.endsWith('.archived'));
+      expect(archived.length).toBe(0);
+      expect(internal.session).toBe(sessionBefore);
+      expect(internal.initialize).not.toHaveBeenCalled();
+    });
+
+    it('deliverMessage marks scheduled-task content with scheduledTask flag', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+      const internal = host as unknown as {
+        session: { sendCustomMessage: ReturnType<typeof vi.fn> };
+        _chatCache: null;
+        _sessionDir: string | null;
+        pendingDeliveries: Array<{ content: string; scheduledTask?: boolean }>;
+      };
+      internal.session = { sendCustomMessage: vi.fn() };
+      internal._chatCache = null;
+      internal._sessionDir = null;
+
+      host.deliverMessage('[Scheduled task: project-log]\n\nproject_id: 1', {
+        sender: 0,
+        receiver: 2,
+        timestamp: Date.now(),
+      });
+      host.deliverMessage('[Message from guide agent (id=1)]\n\nhi', {
+        sender: 1,
+        receiver: 2,
+        timestamp: Date.now(),
+      });
+
+      expect(internal.pendingDeliveries).toHaveLength(2);
+      expect(internal.pendingDeliveries[0].scheduledTask).toBe(true);
+      expect(internal.pendingDeliveries[1].scheduledTask).toBe(false);
     });
   });
 });

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -1703,9 +1703,12 @@ export class AgentHost {
    * Called after `agent_end` for a scheduled-task delivery on roles that opt in via
    * `reset_session_after_scheduled_task: true`.
    *
-   * The old JSONL is archived as `<name>.jsonl.archived` (mirrors session-rotation behavior, so
-   * compaction baseline scanning still finds prior summaries). The next prompt or delivery sees
-   * `this.session === null` and drives reinitialization, which reads the new header-only JSONL.
+   * The old JSONL is archived as `<name>.jsonl.archived` for forensic inspection (the active-
+   * session scanner only reads files ending in `.jsonl`, so archived files are excluded from
+   * subsequent loads). Compaction state is also reset to 0, so baseline lookup will start fresh
+   * on the new session — no scanner traversal of older files is needed. The next prompt or
+   * delivery sees `this.session === null` and drives reinitialization, which reads the new
+   * header-only JSONL.
    *
    * Failures are logged but never thrown: a failed reset must not break the agent. The next cron
    * tick simply runs against the unrotated file and may eventually hit the size-rotation path.

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -631,21 +631,26 @@ export class AgentHost {
       // losing semantic context. Reset happens after delivery promises have resolved (above) so
       // awaiting callers see success before reinit kicks off.
       //
-      // Skip reset if other deliveries are still queued (would be stranded with session=null
-      // until reinit completes). For the Narrator, scheduler jobs serialize one tick at a time,
-      // so this is the common case; the guard is a safety net for unusual interleavings.
-      if (
-        completedScheduledTask &&
-        this.resetSessionAfterScheduledTask &&
-        this.pendingDeliveries.length === 0
-      ) {
+      // Always reset, even if other deliveries are still queued. The pathological case this
+      // feature protects against (e.g. daily-summary + memory-update overlap, or catch-up
+      // storms at startup queueing multiple scheduled tasks) is precisely when several
+      // deliveries pile up. After reinitialize() resolves, replay the queued deliveries
+      // against the fresh session.
+      if (completedScheduledTask && this.resetSessionAfterScheduledTask) {
         this.resetSessionToHeader();
         // Reinitialize asynchronously so the next scheduled tick has a live session ready.
         // Errors are logged inside reinitialize(); cron ticks are 30 min apart so this has
         // plenty of headroom. Using void-and-catch to keep handleSessionEvent synchronous.
-        void this.initialize().catch((err) => {
-          log.error('[AgentHost] Failed to reinitialize after scheduled-task reset:', err);
-        });
+        void this.initialize()
+          .then(() => {
+            // Replay any deliveries queued while the just-completed scheduled task was running
+            // (or that arrived between agent_end and this point). Without replay they would be
+            // stranded in pendingDeliveries with the now-fresh session never seeing them.
+            this.replayPendingDeliveries('after scheduled-task reset');
+          })
+          .catch((err) => {
+            log.error('[AgentHost] Failed to reinitialize after scheduled-task reset:', err);
+          });
       }
 
       // Track compaction for pruning. May synchronously schedule pruning,
@@ -1695,6 +1700,16 @@ export class AgentHost {
         this.unsubscribeSession = null;
       }
       this.session = null;
+      // Reset compaction state alongside the session: the new JSONL has no prior compactions,
+      // so leaving the counter at its prior value (observed at 241+ during the cascade this
+      // feature fixes) would let the pruning trigger fire spuriously against the empty file.
+      // Persist 0 to disk too, since initialize() rehydrates compactionCount from the
+      // .compaction-count file.
+      this.compactionCount = 0;
+      this.writeCompactionCount(0);
+      // Clear lastTurnErrored: a leftover error flag from the just-completed scheduled task
+      // would otherwise corrupt cleanup decisions on the first agent_end of the fresh session.
+      this.lastTurnErrored = false;
       log.info(
         `[AgentHost] Reset ${this.agentRole ?? 'agent'} session after scheduled task; JSONL truncated to fresh header (${newFilename}).`
       );
@@ -1876,32 +1891,44 @@ export class AgentHost {
     // Clear the overflow-causing prompt so a future failover doesn't retry it
     this.pendingPrompt = null;
     this.deliverySendCount = 0;
-    // Replay pending deliveries on the recovered session. Don't clear
-    // pendingDeliveries: agent_end will shift each one as turns succeed.
-    if (this.pendingDeliveries.length > 0 && this.session) {
-      for (const delivery of this.pendingDeliveries) {
-        this.deliverySendCount++;
-        this.session
-          .sendCustomMessage(
-            {
-              customType: 'agent_message',
-              content: delivery.content,
-              display: false,
-              details: delivery.details,
-            },
-            {
-              deliverAs: delivery.urgent ? 'steer' : 'followUp',
-              triggerTurn: true,
-            }
-          )
-          .catch((error) => {
-            this.deliverySendCount = Math.max(0, this.deliverySendCount - 1);
-            log.error('[AgentHost] Failed to replay delivery after context overflow:', error);
-            const idx = this.pendingDeliveries.indexOf(delivery);
-            if (idx !== -1) this.pendingDeliveries.splice(idx, 1);
-            delivery.reject(error instanceof Error ? error : new Error(String(error)));
-          });
-      }
+    this.replayPendingDeliveries('after context overflow');
+  }
+
+  /**
+   * Replay pending deliveries against the current session via sendCustomMessage.
+   *
+   * Used by recovery paths (context overflow, scheduled-task session reset) that swap or
+   * rebuild the underlying SDK session: deliveries that were queued during the disruption
+   * need to be re-sent so the fresh session actually sees them. Don't clear
+   * `pendingDeliveries` here — `agent_end` will shift each one as turns succeed.
+   *
+   * Caller is responsible for clearing `pendingPrompt` / `deliverySendCount` first if the
+   * recovery path requires it.
+   */
+  private replayPendingDeliveries(context: string): void {
+    if (this.pendingDeliveries.length === 0 || !this.session) return;
+    for (const delivery of this.pendingDeliveries) {
+      this.deliverySendCount++;
+      this.session
+        .sendCustomMessage(
+          {
+            customType: 'agent_message',
+            content: delivery.content,
+            display: false,
+            details: delivery.details,
+          },
+          {
+            deliverAs: delivery.urgent ? 'steer' : 'followUp',
+            triggerTurn: true,
+          }
+        )
+        .catch((error) => {
+          this.deliverySendCount = Math.max(0, this.deliverySendCount - 1);
+          log.error(`[AgentHost] Failed to replay delivery ${context}:`, error);
+          const idx = this.pendingDeliveries.indexOf(delivery);
+          if (idx !== -1) this.pendingDeliveries.splice(idx, 1);
+          delivery.reject(error instanceof Error ? error : new Error(String(error)));
+        });
     }
   }
 

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -58,9 +58,11 @@ import {
   sleep,
 } from './retry.js';
 import {
+  createSessionHeader,
   findMostRecentSession,
   parseSessionEntries,
   rotateSessionIfNeeded,
+  writeRotatedFile,
 } from './session-rotation.js';
 
 /** Human-readable label for error categories shown in chat messages. */
@@ -123,6 +125,12 @@ interface AgentDefinition {
   version: string;
   thinking_level?: ThinkingLevel;
   compaction_depth?: number;
+  /** When true and a delivery's content starts with `[Scheduled task:`, the agent's session JSONL
+   *  is truncated to a fresh session header after `agent_end` for that delivery. Intended for
+   *  cron-driven, stateless agents (e.g., Narrator) whose durable memory lives in files
+   *  (`daily_summaries/*.md`, `memory.md`, per-project `log.md`) rather than in their session.
+   *  Prevents context-overflow loops where each tick's restored session keeps growing. */
+  reset_session_after_scheduled_task?: boolean;
   models: {
     anthropic: string;
     cerebras: string;
@@ -158,6 +166,11 @@ export interface AgentHostConfig {
   narratorMessageExcerptBytes?: number;
   /** Session-rotation threshold in bytes. Defaults to SESSION_FILE_SIZE_LIMIT (10 MB). */
   sessionRotationSizeBytes?: number;
+  /** When true and a delivery's content starts with `[Scheduled task:`, truncate the agent's
+   *  session JSONL to header-only after `agent_end` for that delivery. Sourced from the agent
+   *  library frontmatter (`reset_session_after_scheduled_task: true`). Intended for cron-driven,
+   *  stateless agents (Narrator) whose durable memory lives in files, not in their session. */
+  resetSessionAfterScheduledTask?: boolean;
   /** Called when the agent's busy state changes. */
   onBusyChange?: (agentId: number, busy: boolean, contextPercent: number | null) => void;
   /** Called when an agent is terminated via terminate_agent tool. */
@@ -187,6 +200,9 @@ export class AgentHost {
     content: string;
     details: { sender: number; receiver: number; timestamp: number };
     urgent?: boolean;
+    /** True when `content` starts with `[Scheduled task:`. Set at deliverMessage() time and
+     *  read in handleSessionEvent() on `agent_end` to decide whether to reset session JSONL. */
+    scheduledTask?: boolean;
     resolve: () => void;
     reject: (reason: Error) => void;
   }> = [];
@@ -219,6 +235,7 @@ export class AgentHost {
   private onAgentTerminate?: () => void;
   private maxDeliveryBytes: number;
   private sessionRotationSizeBytes: number | undefined;
+  private resetSessionAfterScheduledTask: boolean;
 
   constructor(config: AgentHostConfig) {
     this.db = config.db;
@@ -239,6 +256,9 @@ export class AgentHost {
     this.onAgentTerminate = config.onAgentTerminate;
     this.maxDeliveryBytes = config.maxDeliveryBytes ?? MAX_DELIVERY_BYTES;
     this.sessionRotationSizeBytes = config.sessionRotationSizeBytes;
+    // Caller-provided override; otherwise initialize() reads it from the agent library frontmatter
+    // (`reset_session_after_scheduled_task` field). Default false: only opted-in roles reset.
+    this.resetSessionAfterScheduledTask = config.resetSessionAfterScheduledTask ?? false;
 
     // Store LLM config for openai-compatible provider registration
     this.llmConfig = config.llmConfig;
@@ -351,6 +371,12 @@ export class AgentHost {
     }
 
     this.agentModels = agentConfig.models ?? {};
+    // Source the session-reset flag from the agent library frontmatter unless the constructor
+    // explicitly opted in. Caller-provided `true` always wins; otherwise the frontmatter value
+    // (default false for unset) governs reset behavior for this role.
+    if (!this.resetSessionAfterScheduledTask) {
+      this.resetSessionAfterScheduledTask = agentConfig.reset_session_after_scheduled_task === true;
+    }
     // Static parts of the system prompt (loaded once)
     const staticPrompt = `${agentsRefContent}\n\n${agentPrompt}`;
 
@@ -573,6 +599,7 @@ export class AgentHost {
       // On error turns, lastTurnErrored is true (set synchronously in
       // handlePotentialError before agent_end fires). Skip cleanup so the
       // failed prompt/delivery stays tracked for retry or failover.
+      let completedScheduledTask = false;
       if (!this.lastTurnErrored) {
         // Clear pendingPrompt: one agent_end fires after ALL turns (prompt +
         // follow-ups) are processed, so it's always safe to clear here.
@@ -585,7 +612,10 @@ export class AgentHost {
         const toResolve = Math.min(this.deliverySendCount, this.pendingDeliveries.length);
         for (let i = 0; i < toResolve; i++) {
           const completed = this.pendingDeliveries.shift();
-          if (completed) completed.resolve();
+          if (completed) {
+            if (completed.scheduledTask) completedScheduledTask = true;
+            completed.resolve();
+          }
         }
         this.deliverySendCount = 0;
         // Re-arm the OAuth refresh guard so a future 401 on a fresh token can
@@ -593,6 +623,30 @@ export class AgentHost {
         this.oauthRefreshAttempted = false;
       }
       this.lastTurnErrored = false;
+
+      // If this turn completed a scheduled-task delivery for a role configured to reset,
+      // truncate the session JSONL to a fresh header. The Narrator's durable memory lives in
+      // files (`daily_summaries/*.md`, `memory.md`, per-project `log.md`) — not in its session
+      // — so dropping session state between cron ticks prevents context-overflow loops without
+      // losing semantic context. Reset happens after delivery promises have resolved (above) so
+      // awaiting callers see success before reinit kicks off.
+      //
+      // Skip reset if other deliveries are still queued (would be stranded with session=null
+      // until reinit completes). For the Narrator, scheduler jobs serialize one tick at a time,
+      // so this is the common case; the guard is a safety net for unusual interleavings.
+      if (
+        completedScheduledTask &&
+        this.resetSessionAfterScheduledTask &&
+        this.pendingDeliveries.length === 0
+      ) {
+        this.resetSessionToHeader();
+        // Reinitialize asynchronously so the next scheduled tick has a live session ready.
+        // Errors are logged inside reinitialize(); cron ticks are 30 min apart so this has
+        // plenty of headroom. Using void-and-catch to keep handleSessionEvent synchronous.
+        void this.initialize().catch((err) => {
+          log.error('[AgentHost] Failed to reinitialize after scheduled-task reset:', err);
+        });
+      }
 
       // Track compaction for pruning. May synchronously schedule pruning,
       // setting isPruning = true.
@@ -1403,7 +1457,8 @@ export class AgentHost {
     // Track for failover retry. If the session is destroyed during reinitialization,
     // queued sendCustomMessage calls are lost. This queue lets handlePotentialError
     // replay them on the new session. Cleared per-turn by agent_end (shift).
-    this.pendingDeliveries.push({ content, details, urgent, resolve, reject });
+    const scheduledTask = content.startsWith('[Scheduled task:');
+    this.pendingDeliveries.push({ content, details, urgent, scheduledTask, resolve, reject });
 
     // Capture delivered message in chat cache for UI history.
     // Inter-agent messages and summaries store full content (tag + body).
@@ -1609,6 +1664,43 @@ export class AgentHost {
     this.listeners.forEach((listener) => {
       listener(deferred);
     });
+  }
+
+  /**
+   * Truncate the active session JSONL to a fresh session header and clear in-memory session state.
+   * Called after `agent_end` for a scheduled-task delivery on roles that opt in via
+   * `reset_session_after_scheduled_task: true`.
+   *
+   * The old JSONL is archived as `<name>.jsonl.archived` (mirrors session-rotation behavior, so
+   * compaction baseline scanning still finds prior summaries). The next prompt or delivery sees
+   * `this.session === null` and drives reinitialization, which reads the new header-only JSONL.
+   *
+   * Failures are logged but never thrown: a failed reset must not break the agent. The next cron
+   * tick simply runs against the unrotated file and may eventually hit the size-rotation path.
+   */
+  private resetSessionToHeader(): void {
+    const sessionDir = this._sessionDir;
+    if (!sessionDir) return;
+    const activeFile = findMostRecentSession(sessionDir);
+    if (!activeFile) return;
+
+    try {
+      const newFilename = writeRotatedFile(sessionDir, activeFile, [
+        createSessionHeader(SYSTEM2_DIR),
+      ]);
+      // Detach session-event subscription before clearing the session so listeners don't fire
+      // against a torn-down session. The next prompt/delivery will trigger initialize().
+      if (this.unsubscribeSession) {
+        this.unsubscribeSession();
+        this.unsubscribeSession = null;
+      }
+      this.session = null;
+      log.info(
+        `[AgentHost] Reset ${this.agentRole ?? 'agent'} session after scheduled task; JSONL truncated to fresh header (${newFilename}).`
+      );
+    } catch (err) {
+      log.error('[AgentHost] Failed to reset session JSONL after scheduled task:', err);
+    }
   }
 
   /**

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -236,6 +236,12 @@ export class AgentHost {
   private maxDeliveryBytes: number;
   private sessionRotationSizeBytes: number | undefined;
   private resetSessionAfterScheduledTask: boolean;
+  /** True when the constructor caller passed `resetSessionAfterScheduledTask` explicitly (true OR
+   *  false). Used in initialize() to decide whether to consult the agent library frontmatter. We
+   *  cannot rely on the boolean field alone because `false` and "unset" are indistinguishable —
+   *  without this flag, a caller passing `false` to disable a role's frontmatter `true` would be
+   *  silently overridden right back. */
+  private resetSessionAfterScheduledTaskOverridden: boolean;
 
   constructor(config: AgentHostConfig) {
     this.db = config.db;
@@ -258,6 +264,10 @@ export class AgentHost {
     this.sessionRotationSizeBytes = config.sessionRotationSizeBytes;
     // Caller-provided override; otherwise initialize() reads it from the agent library frontmatter
     // (`reset_session_after_scheduled_task` field). Default false: only opted-in roles reset.
+    // Track override-presence separately so a caller passing `false` (to disable a role's
+    // frontmatter `true`) is distinguishable from "caller did not specify".
+    this.resetSessionAfterScheduledTaskOverridden =
+      config.resetSessionAfterScheduledTask !== undefined;
     this.resetSessionAfterScheduledTask = config.resetSessionAfterScheduledTask ?? false;
 
     // Store LLM config for openai-compatible provider registration
@@ -372,9 +382,11 @@ export class AgentHost {
 
     this.agentModels = agentConfig.models ?? {};
     // Source the session-reset flag from the agent library frontmatter unless the constructor
-    // explicitly opted in. Caller-provided `true` always wins; otherwise the frontmatter value
-    // (default false for unset) governs reset behavior for this role.
-    if (!this.resetSessionAfterScheduledTask) {
+    // caller passed an explicit value. Precedence: explicit caller value (true OR false) wins;
+    // otherwise the frontmatter value (default false for unset) governs reset behavior. Gating on
+    // an "overridden" flag rather than the boolean itself lets a caller pass `false` to disable a
+    // role's frontmatter `true` — without this, `false` would be indistinguishable from "unset".
+    if (!this.resetSessionAfterScheduledTaskOverridden) {
       this.resetSessionAfterScheduledTask = agentConfig.reset_session_after_scheduled_task === true;
     }
     // Static parts of the system prompt (loaded once)
@@ -639,8 +651,13 @@ export class AgentHost {
       if (completedScheduledTask && this.resetSessionAfterScheduledTask) {
         this.resetSessionToHeader();
         // Reinitialize asynchronously so the next scheduled tick has a live session ready.
-        // Errors are logged inside reinitialize(); cron ticks are 30 min apart so this has
-        // plenty of headroom. Using void-and-catch to keep handleSessionEvent synchronous.
+        // Errors are logged in the .catch below; cron ticks are 30 min apart so initialize()
+        // has plenty of headroom. Using void-and-catch to keep handleSessionEvent synchronous.
+        // Set isReinitializing so any deliverMessage()/prompt() calls landing during the
+        // reset+reinit window get the existing "Agent is reinitializing" rejection instead of
+        // racing against a half-torn-down session, then clear it in .finally so the next tick
+        // is unblocked even if initialize() throws.
+        this.isReinitializing = true;
         void this.initialize()
           .then(() => {
             // Replay any deliveries queued while the just-completed scheduled task was running
@@ -650,6 +667,9 @@ export class AgentHost {
           })
           .catch((err) => {
             log.error('[AgentHost] Failed to reinitialize after scheduled-task reset:', err);
+          })
+          .finally(() => {
+            this.isReinitializing = false;
           });
       }
 
@@ -1391,6 +1411,9 @@ export class AgentHost {
    * @param options.isSteering If true, the message is queued as a steering message (inserted ASAP into the agent loop)
    */
   async prompt(content: string, options?: { isSteering?: boolean }): Promise<void> {
+    if (this.isReinitializing) {
+      throw new Error('Agent is reinitializing, prompt rejected');
+    }
     if (!this.session) {
       throw new Error('AgentHost not initialized. Call initialize() first.');
     }
@@ -1432,11 +1455,15 @@ export class AgentHost {
     details: { sender: number; receiver: number; timestamp: number },
     urgent?: boolean
   ): Promise<void> {
-    if (!this.session) {
-      return Promise.reject(new Error('AgentHost not initialized. Call initialize() first.'));
-    }
+    // Check isReinitializing BEFORE the null-session guard. The scheduled-task reset path
+    // explicitly nulls `this.session` before kicking off initialize(), so during that window
+    // both conditions hold; surfacing the more specific "reinitializing" error helps callers
+    // distinguish a transient reinit from a permanent uninitialized state.
     if (this.isReinitializing) {
       return Promise.reject(new Error('Agent is reinitializing, delivery rejected'));
+    }
+    if (!this.session) {
+      return Promise.reject(new Error('AgentHost not initialized. Call initialize() first.'));
     }
 
     // Check wire-size budget before queuing
@@ -1690,16 +1717,31 @@ export class AgentHost {
     if (!activeFile) return;
 
     try {
-      const newFilename = writeRotatedFile(sessionDir, activeFile, [
-        createSessionHeader(SYSTEM2_DIR),
-      ]);
-      // Detach session-event subscription before clearing the session so listeners don't fire
-      // against a torn-down session. The next prompt/delivery will trigger initialize().
+      // Tear the SDK session down BEFORE renaming the active JSONL. The pi-coding-agent
+      // SessionManager uses `appendFileSync(this.sessionFile, ...)` and resolves `sessionFile`
+      // up front. After we rename the active file, any further append from the live SDK session
+      // would recreate the file at the original path WITHOUT a header — exactly the hazard the
+      // existing rotateSessionIfNeeded path warns about. Order: detach our subscription, capture
+      // and null the session ref so concurrent paths can't reuse it, then call session.dispose()
+      // (which calls _disconnectFromAgent and clears the SDK's internal event listeners).
       if (this.unsubscribeSession) {
         this.unsubscribeSession();
         this.unsubscribeSession = null;
       }
+      const oldSession = this.session;
       this.session = null;
+      if (oldSession) {
+        try {
+          oldSession.dispose();
+        } catch (disposeErr) {
+          // dispose() should not throw — log and continue so the rotation still happens.
+          log.warn('[AgentHost] Error disposing old session during reset:', disposeErr);
+        }
+      }
+
+      const newFilename = writeRotatedFile(sessionDir, activeFile, [
+        createSessionHeader(SYSTEM2_DIR),
+      ]);
       // Reset compaction state alongside the session: the new JSONL has no prior compactions,
       // so leaving the counter at its prior value (observed at 241+ during the cascade this
       // feature fixes) would let the pruning trigger fire spuriously against the empty file.

--- a/src/server/agents/library/narrator.md
+++ b/src/server/agents/library/narrator.md
@@ -38,6 +38,8 @@ Messages arrive with a `[Scheduled task: <name>]` prefix. Handle them as follows
 
 **Cursor management.** The server automatically advances and commits `last_narrator_update_ts` in all knowledge files after you finish processing each delivery. Do not modify this field yourself.
 
+**Session resets between scheduled tasks.** Your session JSONL is automatically truncated to a fresh header after each `[Scheduled task: ...]` delivery completes. You will not retain conversational memory of prior scheduled tasks. Your durable record lives in the daily summary files (`daily_summaries/*.md`), `memory.md`, and per-project `log.md` files — read them when you need historical context. This keeps your working set small enough to fit Haiku's 200K context limit even when source-agent activity is dense.
+
 ### Project Log (`[Scheduled task: project-log]`)
 
 **Goal:** Append a narrative summary of recent project-scoped activity to the project's continuous log file.

--- a/src/server/agents/library/narrator.md
+++ b/src/server/agents/library/narrator.md
@@ -4,6 +4,7 @@ description: "Memory keeper: maintains long-term memory and creates daily activi
 version: 3.0.0
 thinking_level: medium
 compaction_depth: 3
+reset_session_after_scheduled_task: true
 models:
   anthropic: claude-haiku-4-5-20251001
   cerebras: gpt-oss-120b

--- a/src/server/agents/session-rotation.ts
+++ b/src/server/agents/session-rotation.ts
@@ -106,7 +106,7 @@ function generateSessionFilename(): string {
 /**
  * Create a new session header.
  */
-function createSessionHeader(cwd: string): SessionEntry {
+export function createSessionHeader(cwd: string): SessionEntry {
   return {
     type: 'session',
     version: 3,
@@ -181,7 +181,7 @@ function selectTailEntries(entries: SessionEntry[], tailBytes: number): SessionE
 /**
  * Write rotated entries to a new JSONL and archive the old file.
  */
-function writeRotatedFile(
+export function writeRotatedFile(
   sessionDir: string,
   oldFilePath: string,
   newEntries: SessionEntry[]


### PR DESCRIPTION
## Summary

- Add a per-role `reset_session_after_scheduled_task` flag in agent library frontmatter (default false). Narrator opts in; other agents keep their conversational sessions.
- After `agent_end` for any delivery whose content starts with `[Scheduled task:`, the `AgentHost` archives the active JSONL, writes a fresh header-only file, clears the in-memory session and compaction state (counter zeroed in memory and on disk), and kicks off async `initialize()` so the next cron tick has a live session ready.
- After `initialize()` resolves, any deliveries that were queued during the just-completed task (or that arrived between `agent_end` and reinit) are replayed against the fresh session via the same `replayPendingDeliveries` helper used by the failover-recovery path.
- Fixes the context-overflow cascade where each tick's restored Narrator session (long writeup + tool-call traces) plus the new catch-up delivery exceeded Haiku 4.5's 200K window, growing the JSONL by tens of MB before size-rotation fired.

## Design notes

- **Always reset, even with queued deliveries.** The pathological cases this feature protects against (daily-summary + memory-update overlap, catch-up storms at startup queueing multiple scheduled tasks) are precisely when several deliveries pile up. Reset always fires; queued deliveries are replayed against the fresh session after reinit completes.
- **Reset runs after delivery promises resolve**, so awaiting callers (scheduler) see the delivery succeed before reinit begins.
- **SDK session is disposed before file rotation.** `AgentSession.dispose()` is called before `writeRotatedFile` so any post-rename append from the SDK can't recreate the active path without a header. Wrapped in try/log.warn so a buggy dispose can't abort rotation.
- **`isReinitializing` is set during the reset+reinit window**, so any incoming `deliverMessage`/`prompt` get the clearer "Agent is reinitializing" error instead of failing on `session === null`.
- **Caller override semantics:** `AgentHostConfig.resetSessionAfterScheduledTask` is tracked separately from frontmatter via `resetSessionAfterScheduledTaskOverridden`, so a caller passing `false` correctly disables a role's frontmatter `true` (tests, diagnostics).
- **Compaction state is reset along with the session.** The counter is zeroed in memory AND `.compaction-count` is overwritten to `0`, since `initialize()` rehydrates from disk. This ensures baseline lookup starts fresh after reset; the older-file scanner (`scanOlderSessionFiles`) only reads `.jsonl`, not `.jsonl.archived`, so archived files are correctly excluded.
- `writeRotatedFile`, `createSessionHeader`, and `findMostRecentSession` were exported so the reset path reuses the same archive/header semantics as size-based rotation.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm vitest run src/server/agents/host.test.ts` — 9 reset-specific tests pass
- [x] `pnpm test` — full suite 847 tests pass (was 838 on main)
- [x] `pnpm check` clean
- [x] `pnpm build` succeeds
- [x] New tests cover: scheduled-task prefix detection on `deliverMessage`, JSONL truncation + archival + session clear after `agent_end`, no-op when delivery is not a scheduled task, no-op when the flag is disabled, queued-overlap scenario (delivery B queued before A's `agent_end`; reset fires; B replays against fresh session), compaction state reset, caller override disabling frontmatter `true`, in-flight reinit window returning the "Agent is reinitializing" error

Fixes #154