### PR TITLE
feat(ui): centralize markdown rendering with GFM tables support

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
     "ws": "^8.16.0",
     "zustand": "^4.5.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ dependencies:
   react-markdown:
     specifier: ^10.1.0
     version: 10.1.0(@types/react@18.3.28)(react@18.3.1)
+  remark-gfm:
+    specifier: ^4.0.1
+    version: 4.0.1
   ws:
     specifier: ^8.16.0
     version: 8.20.0
@@ -4219,6 +4222,11 @@ packages:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
     dev: false
 
+  /escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+    dev: false
+
   /escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
     engines: {node: '>=6.0'}
@@ -5139,6 +5147,10 @@ packages:
       semver: 7.7.4
     dev: true
 
+  /markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+    dev: false
+
   /marked@15.0.12:
     resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
     engines: {node: '>= 18'}
@@ -5156,6 +5168,15 @@ packages:
       '@types/mdast': 3.0.15
       '@types/unist': 2.0.11
       unist-util-visit: 4.1.2
+    dev: false
+
+  /mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
     dev: false
 
   /mdast-util-from-markdown@1.3.1:
@@ -5192,6 +5213,75 @@ packages:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+    dev: false
+
+  /mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5362,6 +5452,78 @@ packages:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: false
+
+  /micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: false
+
+  /micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: false
+
+  /micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: false
+
+  /micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: false
+
+  /micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+    dependencies:
+      micromark-util-types: 2.0.2
+    dev: false
+
+  /micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: false
+
+  /micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
     dev: false
 
@@ -6335,6 +6497,19 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
+  /remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /remark-parse@10.0.2:
     resolution: {integrity: sha512-3ydxgHa/ZQzG8LvC7jTXccARYDcRld3VfcgIIFs7bI6vbRSxJJmzgLEIIoYKyrfhaY+ujuWaf/PJiMZXoiCXgw==}
     dependencies:
@@ -6373,6 +6548,14 @@ packages:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+    dev: false
+
+  /remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
     dev: false
 
   /require-directory@2.1.1:

--- a/src/ui/components/ArtifactViewer.tsx
+++ b/src/ui/components/ArtifactViewer.tsx
@@ -14,7 +14,7 @@ import { useArtifactStore } from '../stores/artifact';
 import { useThemeStore } from '../stores/theme';
 import { useAccentColors } from '../theme/useAccentColors';
 import { KanbanBoard } from './KanbanBoard';
-import Markdown from './Markdown';
+import { Markdown } from './Markdown';
 import { ParticlesBackground } from './ParticlesBackground';
 
 const MAX_PREVIEW_BYTES = 5 * 1024 * 1024; // 5 MB

--- a/src/ui/components/ArtifactViewer.tsx
+++ b/src/ui/components/ArtifactViewer.tsx
@@ -8,13 +8,13 @@
 import { XIcon } from '@primer/octicons-react';
 import { Box, IconButton, Text } from '@primer/react';
 import { useEffect, useRef, useState } from 'react';
-import Markdown from 'react-markdown';
 import { useArtifactMtimePoll } from '../hooks/useArtifactMtimePoll';
 import { handleQueryMessage } from '../query-bridge';
 import { useArtifactStore } from '../stores/artifact';
 import { useThemeStore } from '../stores/theme';
 import { useAccentColors } from '../theme/useAccentColors';
 import { KanbanBoard } from './KanbanBoard';
+import Markdown from './Markdown';
 import { ParticlesBackground } from './ParticlesBackground';
 
 const MAX_PREVIEW_BYTES = 5 * 1024 * 1024; // 5 MB

