### PR TITLE
feat(session-rotation): cap session JSONL archive count per agent

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -108,6 +108,7 @@ budget_chars = 20000  # Max chars per knowledge file; Narrator condenses overrun
 
 [session]
 rotation_size_bytes = 10485760        # Rotation threshold (~10 MB); anchored if compaction exists, bare-bytes-tail otherwise
+archive_keep_count = 5                # Max .jsonl.archived files retained per agent's session directory
 
 [delivery]
 max_bytes = 1048576                # Hard cap on inter-agent delivery wire size (~1 MB)
@@ -171,6 +172,7 @@ Each agent appends turns to a JSONL session file under `~/.system2/sessions/<rol
 | Setting | Default | Purpose |
 |---------|---------|---------|
 | `rotation_size_bytes` | 10485760 (10 MB) | Rotation threshold. On agent cold start, if the active JSONL exceeds this size, the file is rotated and the old one is renamed to `<filename>.jsonl.archived`. |
+| `archive_keep_count` | 5 | Maximum number of `.jsonl.archived` files retained per agent's session directory. After every successful rotation (size-based on cold start, or the per-task narrator session reset), older archives are pruned by mtime so disk usage stays bounded for high-volume agents. The Narrator alone produces ~48 archives/day on a 30-min cron; without a cap, archive disk grows monotonically. |
 
 **Two inner paths, one threshold.** Once `rotation_size_bytes` is exceeded:
 

--- a/src/cli/utils/config.test.ts
+++ b/src/cli/utils/config.test.ts
@@ -807,12 +807,14 @@ describe('convertTomlDelivery', () => {
 });
 
 describe('convertTomlSession', () => {
-  it('reads valid config correctly with rotation_size_bytes set', () => {
+  it('reads valid config correctly with all fields set', () => {
     const result = convertTomlSession({
       rotation_size_bytes: 5 * 1024 * 1024,
+      archive_keep_count: 8,
     });
     expect(result).toEqual({
       rotation_size_bytes: 5 * 1024 * 1024,
+      archive_keep_count: 8,
     });
   });
 
@@ -826,6 +828,8 @@ describe('convertTomlSession', () => {
       rotation_size_bytes: 20 * 1024 * 1024,
     });
     expect(result.rotation_size_bytes).toBe(20 * 1024 * 1024);
+    // Missing archive_keep_count falls back to the default.
+    expect(result.archive_keep_count).toBe(DEFAULT_SESSION.archive_keep_count);
   });
 
   it('warns and uses default for non-positive rotation_size_bytes', () => {
@@ -858,28 +862,69 @@ describe('convertTomlSession', () => {
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
   });
+
+  it('preserves a valid archive_keep_count', () => {
+    const result = convertTomlSession({ archive_keep_count: 12 });
+    expect(result.archive_keep_count).toBe(12);
+    expect(result.rotation_size_bytes).toBe(DEFAULT_SESSION.rotation_size_bytes);
+  });
+
+  it('warns and uses default for non-positive archive_keep_count', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = convertTomlSession({ archive_keep_count: 0 });
+    expect(result.archive_keep_count).toBe(DEFAULT_SESSION.archive_keep_count);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('session.archive_keep_count'));
+    warnSpy.mockRestore();
+  });
+
+  it('warns and uses default for negative archive_keep_count', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = convertTomlSession({ archive_keep_count: -3 });
+    expect(result.archive_keep_count).toBe(DEFAULT_SESSION.archive_keep_count);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('session.archive_keep_count'));
+    warnSpy.mockRestore();
+  });
+
+  it('warns and uses default for non-integer archive_keep_count', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = convertTomlSession({ archive_keep_count: 5.7 });
+    expect(result.archive_keep_count).toBe(DEFAULT_SESSION.archive_keep_count);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('session.archive_keep_count'));
+    warnSpy.mockRestore();
+  });
+
+  it('does not warn when archive_keep_count is a valid positive integer', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    convertTomlSession({ archive_keep_count: 5 });
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
 });
 
 describe('buildConfigToml — [session] section', () => {
-  it('emits [session] section with default value when not specified', () => {
+  it('emits [session] section with default values when not specified', () => {
     const result = buildConfigToml({});
     expect(result).toContain('[session]');
     expect(result).toContain(`rotation_size_bytes = ${DEFAULT_SESSION.rotation_size_bytes}`);
+    expect(result).toContain(`archive_keep_count = ${DEFAULT_SESSION.archive_keep_count}`);
   });
 
-  it('emits [session] section with custom value when specified', () => {
+  it('emits [session] section with custom values when specified', () => {
     const result = buildConfigToml({
       session: {
         rotation_size_bytes: 20 * 1024 * 1024,
+        archive_keep_count: 10,
       },
     });
     expect(result).toContain('[session]');
     expect(result).toContain(`rotation_size_bytes = ${20 * 1024 * 1024}`);
+    expect(result).toContain('archive_keep_count = 10');
   });
 
   it('round-trips [session] section through TOML.parse and convertTomlSession', () => {
     const input = {
       rotation_size_bytes: 15 * 1024 * 1024,
+      archive_keep_count: 7,
     };
     const toml = buildConfigToml({ session: input });
     const parsed = TOML.parse(toml) as Record<string, unknown>;

--- a/src/cli/utils/config.ts
+++ b/src/cli/utils/config.ts
@@ -26,7 +26,10 @@ import type {
   ThinkingLevel,
   ToolsConfig,
 } from '../../shared/index.js';
-import { DEFAULT_SESSION_ROTATION_SIZE_BYTES } from '../../shared/index.js';
+import {
+  DEFAULT_SESSION_ARCHIVE_KEEP_COUNT,
+  DEFAULT_SESSION_ROTATION_SIZE_BYTES,
+} from '../../shared/index.js';
 
 export const SYSTEM2_DIR = join(homedir(), '.system2');
 export const CONFIG_FILE = join(SYSTEM2_DIR, 'config.toml');
@@ -137,6 +140,7 @@ interface TomlConfig {
   };
   session?: {
     rotation_size_bytes?: number;
+    archive_keep_count?: number;
   };
   logs?: {
     rotation_threshold_mb?: number;
@@ -170,6 +174,7 @@ export const DEFAULT_DELIVERY: DeliveryConfig = {
  *  server-side defaults cannot drift. */
 export const DEFAULT_SESSION: SessionConfig = {
   rotation_size_bytes: DEFAULT_SESSION_ROTATION_SIZE_BYTES, // 10 MB — rotation threshold (anchored if compaction exists, bare-bytes-tail otherwise)
+  archive_keep_count: DEFAULT_SESSION_ARCHIVE_KEEP_COUNT, // keep the 5 most-recent .jsonl.archived files per agent
 };
 
 /**
@@ -361,8 +366,9 @@ export function convertTomlSession(toml: NonNullable<TomlConfig['session']>): Se
   }
 
   const rotation_size_bytes = resolveField('rotation_size_bytes', toml.rotation_size_bytes);
+  const archive_keep_count = resolveField('archive_keep_count', toml.archive_keep_count);
 
-  return { rotation_size_bytes };
+  return { rotation_size_bytes, archive_keep_count };
 }
 
 /**
@@ -857,6 +863,17 @@ export function buildConfigToml(options: {
     `# (the absence of a compaction at this size signals the agent has been in a failure loop).`
   );
   lines.push(`rotation_size_bytes = ${session.rotation_size_bytes}`);