--- a/src/ui/components/Markdown.tsx
+++ b/src/ui/components/Markdown.tsx
@@ -1,13 +1,8 @@
 import ReactMarkdown, { type Options } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-export function Markdown({ remarkPlugins, children, ...rest }: Options) {
-  const extra = (remarkPlugins ?? []).filter((p) => p !== remarkGfm);
-  return (
-    <ReactMarkdown remarkPlugins={[remarkGfm, ...extra]} {...rest}>
-      {children}
-    </ReactMarkdown>
-  );
+export function Markdown(props: Omit<Options, 'remarkPlugins'>) {
+  return <ReactMarkdown {...props} remarkPlugins={[remarkGfm]} />;
 }
 
 export default Markdown;

--- a/src/ui/components/Markdown.tsx
+++ b/src/ui/components/Markdown.tsx
@@ -2,9 +2,9 @@ import ReactMarkdown, { type Options } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 export function Markdown({ remarkPlugins, children, ...rest }: Options) {
-  const plugins = remarkPlugins ? [remarkGfm, ...remarkPlugins] : [remarkGfm];
+  const extra = (remarkPlugins ?? []).filter((p) => p !== remarkGfm);
   return (
-    <ReactMarkdown remarkPlugins={plugins} {...rest}>
+    <ReactMarkdown remarkPlugins={[remarkGfm, ...extra]} {...rest}>
       {children}
     </ReactMarkdown>
   );

--- a/src/ui/components/Markdown.tsx
+++ b/src/ui/components/Markdown.tsx
@@ -1,8 +1,8 @@
 import ReactMarkdown, { type Options } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
-export function Markdown(props: Omit<Options, 'remarkPlugins'>) {
-  return <ReactMarkdown {...props} remarkPlugins={[remarkGfm]} />;
-}
+const REMARK_PLUGINS = [remarkGfm];
 
-export default Markdown;
+export function Markdown(props: Omit<Options, 'remarkPlugins'>) {
+  return <ReactMarkdown {...props} remarkPlugins={REMARK_PLUGINS} />;
+}

--- a/src/ui/components/Markdown.tsx
+++ b/src/ui/components/Markdown.tsx
@@ -1,0 +1,13 @@
+import ReactMarkdown, { type Options } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+export function Markdown({ remarkPlugins, children, ...rest }: Options) {
+  const plugins = remarkPlugins ? [remarkGfm, ...remarkPlugins] : [remarkGfm];
+  return (
+    <ReactMarkdown remarkPlugins={plugins} {...rest}>
+      {children}
+    </ReactMarkdown>
+  );
+}
+
+export default Markdown;

--- a/src/ui/components/MessageList.tsx
+++ b/src/ui/components/MessageList.tsx
@@ -17,7 +17,7 @@ import {
 } from '../stores/chat';
 import { colors } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
-import Markdown from './Markdown';
+import { Markdown } from './Markdown';
 
 /** Format a millisecond timestamp as local HH:MM, or "Mar 18, HH:MM" if not today */
 function formatTime(ts: number): string {

--- a/src/ui/components/MessageList.tsx
+++ b/src/ui/components/MessageList.tsx
@@ -158,7 +158,7 @@ function MarkdownContent({ content, muted }: { content: string; muted?: boolean 
         '& th, & td': {
           border: '1px solid',
           borderColor: 'border.default',
-          padding: 1,
+          padding: 2,
           textAlign: 'left',
         },
         '& th': { fontWeight: 'bold', backgroundColor: 'neutral.muted' },

--- a/src/ui/components/MessageList.tsx
+++ b/src/ui/components/MessageList.tsx
@@ -7,7 +7,6 @@
 
 import { Box, Text } from '@primer/react';
 import { Fragment, useEffect, useLayoutEffect, useRef, useState } from 'react';
-import Markdown from 'react-markdown';
 import {
   EMPTY_AGENT_STATE,
   type Message,
@@ -18,6 +17,7 @@ import {
 } from '../stores/chat';
 import { colors } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
+import Markdown from './Markdown';
 
 /** Format a millisecond timestamp as local HH:MM, or "Mar 18, HH:MM" if not today */
 function formatTime(ts: number): string {
@@ -149,6 +149,19 @@ function MarkdownContent({ content, muted }: { content: string; muted?: boolean 
           marginLeft: 0,
           color: 'fg.muted',
         },
+        '& table': {
+          borderCollapse: 'collapse',
+          width: '100%',
+          marginTop: 2,
+          marginBottom: 2,
+        },
+        '& th, & td': {
+          border: '1px solid',
+          borderColor: 'border.default',
+          padding: 1,
+          textAlign: 'left',
+        },
+        '& th': { fontWeight: 'bold', backgroundColor: 'neutral.muted' },
       }}
     >
       <Markdown>{content}</Markdown>

--- a/src/ui/components/ProjectDetailModal.tsx
+++ b/src/ui/components/ProjectDetailModal.tsx
@@ -10,7 +10,7 @@ import { Box, IconButton, Text } from '@primer/react';
 import { useEffect, useRef } from 'react';
 import { colors } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
-import Markdown from './Markdown';
+import { Markdown } from './Markdown';
 
 interface ProjectData {
   id: number;

--- a/src/ui/components/ProjectDetailModal.tsx
+++ b/src/ui/components/ProjectDetailModal.tsx
@@ -8,9 +8,9 @@
 import { XIcon } from '@primer/octicons-react';
 import { Box, IconButton, Text } from '@primer/react';
 import { useEffect, useRef } from 'react';
-import Markdown from 'react-markdown';
 import { colors } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
+import Markdown from './Markdown';
 
 interface ProjectData {
   id: number;

--- a/src/ui/components/TaskDetailModal.tsx
+++ b/src/ui/components/TaskDetailModal.tsx
@@ -8,10 +8,10 @@
 import { XIcon } from '@primer/octicons-react';
 import { Box, IconButton, Text } from '@primer/react';
 import { useEffect, useRef, useState } from 'react';
-import Markdown from 'react-markdown';
 import { usePushStore } from '../stores/push';
 import { colors } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
+import Markdown from './Markdown';
 
 interface TaskDetail {
   id: number;

--- a/src/ui/components/TaskDetailModal.tsx
+++ b/src/ui/components/TaskDetailModal.tsx
@@ -11,7 +11,7 @@ import { useEffect, useRef, useState } from 'react';
 import { usePushStore } from '../stores/push';
 import { colors } from '../theme/colors';
 import { useAccentColors } from '../theme/useAccentColors';
-import Markdown from './Markdown';
+import { Markdown } from './Markdown';
 
 interface TaskDetail {
   id: number;


### PR DESCRIPTION
## Summary

- New `src/ui/components/Markdown.tsx` wraps `react-markdown` with `remark-gfm` always applied, so GFM tables, strikethrough, autolinks, and task lists render across the UI.
- All four `react-markdown` call sites switch to the shared wrapper: `ArtifactViewer`, `MessageList`, `TaskDetailModal`, `ProjectDetailModal`.
- Chat `MarkdownContent` gains table border styling so chat tables match the artifact viewer's look.
- Adds `remark-gfm@4.0.1` dependency.

The reported symptom: GFM tables (e.g. in WID Full Dataset README artifacts) rendered as plain text with literal `|` characters in both the artifact viewer and chat, while the same source rendered correctly in VSCode's preview. Root cause: `react-markdown` was wired in without `remark-gfm`, so the parser only handles CommonMark and treats table syntax as text.

## Test plan

- [x] `pnpm check` clean
- [x] `pnpm build` clean
- [x] `pnpm test` (1002 passed)
- [ ] Open a markdown artifact with a GFM table; verify it renders as a table
- [ ] Send/receive a chat message containing a GFM table; verify it renders with borders
- [ ] Open a task or project description containing a GFM table; verify it renders (no border styling, expected)