+  lines.push('');
+  lines.push(
+    `# Maximum number of .jsonl.archived files to retain per agent's session directory (default: ${DEFAULT_SESSION.archive_keep_count}).`
+  );
+  lines.push(
+    `# After each rotation or session reset, older archives are pruned by mtime so disk usage stays bounded`
+  );
+  lines.push(
+    `# even for high-volume agents (e.g. the Narrator, which archives once per scheduled task).`
+  );
+  lines.push(`archive_keep_count = ${session.archive_keep_count}`);
   lines.push('');
 
   const delivery = options.delivery ?? DEFAULT_DELIVERY;

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -6,7 +6,15 @@
  * session.prompt() resolves.
  */
 
-import { mkdirSync, readdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -4044,6 +4052,74 @@ describe('AgentHost', () => {
       expect(internal.compactionCount).toBe(0);
       expect(readFileSync(countFile, 'utf-8').trim()).toBe('0');
       expect(internal.lastTurnErrored).toBe(false);
+    });
+
+    it('prunes old .jsonl.archived files after writing the new session header', () => {
+      // Pre-seed 6 stale archives spread across distinct mtimes so the prune step has
+      // unambiguous newest/oldest ordering. The reset path then archives the active JSONL,
+      // making 7 archives total; with the default cap of 5, the 2 oldest must be deleted.
+      const stalePaths: string[] = [];
+      for (let i = 0; i < 6; i++) {
+        const p = join(testDir, `stale-${i}.jsonl.archived`);
+        writeFileSync(p, 'old');
+        utimesSync(p, new Date(1000 + i * 10), new Date(1000 + i * 10));
+        stalePaths.push(p);
+      }
+
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+        resetSessionAfterScheduledTask: true,
+        // Use a custom keepCount distinct from the default to confirm the value flows through.
+        archiveKeepCount: 3,
+      });
+      const internal = host as unknown as ResetInternal;
+      internal.session = { sendCustomMessage: vi.fn(), dispose: vi.fn() };
+      internal._sessionDir = testDir;
+      internal._chatCache = null;
+      internal.agentRole = 'narrator';
+      internal.unsubscribeSession = null;
+      internal.handlePotentialError = vi.fn().mockResolvedValue(undefined);
+      internal.handleCompactionTracking = vi.fn();
+      internal.initialize = vi.fn().mockResolvedValue(undefined);
+
+      // Active JSONL has the newest mtime (it will become the newest .archived after reset).
+      const activeFile = join(testDir, `${Date.now()}_seed.jsonl`);
+      const seedLines = [
+        JSON.stringify({ type: 'session', version: 3, id: 'old-id', cwd: '/some/cwd' }),
+        JSON.stringify({ type: 'message', message: { role: 'user', content: 'hi' } }),
+      ];
+      writeFileSync(activeFile, `${seedLines.join('\n')}\n`);
+      // Stamp the active file with a clearly newer mtime so it survives pruning.
+      utimesSync(activeFile, new Date(10_000), new Date(10_000));
+
+      const details = { sender: 1, receiver: 2, timestamp: Date.now() };
+      internal.pendingDeliveries = [
+        {
+          content: '[Scheduled task: daily-summary]\n\nfile: /x',
+          details,
+          scheduledTask: true,
+          resolve: vi.fn(),
+          reject: vi.fn(),
+        },
+      ];
+      internal.deliverySendCount = 1;
+
+      internal.handleSessionEvent({ type: 'agent_end' });
+
+      // Active file is renamed to .archived → 7 total → cap=3 → 4 oldest pruned.
+      const archives = readdirSync(testDir).filter((f) => f.endsWith('.jsonl.archived'));
+      expect(archives.length).toBe(3);
+
+      // The freshly archived active file must be among the kept (it had the newest mtime).
+      const archivedActive = `${activeFile}.archived`;
+      expect(archives).toContain(archivedActive.split('/').pop());
+
+      // The two oldest stale archives must be gone.
+      expect(existsSync(stalePaths[0])).toBe(false);
+      expect(existsSync(stalePaths[1])).toBe(false);
     });
 
     it('deliverMessage marks scheduled-task content with scheduledTask flag', () => {

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -16,7 +16,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LlmConfig } from '../../shared/index.js';
 import { AgentHost, MAX_DELIVERY_BYTES } from './host.js';
@@ -4115,7 +4115,7 @@ describe('AgentHost', () => {
 
       // The freshly archived active file must be among the kept (it had the newest mtime).
       const archivedActive = `${activeFile}.archived`;
-      expect(archives).toContain(archivedActive.split('/').pop());
+      expect(archives).toContain(basename(archivedActive));
 
       // The two oldest stale archives must be gone.
       expect(existsSync(stalePaths[0])).toBe(false);

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -28,13 +28,14 @@ import {
   SettingsManager,
 } from '@mariozechner/pi-coding-agent';
 import matter from 'gray-matter';
-import type {
-  AgentsConfig,
-  LlmConfig,
-  LlmProvider,
-  ServicesConfig,
-  ThinkingLevel,
-  ToolsConfig,
+import {
+  type AgentsConfig,
+  DEFAULT_SESSION_ARCHIVE_KEEP_COUNT,
+  type LlmConfig,
+  type LlmProvider,
+  type ServicesConfig,
+  type ThinkingLevel,
+  type ToolsConfig,
 } from '../../shared/index.js';
 import { MessageHistory } from '../chat/history.js';
 import type { DatabaseClient } from '../db/client.js';
@@ -61,6 +62,7 @@ import {
   createSessionHeader,
   findMostRecentSession,
   parseSessionEntries,
+  pruneArchives,
   rotateSessionIfNeeded,
   writeRotatedFile,
 } from './session-rotation.js';
@@ -166,6 +168,10 @@ export interface AgentHostConfig {
   narratorMessageExcerptBytes?: number;
   /** Session-rotation threshold in bytes. Defaults to SESSION_FILE_SIZE_LIMIT (10 MB). */
   sessionRotationSizeBytes?: number;
+  /** Maximum number of `.jsonl.archived` files to retain per agent's session directory.
+   *  Defaults to DEFAULT_SESSION_ARCHIVE_KEEP_COUNT (5). Pruning runs after every successful
+   *  rotation (size-based) and after the narrator session-reset path. */
+  archiveKeepCount?: number;
   /** When true and a delivery's content starts with `[Scheduled task:`, truncate the agent's
    *  session JSONL to header-only after `agent_end` for that delivery. Sourced from the agent
    *  library frontmatter (`reset_session_after_scheduled_task: true`). Intended for cron-driven,
@@ -235,6 +241,7 @@ export class AgentHost {
   private onAgentTerminate?: () => void;
   private maxDeliveryBytes: number;
   private sessionRotationSizeBytes: number | undefined;
+  private archiveKeepCount: number;
   private resetSessionAfterScheduledTask: boolean;
   /** True when the constructor caller passed `resetSessionAfterScheduledTask` explicitly (true OR
    *  false). Used in initialize() to decide whether to consult the agent library frontmatter. We
@@ -262,6 +269,7 @@ export class AgentHost {
     this.onAgentTerminate = config.onAgentTerminate;
     this.maxDeliveryBytes = config.maxDeliveryBytes ?? MAX_DELIVERY_BYTES;
     this.sessionRotationSizeBytes = config.sessionRotationSizeBytes;
+    this.archiveKeepCount = config.archiveKeepCount ?? DEFAULT_SESSION_ARCHIVE_KEEP_COUNT;
     // Caller-provided override; otherwise initialize() reads it from the agent library frontmatter
     // (`reset_session_after_scheduled_task` field). Default false: only opted-in roles reset.
     // Track override-presence separately so a caller passing `false` (to disable a role's
@@ -348,7 +356,8 @@ export class AgentHost {
       const rotated = rotateSessionIfNeeded(
         agentSessionDir,
         SYSTEM2_DIR,
-        this.sessionRotationSizeBytes
+        this.sessionRotationSizeBytes,
+        this.archiveKeepCount
       );
       if (rotated) {
         log.info('[AgentHost] Session file rotated to new file');
@@ -1745,6 +1754,10 @@ export class AgentHost {
       const newFilename = writeRotatedFile(sessionDir, activeFile, [
         createSessionHeader(SYSTEM2_DIR),
       ]);
+      // Cap archive count: this path runs once per scheduled task on opted-in roles (Narrator
+      // produces ~48 archives/day on a 30-min cron), so unbounded retention drives steady disk
+      // pressure. Prune to the configured cap so storage stays bounded regardless of runtime.
+      pruneArchives(sessionDir, this.archiveKeepCount);
       // Reset compaction state alongside the session: the new JSONL has no prior compactions,
       // so leaving the counter at its prior value (observed at 241+ during the cascade this
       // feature fixes) would let the pruning trigger fire spuriously against the empty file.

--- a/src/server/agents/session-rotation.test.ts
+++ b/src/server/agents/session-rotation.test.ts
@@ -5,6 +5,7 @@ import {
   readFileSync,
   renameSync,
   rmSync,
+  symlinkSync,
   unlinkSync,
   utimesSync,
   writeFileSync,
@@ -547,6 +548,35 @@ describe('pruneArchives', () => {
 
     expect(existsSync(a)).toBe(true);
     expect(existsSync(b)).toBe(true);
+  });
+
+  it('skips archives whose stat throws (broken symlink) and prunes the rest', () => {
+    // Real archives with distinct mtimes.
+    const a = makeArchive('a.jsonl.archived', 1000);
+    const b = makeArchive('b.jsonl.archived', 2000);
+    const c = makeArchive('c.jsonl.archived', 3000);
+
+    // Broken symlink: matches the archive glob, but statSync follows symlinks and
+    // throws ENOENT on a missing target. This exercises the per-file try/catch in
+    // pruneArchives: the bad entry is skipped, the real entries still sort + prune.
+    const brokenLink = join(tmpDir, 'broken.jsonl.archived');
+    symlinkSync(join(tmpDir, 'does-not-exist.jsonl.archived'), brokenLink);
+
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+
+    pruneArchives(tmpDir, 2);
+
+    // Two newest real archives kept, oldest pruned.
+    expect(existsSync(a)).toBe(false);
+    expect(existsSync(b)).toBe(true);
+    expect(existsSync(c)).toBe(true);
+    // Broken symlink untouched: stat failed, so it never entered the sort or delete list.
+    // (lstat would still succeed on the dangling link itself, but we don't lstat in pruneArchives.)
+    expect(readdirSync(tmpDir)).toContain('broken.jsonl.archived');
+    // A warn fired for the failed stat.
+    const warns = warnSpy.mock.calls.flat().map(String).join(' ');
+    expect(warns).toContain('Failed to stat archive');
+    warnSpy.mockRestore();
   });
 
   it('does not delete non-archive files in the same directory', () => {

--- a/src/server/agents/session-rotation.test.ts
+++ b/src/server/agents/session-rotation.test.ts
@@ -1,9 +1,19 @@
-import { existsSync, mkdirSync, readFileSync, rmSync, utimesSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  unlinkSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { log } from '../utils/logger.js';
-import { findMostRecentSession, rotateSessionIfNeeded } from './session-rotation.js';
+import { findMostRecentSession, pruneArchives, rotateSessionIfNeeded } from './session-rotation.js';
 
 function makeTmpDir(): string {
   const dir = join(
@@ -478,5 +488,170 @@ describe('rotateSessionIfNeeded', () => {
       expect(warnText).toMatch(/\d+\.\d+ MB/);
       warnSpy.mockRestore();
     });
+  });
+});
+
+describe('pruneArchives', () => {
+  function makeArchive(name: string, mtimeSeconds: number): string {
+    const fullPath = join(tmpDir, name);
+    writeFileSync(fullPath, 'archived content');
+    utimesSync(fullPath, new Date(mtimeSeconds * 1000), new Date(mtimeSeconds * 1000));
+    return fullPath;
+  }
+
+  it('keeps exactly keepCount newest archives by mtime', () => {
+    const a = makeArchive('a.jsonl.archived', 1000);
+    const b = makeArchive('b.jsonl.archived', 2000);
+    const c = makeArchive('c.jsonl.archived', 3000);
+    const d = makeArchive('d.jsonl.archived', 4000);
+    const e = makeArchive('e.jsonl.archived', 5000);
+
+    pruneArchives(tmpDir, 2);
+
+    // Only the 2 newest (d, e) remain; a/b/c are pruned.
+    expect(existsSync(a)).toBe(false);
+    expect(existsSync(b)).toBe(false);
+    expect(existsSync(c)).toBe(false);
+    expect(existsSync(d)).toBe(true);
+    expect(existsSync(e)).toBe(true);
+  });
+
+  it('is a no-op when there are fewer archives than keepCount', () => {
+    const a = makeArchive('a.jsonl.archived', 1000);
+    const b = makeArchive('b.jsonl.archived', 2000);
+
+    pruneArchives(tmpDir, 5);
+
+    expect(existsSync(a)).toBe(true);
+    expect(existsSync(b)).toBe(true);
+  });
+
+  it('is a no-op when count exactly equals keepCount', () => {
+    const a = makeArchive('a.jsonl.archived', 1000);
+    const b = makeArchive('b.jsonl.archived', 2000);
+    const c = makeArchive('c.jsonl.archived', 3000);
+
+    pruneArchives(tmpDir, 3);
+
+    expect(existsSync(a)).toBe(true);
+    expect(existsSync(b)).toBe(true);
+    expect(existsSync(c)).toBe(true);
+  });
+
+  it('does nothing when keepCount <= 0', () => {
+    const a = makeArchive('a.jsonl.archived', 1000);
+    const b = makeArchive('b.jsonl.archived', 2000);
+
+    pruneArchives(tmpDir, 0);
+    pruneArchives(tmpDir, -1);
+
+    expect(existsSync(a)).toBe(true);
+    expect(existsSync(b)).toBe(true);
+  });
+
+  it('does not delete non-archive files in the same directory', () => {
+    const archive = makeArchive('old.jsonl.archived', 1000);
+    const otherArchive = makeArchive('newer.jsonl.archived', 2000);
+    const active = join(tmpDir, 'active.jsonl');
+    writeFileSync(active, 'active');
+    const sibling = join(tmpDir, 'compaction-count.txt');
+    writeFileSync(sibling, '5');
+
+    pruneArchives(tmpDir, 1);
+
+    // Only the older archive is removed.
+    expect(existsSync(archive)).toBe(false);
+    expect(existsSync(otherArchive)).toBe(true);
+    expect(existsSync(active)).toBe(true);
+    expect(existsSync(sibling)).toBe(true);
+  });
+
+  it('returns silently when sessionDir does not exist', () => {
+    expect(() => pruneArchives('/nonexistent/path/xyz-123', 5)).not.toThrow();
+  });
+});
+
+describe('rotateSessionIfNeeded — archive pruning', () => {
+  function seedSession(): void {
+    const file = join(tmpDir, 'session.jsonl');
+    writeJsonl(file, [
+      sessionHeader(),
+      messageEntry('e1', null, 'user'),
+      messageEntry('e2', 'e1', 'assistant'),
+      compactionEntry('c1', 'e2', 'e1'),
+      messageEntry('e3', 'c1', 'user'),
+    ]);
+  }
+
+  it('after 7 rotations with archive_keep_count=5, only 5 archives remain (newest kept)', () => {
+    // Simulate 7 rotations; each call rotates the active jsonl into a new .archived file.
+    const archivedPaths: string[] = [];
+    for (let i = 0; i < 7; i++) {
+      seedSession();
+      const rotated = rotateSessionIfNeeded(tmpDir, '/tmp', 0, 5);
+      expect(rotated).toBe(true);
+      // Stamp the resulting archive's mtime so the keep-newest-by-mtime ordering is deterministic
+      // (multiple rotations within a single ms could otherwise collide on the filesystem).
+      const file = join(tmpDir, 'session.jsonl');
+      const archivedPath = `${file}.archived`;
+      const mtime = new Date((i + 1) * 1000);
+      utimesSync(archivedPath, mtime, mtime);
+      // Rename so the next iteration's `session.jsonl` rotates cleanly without colliding with
+      // the freshly-created `session.jsonl.archived` from the previous iteration.
+      const renamed = join(tmpDir, `archive-${i}.jsonl.archived`);
+      renameSync(archivedPath, renamed);
+      utimesSync(renamed, mtime, mtime);
+      archivedPaths.push(renamed);
+
+      // Remove the freshly written `session.jsonl` (the new active file generated by rotation
+      // is named with a timestamp+uuid, not `session.jsonl`). Clean any *.jsonl files the
+      // rotator emitted so the next iteration's seedSession can reuse `session.jsonl`.
+      const remainingJsonl = readdirSync(tmpDir).filter(
+        (f) => f.endsWith('.jsonl') && !f.endsWith('.archived')
+      );
+      for (const r of remainingJsonl) {
+        unlinkSync(join(tmpDir, r));
+      }
+    }
+
+    // After 7 rotations + prune-on-each-rotation cap of 5: 5 archives remain.
+    const archives = readdirSync(tmpDir).filter((f) => f.endsWith('.jsonl.archived'));
+    expect(archives.length).toBe(5);
+
+    // The 5 remaining must be the 5 newest by mtime — the last 5 we created (i=2..6).
+    const remainingPaths = archives.map((f) => join(tmpDir, f)).sort();
+    const expectedKept = archivedPaths.slice(2).sort();
+    expect(remainingPaths).toEqual(expectedKept);
+  });
+
+  it('bare-bytes-tail rotation also prunes archives', () => {
+    // Pre-seed 6 stale archives with old mtimes so the prune step has work to do.
+    for (let i = 0; i < 6; i++) {
+      const path = join(tmpDir, `stale-${i}.jsonl.archived`);
+      writeFileSync(path, 'old');
+      utimesSync(path, new Date(1000 + i), new Date(1000 + i));
+    }
+
+    // Build a session with no compaction so rotation goes through the bare-bytes-tail path.
+    const file = join(tmpDir, 'session.jsonl');
+    const entries: object[] = [sessionHeader()];
+    for (let i = 0; i < 8; i++) {
+      const prev = i === 0 ? null : `e${i - 1}`;
+      entries.push(messageEntry(`e${i}`, prev, i % 2 === 0 ? 'user' : 'assistant'));
+    }
+    writeJsonl(file, entries);
+
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+    const rotated = rotateSessionIfNeeded(tmpDir, '/tmp', 0, 3);
+    expect(rotated).toBe(true);
+    warnSpy.mockRestore();
+
+    // Bare-bytes-tail rotation creates one new archive; with cap=3 and 6 stale + 1 new = 7
+    // archives, the 4 oldest must be pruned, leaving exactly 3.
+    const archives = readdirSync(tmpDir).filter((f) => f.endsWith('.jsonl.archived'));
+    expect(archives.length).toBe(3);
+    // The newly rotated archive (session.jsonl.archived, written just now) must be among the
+    // 3 newest by mtime and therefore preserved.
+    expect(archives).toContain('session.jsonl.archived');
   });
 });

--- a/src/server/agents/session-rotation.ts
+++ b/src/server/agents/session-rotation.ts
@@ -228,23 +228,39 @@ export function pruneArchives(sessionDir: string, keepCount: number): void {
   }
   if (archived.length <= keepCount) return;
 
-  // Sort by mtime descending (newest first); delete everything past keepCount.
+  // Sort by mtime descending (newest first); delete everything past keepCount. statSync is
+  // wrapped per-file: a concurrently-removed archive, broken symlink, or unreadable inode
+  // should skip+log, never abort rotation.
   const sorted = archived
-    .map((f) => {
+    .flatMap((f) => {
       const fullPath = join(sessionDir, f);
-      const stat = statSync(fullPath);
-      return { path: fullPath, mtime: stat.mtime.getTime() };
+      try {
+        const stat = statSync(fullPath);
+        return [{ path: fullPath, mtime: stat.mtime.getTime() }];
+      } catch (err) {
+        log.warn(`[SessionRotation] Failed to stat archive ${fullPath}: ${err}`);
+        return [];
+      }
     })
     .sort((a, b) => b.mtime - a.mtime);
 
   const toDelete = sorted.slice(keepCount);
+  const prunedNames: string[] = [];
   for (const entry of toDelete) {
     try {
       unlinkSync(entry.path);
-      log.info(`[SessionRotation] Pruned old archive: ${basename(entry.path)}`);
+      prunedNames.push(basename(entry.path));
     } catch (err) {
       log.warn(`[SessionRotation] Failed to prune ${entry.path}: ${err}`);
     }
+  }
+
+  // Single summary line so first-prune-after-upgrade (potentially many archives) doesn't
+  // flood the log with one line per file.
+  if (prunedNames.length > 0) {
+    log.info(
+      `[SessionRotation] Pruned ${prunedNames.length} old archive(s) in ${sessionDir}: newest=${prunedNames[0]}, oldest=${prunedNames[prunedNames.length - 1]}`
+    );
   }
 }
 

--- a/src/server/agents/session-rotation.ts
+++ b/src/server/agents/session-rotation.ts
@@ -6,9 +6,19 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { readdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
+import {
+  readdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { basename, join } from 'node:path';
-import { DEFAULT_SESSION_ROTATION_SIZE_BYTES } from '../../shared/types/config.js';
+import {
+  DEFAULT_SESSION_ARCHIVE_KEEP_COUNT,
+  DEFAULT_SESSION_ROTATION_SIZE_BYTES,
+} from '../../shared/types/config.js';
 import { log } from '../utils/logger.js';
 
 /** Default rotation threshold. Imported from shared so CLI config defaults and server-side
@@ -198,6 +208,47 @@ export function writeRotatedFile(
 }
 
 /**
+ * Prune `.jsonl.archived` files in `sessionDir`, keeping only the `keepCount` most recent by mtime.
+ *
+ * No-op if `keepCount <= 0`, if the directory cannot be read, or if there are fewer archives than
+ * the cap. Failures to delete individual files are logged at warn level but do not throw — pruning
+ * is best-effort cleanup, not load-bearing for correctness.
+ *
+ * Called after every successful `writeRotatedFile` (anchored rotation, bare-bytes-tail fallback,
+ * header-only fallback, and the narrator session-reset path) so archive count stays bounded for
+ * high-volume agents.
+ */
+export function pruneArchives(sessionDir: string, keepCount: number): void {
+  if (keepCount <= 0) return;
+  let archived: string[];
+  try {
+    archived = readdirSync(sessionDir).filter((f) => f.endsWith('.jsonl.archived'));
+  } catch {
+    return;
+  }
+  if (archived.length <= keepCount) return;
+
+  // Sort by mtime descending (newest first); delete everything past keepCount.
+  const sorted = archived
+    .map((f) => {
+      const fullPath = join(sessionDir, f);
+      const stat = statSync(fullPath);
+      return { path: fullPath, mtime: stat.mtime.getTime() };
+    })
+    .sort((a, b) => b.mtime - a.mtime);
+
+  const toDelete = sorted.slice(keepCount);
+  for (const entry of toDelete) {
+    try {
+      unlinkSync(entry.path);
+      log.info(`[SessionRotation] Pruned old archive: ${basename(entry.path)}`);
+    } catch (err) {
+      log.warn(`[SessionRotation] Failed to prune ${entry.path}: ${err}`);
+    }
+  }
+}
+
+/**
  * Bare-bytes-tail fallback: write a fresh session header + a bounded recent tail
  * (selected via selectTailEntries, anchored to a user turn) and archive the old file.
  * Used when no compaction anchor exists or the anchor is malformed.
@@ -264,12 +315,15 @@ function forceHeaderOnlyRotation(
  * @param sessionDir - Directory containing session JSONL files
  * @param cwd - Current working directory for session header
  * @param thresholdBytes - Rotation threshold (default 10 MB)
+ * @param archiveKeepCount - Maximum `.jsonl.archived` files to retain (default 5).
+ *                          Pruning runs after every successful rotation in this function.
  * @returns true if rotation occurred, false otherwise
  */
 export function rotateSessionIfNeeded(
   sessionDir: string,
   cwd: string,
-  thresholdBytes: number = SESSION_FILE_SIZE_LIMIT
+  thresholdBytes: number = SESSION_FILE_SIZE_LIMIT,
+  archiveKeepCount: number = DEFAULT_SESSION_ARCHIVE_KEEP_COUNT
 ): boolean {
   // Find most recent session file
   const currentFile = findMostRecentSession(sessionDir);
@@ -293,7 +347,9 @@ export function rotateSessionIfNeeded(
     log.warn(
       `[SessionRotation] File exceeded threshold but parsed to 0 entries: ${currentFile} (size ${formatMB(stat.size)} MB). All lines may be malformed JSON. Forcing header-only rotation so cold start is unblocked and disk usage remains bounded.`
     );
-    return forceHeaderOnlyRotation(sessionDir, cwd, currentFile, 'parsed to 0 entries');
+    const rotated = forceHeaderOnlyRotation(sessionDir, cwd, currentFile, 'parsed to 0 entries');
+    pruneArchives(sessionDir, archiveKeepCount);
+    return rotated;
   }
 
   // Find compaction entry
@@ -306,13 +362,15 @@ export function rotateSessionIfNeeded(
     log.warn(
       `[SessionRotation] No compaction found in ${currentFile} (size ${formatMB(stat.size)} MB). Forcing bare-bytes-tail rotation: keeping the header plus up to the last ${formatMB(HARD_FALLBACK_TAIL_BYTES)} MB of entries. If no safe user-turn anchor exists within that window, or if a single entry exceeds the cap, rotation may fall back to header-only. Older state will be archived. Repeated occurrences signal the agent has been in a failure loop.`
     );
-    return forceBareBytesTailRotation(
+    const rotated = forceBareBytesTailRotation(
       sessionDir,
       cwd,
       currentFile,
       entries,
       'no compaction anchor'
     );
+    pruneArchives(sessionDir, archiveKeepCount);
+    return rotated;
   }
 
   const { entry: compactionEntry, index: compactionIndex } = compaction;
@@ -324,13 +382,15 @@ export function rotateSessionIfNeeded(
     log.warn(
       `[SessionRotation] Compaction has no firstKeptEntryId in ${currentFile} (size ${formatMB(stat.size)} MB). Falling back to bare-bytes-tail rotation.`
     );
-    return forceBareBytesTailRotation(
+    const rotated = forceBareBytesTailRotation(
       sessionDir,
       cwd,
       currentFile,
       entries,
       'compaction missing firstKeptEntryId'
     );
+    pruneArchives(sessionDir, archiveKeepCount);
+    return rotated;
   }
 
   // Find index of firstKeptEntryId
@@ -341,13 +401,15 @@ export function rotateSessionIfNeeded(
     log.warn(
       `[SessionRotation] firstKeptEntryId ${firstKeptEntryId} not found in ${currentFile} (size ${formatMB(stat.size)} MB). Falling back to bare-bytes-tail rotation.`
     );
-    return forceBareBytesTailRotation(
+    const rotated = forceBareBytesTailRotation(
       sessionDir,
       cwd,
       currentFile,
       entries,
       `firstKeptEntryId ${firstKeptEntryId} not found`
     );
+    pruneArchives(sessionDir, archiveKeepCount);
+    return rotated;
   }
 
   // Build new entries in chronological order:
@@ -381,5 +443,6 @@ export function rotateSessionIfNeeded(
   );
   log.info(`[SessionRotation] Old file archived: ${basename(currentFile)}.archived`);
 
+  pruneArchives(sessionDir, archiveKeepCount);
   return true;
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -172,6 +172,7 @@ export class Server {
     const maxDeliveryBytes = config.deliveryConfig?.max_bytes ?? MAX_DELIVERY_BYTES;
     const narratorMessageExcerptBytes = config.deliveryConfig?.narrator_message_excerpt_bytes;
     const sessionRotationSizeBytes = config.sessionConfig?.rotation_size_bytes;
+    const archiveKeepCount = config.sessionConfig?.archive_keep_count;
     this.agentHost = new AgentHost({
       db: this.db,
       agentId: guideAgent.id,
@@ -189,6 +190,7 @@ export class Server {
       maxDeliveryBytes,
       narratorMessageExcerptBytes,
       sessionRotationSizeBytes,
+      archiveKeepCount,
       ...callbacks,
     });
     this.agentRegistry.register(guideAgent.id, this.agentHost);
@@ -211,6 +213,7 @@ export class Server {
       maxDeliveryBytes,
       narratorMessageExcerptBytes,
       sessionRotationSizeBytes,
+      archiveKeepCount,
       ...callbacks,
     });
     this.agentRegistry.register(narratorAgent.id, this.narratorHost);
@@ -498,6 +501,7 @@ export class Server {
       maxDeliveryBytes: this.config.deliveryConfig?.max_bytes ?? MAX_DELIVERY_BYTES,
       narratorMessageExcerptBytes: this.config.deliveryConfig?.narrator_message_excerpt_bytes,
       sessionRotationSizeBytes: this.config.sessionConfig?.rotation_size_bytes,
+      archiveKeepCount: this.config.sessionConfig?.archive_keep_count,
       ...this.buildAgentCallbacks(),
     });
 

--- a/src/shared/types/config.ts
+++ b/src/shared/types/config.ts
@@ -119,9 +119,18 @@ export interface SessionConfig {
    *  that tail. If no user turn exists in the kept window — or if a single entry alone exceeds
    *  the tail cap — rotation writes only the new session header. */
   rotation_size_bytes: number;
+  /** Maximum number of `.jsonl.archived` files to retain per agent's session directory.
+   *  After each rotation or session reset, older archives are pruned by mtime.
+   *  Default 5 (forensic value drops sharply past the most-recent few). */
+  archive_keep_count: number;
 }
 
 /** Single source of truth for the default session-rotation threshold (10 MB). Both the CLI's
  *  generated config.toml and the server's `rotateSessionIfNeeded` parameter default reference
  *  this constant so they cannot drift. */
 export const DEFAULT_SESSION_ROTATION_SIZE_BYTES = 10 * 1024 * 1024;
+
+/** Default archive-retention count. Mirrors the existing log-rotation cap in
+ *  `src/cli/utils/log-rotation.ts` (5 archives) and bounds long-running narrator deployments
+ *  at ~5 × archive_size of disk per agent regardless of runtime. */
+export const DEFAULT_SESSION_ARCHIVE_KEEP_COUNT = 5;


### PR DESCRIPTION
## Summary

- Adds `archive_keep_count` to the `[session]` config section (default `5`) and prunes older `.jsonl.archived` files after every rotation/reset path.
- Wires the value through `SessionConfig` → `AgentHostConfig.archiveKeepCount` → both `rotateSessionIfNeeded` (size-based + bare-bytes-tail + header-only fallbacks) and the narrator post-scheduled-task `resetSessionToHeader`.
- Pruning is synchronous, best-effort, mtime-based: keep the newest N, log+continue on per-file unlink failures.
- Without a cap, archives grew monotonically. The narrator alone produces ~48 archives/day on the 30-min cron (~840/week × ~1 MB each). The cap bounds storage at ~5 × archive_size per agent, mirroring `src/cli/utils/log-rotation.ts`.

## Test plan

- [x] `pruneArchives` keeps exactly `keepCount` newest archives by mtime; no-op when count <= keepCount or keepCount <= 0; ignores non-archive files; tolerates missing dir.
- [x] After 7 rotations with `archive_keep_count=5`, exactly 5 archives remain (the 5 newest by mtime).
- [x] Bare-bytes-tail rotation also prunes archives (asserted with pre-seeded stale archives).
- [x] `resetSessionToHeader` prunes archives after writing the new header (custom `archiveKeepCount=3` plumbed through `AgentHost` constructor; oldest stale archives deleted, freshly archived active file preserved).
- [x] `convertTomlSession` reads/validates `archive_keep_count` (positive integer, fall back to default with `console.warn` on invalid input). Round-trips through `buildConfigToml` + `TOML.parse`.
- [x] `pnpm typecheck`, `pnpm test` (861 passed), `pnpm check`, `pnpm build` all green.

## Docs

- Updated the `[session]` config block and the Session Rotation table in `docs/configuration.md` with the new field.

Fixes #156