### PR TITLE
fix(compaction): unblock auto-compaction on high-context models + surface failures + only count real successes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Auto-compaction now runs end-to-end on high-context Anthropic models. The pi-coding-agent SDK was computing `maxTokens = 0.8 × reserveTokens` (or `0.5 ×` for turn-prefix summaries) without clamping at `model.maxTokens`, so on configurations where `0.25 × contextWindow > model.maxTokens` (in practice: `claude-opus-4-7` with the 1M-context variant and our `reserveTokens = 500K`) every summarization request was rejected by the API with HTTP 400 (`max_tokens: 250000 > 128000`). Context grew unbounded turn after turn while the chat falsely reported successful compactions. Fixed locally via `pnpm patch @mariozechner/pi-coding-agent@0.71.1` clamping at both call sites; the same fix was filed upstream as [pi-mono#4390](https://github.com/badlogic/pi-mono/issues/4390) ([#174](https://github.com/diegoscarabelli/system2/pull/174))
+- `history-capture` now surfaces the real outcome of `compaction_end` instead of pushing a generic "Context compacted" for every event regardless of success. Successful compactions get a clean "Context compacted"; aborted ones get "Context compaction aborted"; failed ones include the SDK's `errorMessage`. This is the patch that exposed the SDK 400 above — without it the failure was invisible for ~10 days. Message IDs use `randomUUID()` (full UUID) instead of `msg-${Date.now()}` to prevent React key collisions when start/end fire within the same millisecond (which happens on silent-failure paths) ([#174](https://github.com/diegoscarabelli/system2/pull/174))
+- `AgentHost.handleCompactionTracking` only bumps the pruning counter when the SDK reports a real success (`result != null && !aborted && !errorMessage`). Previously every `compaction_end` event incremented the counter, so silent failures inflated it toward `compaction_depth` and would have triggered a doomed pruning compaction (which would 400-fail for the same SDK reason). The parameter is now typed as `AgentSessionEvent` directly so TypeScript narrows the discriminated union without an `as` cast; overflow recovery now calls a new `bumpCompactionCount()` helper instead of fabricating a partial event ([#174](https://github.com/diegoscarabelli/system2/pull/174))
+
+### Changed
+
+- The chat-store's `compactionStatus` no longer has a `'compacted'` terminal state. `finishCompaction` transitions `'compacting' → 'idle'` directly, so the transient in-flight indicator at the bottom of the timeline disappears as soon as the compaction completes (instead of staying glued at the bottom out of chronological order while later messages stream in above it). The persisted "Context compacted" system message from `history-capture` already records the event in correct chronological position ([#174](https://github.com/diegoscarabelli/system2/pull/174))
+
 ## [0.3.3] - 2026-05-10
 
 ### Added

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -187,7 +187,7 @@ Supports multi-agent chat via per-agent state. Each agent has its own message hi
 | `currentTurnEvents` | `ChatTurnEvent[]` | Thinking + tool calls for current turn |
 | `isStreaming` | `boolean` | Currently receiving chunks |
 | `isWaitingForResponse` | `boolean` | Sent message, no response yet |
-| `compactionStatus` | `'idle' \| 'compacting' \| 'compacted'` | Auto-compaction state (transient, not persisted) |
+| `compactionStatus` | `'idle' \| 'compacting'` | Transient in-flight indicator (not persisted). Transitions back to `idle` on `compaction_end`; the persisted "Context compacted" system message from `history-capture` records the event in chronological position. |
 
 Components read the active agent's state via selectors (e.g., `useChatStore(s => s.agentStates.get(s.activeAgentId))`). An exported `EMPTY_AGENT_STATE` constant provides a stable default for selectors when no agent state exists yet.
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -78,7 +78,7 @@ type ServerMessage =
 | `ready_for_input` | Agent finished, ready for next message |
 | `chat_history` | Sent on connect (Guide) and on `switch_agent`: recent messages for the specified agent |
 | `user_message_broadcast` | User message from another tab, broadcast to all other connected clients |
-| `compaction_start` / `compaction_end` | Auto-compaction lifecycle (context window management). UI shows transient "Compacting..." / "Compacted" indicator |
+| `compaction_start` / `compaction_end` | Auto-compaction lifecycle (context window management). UI shows a transient "Compacting..." indicator while in flight; on `compaction_end` the indicator clears and the chat timeline gets a persisted "Context compacted" (or `failed: ...` / `aborted`) system message in chronological position |
 | `board_changed` | Broadcast when `write_system2_db` modifies a project, task, task_link, or task_comment. UI panels refetch `/api/kanban`. |
 | `agents_changed` | Broadcast when an agent is spawned, terminated, or resurrected. UI panels refetch `/api/agents`. |
 | `artifacts_changed` | Broadcast when `write_system2_db` modifies an artifact. UI panels refetch `/api/artifacts`. |

--- a/package.json
+++ b/package.json
@@ -95,5 +95,10 @@
     "vite": "^5.0.11",
     "vitest": "4.0.18"
   },
-  "packageManager": "pnpm@8.15.0"
+  "packageManager": "pnpm@8.15.0",
+  "pnpm": {
+    "patchedDependencies": {
+      "@mariozechner/pi-coding-agent@0.71.1": "patches/@mariozechner__pi-coding-agent@0.71.1.patch"
+    }
+  }
 }

--- a/patches/@mariozechner__pi-coding-agent@0.71.1.patch
+++ b/patches/@mariozechner__pi-coding-agent@0.71.1.patch
@@ -1,0 +1,28 @@
+diff --git a/dist/core/compaction/compaction.js b/dist/core/compaction/compaction.js
+index 0658cb737dd13f5606ea9b5ebb98443c547a922d..33f848d0384eed496aa991b4147e7031de323ac7 100644
+--- a/dist/core/compaction/compaction.js
++++ b/dist/core/compaction/compaction.js
+@@ -430,7 +430,11 @@ Keep each section concise. Preserve exact file paths, function names, and error
+  * If previousSummary is provided, uses the update prompt to merge.
+  */
+ export async function generateSummary(currentMessages, model, reserveTokens, apiKey, headers, signal, customInstructions, previousSummary, thinkingLevel) {
+-    const maxTokens = Math.floor(0.8 * reserveTokens);
++    // Clamp at the model's per-response output cap. Without this, large-context
++    // models (e.g. claude-opus-4-7 with a 1M context window) compute a maxTokens
++    // that exceeds the provider's output limit and the API rejects every
++    // summarization request with HTTP 400.
++    const maxTokens = Math.min(Math.floor(0.8 * reserveTokens), model.maxTokens ?? Infinity);
+     // Use update prompt if we have a previous summary, otherwise initial prompt
+     let basePrompt = previousSummary ? UPDATE_SUMMARIZATION_PROMPT : SUMMARIZATION_PROMPT;
+     if (customInstructions) {
+@@ -590,7 +594,9 @@ export async function compact(preparation, model, apiKey, headers, customInstruc
+  * Generate a summary for a turn prefix (when splitting a turn).
+  */
+ async function generateTurnPrefixSummary(messages, model, reserveTokens, apiKey, headers, signal, thinkingLevel) {
+-    const maxTokens = Math.floor(0.5 * reserveTokens); // Smaller budget for turn prefix
++    // Smaller budget for turn prefix, clamped at the model's per-response cap
++    // (see generateSummary above for the rationale).
++    const maxTokens = Math.min(Math.floor(0.5 * reserveTokens), model.maxTokens ?? Infinity);
+     const llmMessages = convertToLlm(messages);
+     const conversationText = serializeConversation(llmMessages);
+     const promptText = `<conversation>\n${conversationText}\n</conversation>\n\n${TURN_PREFIX_SUMMARIZATION_PROMPT}`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@mariozechner/pi-coding-agent@0.71.1':
+    hash: loarssh6j74qyu4ihirmxx4ipy
+    path: patches/@mariozechner__pi-coding-agent@0.71.1.patch
+
 dependencies:
   '@clack/prompts':
     specifier: ^1.0.1
@@ -19,7 +24,7 @@ dependencies:
     version: 0.71.1(ws@8.20.0)(zod@4.4.1)
   '@mariozechner/pi-coding-agent':
     specifier: ^0.71.1
-    version: 0.71.1(ws@8.20.0)(zod@4.4.1)
+    version: 0.71.1(patch_hash=loarssh6j74qyu4ihirmxx4ipy)(ws@8.20.0)(zod@4.4.1)
   '@mozilla/readability':
     specifier: ^0.6.0
     version: 0.6.0
@@ -1779,7 +1784,7 @@ packages:
       - zod
     dev: false
 
-  /@mariozechner/pi-coding-agent@0.71.1(ws@8.20.0)(zod@4.4.1):
+  /@mariozechner/pi-coding-agent@0.71.1(patch_hash=loarssh6j74qyu4ihirmxx4ipy)(ws@8.20.0)(zod@4.4.1):
     resolution: {integrity: sha512-pP7ymz+MmZrcN5aUldm1q1cVbG3u04yZR/XsHEfidku5W3PP1uxsA0A4g4NOhXnkK5EZ+Qg6H12BAbVvl7Qq2Q==}
     engines: {node: '>=20.6.0'}
     hasBin: true
@@ -1816,6 +1821,7 @@ packages:
       - ws
       - zod
     dev: false
+    patched: true
 
   /@mariozechner/pi-tui@0.71.1:
     resolution: {integrity: sha512-jNMN9EmGiH8EIKG62fceOTonoJ9k0cohTdjQCDrOk77vnxPVK+3be/+S1xk4hxviltwxlRH0d7mGQXs+CuEL8g==}

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -166,7 +166,12 @@ describe('AgentHost', () => {
       const hostInternal = host as unknown as {
         pendingPrompt: string | null;
         session: { prompt: ReturnType<typeof vi.fn> };
-        handleSessionEvent: (event: { type: string }) => void;
+        handleSessionEvent: (event: {
+          type: string;
+          result?: unknown;
+          aborted?: boolean;
+          errorMessage?: string;
+        }) => void;
       };
 
       // Track pendingPrompt value during session.prompt()
@@ -211,7 +216,12 @@ describe('AgentHost', () => {
 
       const hostInternal = host as unknown as {
         pendingPrompt: string | null;
-        handleSessionEvent: (event: { type: string }) => void;
+        handleSessionEvent: (event: {
+          type: string;
+          result?: unknown;
+          aborted?: boolean;
+          errorMessage?: string;
+        }) => void;
         handlePotentialError: ReturnType<typeof vi.fn>;
         handleCompactionTracking: ReturnType<typeof vi.fn>;
       };
@@ -2477,7 +2487,12 @@ describe('AgentHost', () => {
         compact: ReturnType<typeof vi.fn>;
         getContextUsage: ReturnType<typeof vi.fn>;
       } | null;
-      handleCompactionTracking: (event: { type: string }) => void;
+      handleCompactionTracking: (event: {
+        type: string;
+        result?: unknown;
+        aborted?: boolean;
+        errorMessage?: string;
+      }) => void;
       triggerPruningCompaction: () => Promise<void>;
       findBaselineSummary: () => string | null;
       readCompactionCount: () => number;
@@ -2624,22 +2639,76 @@ describe('AgentHost', () => {
     });
 
     describe('handleCompactionTracking', () => {
-      it('increments counter on compaction_end and persists', () => {
+      it('increments counter on a successful compaction_end (non-null result)', () => {
         const { internal } = makeHostForPruning(3);
         internal.compactionCount = 0;
         internal.writeCompactionCount = vi.fn();
 
-        internal.handleCompactionTracking({ type: 'compaction_end' });
+        internal.handleCompactionTracking({
+          type: 'compaction_end',
+          result: { firstKeptEntryId: 'abc' },
+          aborted: false,
+        });
 
         expect(internal.compactionCount).toBe(1);
         expect(internal.writeCompactionCount).toHaveBeenCalledWith(1);
+      });
+
+      it('does NOT increment when result is undefined (silent no-op)', () => {
+        const { internal } = makeHostForPruning(3);
+        internal.compactionCount = 0;
+        internal.writeCompactionCount = vi.fn();
+
+        internal.handleCompactionTracking({
+          type: 'compaction_end',
+          result: undefined,
+          aborted: false,
+        });
+
+        expect(internal.compactionCount).toBe(0);
+        expect(internal.writeCompactionCount).not.toHaveBeenCalled();
+      });
+
+      it('does NOT increment when aborted', () => {
+        const { internal } = makeHostForPruning(3);
+        internal.compactionCount = 0;
+        internal.writeCompactionCount = vi.fn();
+
+        internal.handleCompactionTracking({
+          type: 'compaction_end',
+          result: { firstKeptEntryId: 'abc' },
+          aborted: true,
+        });
+
+        expect(internal.compactionCount).toBe(0);
+        expect(internal.writeCompactionCount).not.toHaveBeenCalled();
+      });
+
+      it('does NOT increment when errorMessage is set', () => {
+        const { internal } = makeHostForPruning(3);
+        internal.compactionCount = 0;
+        internal.writeCompactionCount = vi.fn();
+
+        internal.handleCompactionTracking({
+          type: 'compaction_end',
+          result: undefined,
+          aborted: false,
+          errorMessage: 'Auto-compaction failed: HTTP 400',
+        });
+
+        expect(internal.compactionCount).toBe(0);
+        expect(internal.writeCompactionCount).not.toHaveBeenCalled();
       });
 
       it('does not increment counter when compaction_depth is 0', () => {
         const { internal } = makeHostForPruning(0);
         internal.compactionCount = 0;
 
-        internal.handleCompactionTracking({ type: 'compaction_end' });
+        internal.handleCompactionTracking({
+          type: 'compaction_end',
+          result: { firstKeptEntryId: 'abc' },
+          aborted: false,
+        });
 
         expect(internal.compactionCount).toBe(0);
       });
@@ -2721,7 +2790,12 @@ describe('AgentHost', () => {
         onBusyChange?: (agentId: number, busy: boolean, contextPercent: number | null) => void;
         listeners: Set<(event: { type: string }) => void>;
         deferredAgentEnd: { type: string } | null;
-        handleSessionEvent: (event: { type: string }) => void;
+        handleSessionEvent: (event: {
+          type: string;
+          result?: unknown;
+          aborted?: boolean;
+          errorMessage?: string;
+        }) => void;
         handlePotentialError: (event: unknown) => Promise<void>;
       };
 
@@ -2856,7 +2930,11 @@ describe('AgentHost', () => {
         def.handlePotentialError = vi.fn().mockResolvedValue(undefined);
         def.listeners = new Set();
 
-        def.handleSessionEvent({ type: 'compaction_end' });
+        def.handleSessionEvent({
+          type: 'compaction_end',
+          result: { firstKeptEntryId: 'abc' },
+          aborted: false,
+        });
 
         expect(def.compactionCount).toBe(1);
       });

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -17,6 +17,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, join } from 'node:path';
+import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LlmConfig } from '../../shared/index.js';
 import { AgentHost, MAX_DELIVERY_BYTES, pickModelForTier } from './host.js';
@@ -2487,12 +2488,8 @@ describe('AgentHost', () => {
         compact: ReturnType<typeof vi.fn>;
         getContextUsage: ReturnType<typeof vi.fn>;
       } | null;
-      handleCompactionTracking: (event: {
-        type: string;
-        result?: unknown;
-        aborted?: boolean;
-        errorMessage?: string;
-      }) => void;
+      handleCompactionTracking: (event: AgentSessionEvent) => void;
+      bumpCompactionCount: () => void;
       triggerPruningCompaction: () => Promise<void>;
       findBaselineSummary: () => string | null;
       readCompactionCount: () => number;
@@ -2639,16 +2636,29 @@ describe('AgentHost', () => {
     });
 
     describe('handleCompactionTracking', () => {
+      // Helper: tests deliberately construct minimal compaction_end events;
+      // cast through unknown so we don't have to fabricate every required
+      // field on the SDK's union member.
+      function compactionEnd(overrides: {
+        result?: { firstKeptEntryId: string; summary?: string; tokensBefore?: number };
+        aborted?: boolean;
+        errorMessage?: string;
+      }): AgentSessionEvent {
+        return {
+          type: 'compaction_end',
+          reason: 'threshold',
+          willRetry: false,
+          aborted: false,
+          ...overrides,
+        } as unknown as AgentSessionEvent;
+      }
+
       it('increments counter on a successful compaction_end (non-null result)', () => {
         const { internal } = makeHostForPruning(3);
         internal.compactionCount = 0;
         internal.writeCompactionCount = vi.fn();
 
-        internal.handleCompactionTracking({
-          type: 'compaction_end',
-          result: { firstKeptEntryId: 'abc' },
-          aborted: false,
-        });
+        internal.handleCompactionTracking(compactionEnd({ result: { firstKeptEntryId: 'abc' } }));
 
         expect(internal.compactionCount).toBe(1);
         expect(internal.writeCompactionCount).toHaveBeenCalledWith(1);
@@ -2659,11 +2669,7 @@ describe('AgentHost', () => {
         internal.compactionCount = 0;
         internal.writeCompactionCount = vi.fn();
 
-        internal.handleCompactionTracking({
-          type: 'compaction_end',
-          result: undefined,
-          aborted: false,
-        });
+        internal.handleCompactionTracking(compactionEnd({ result: undefined }));
 
         expect(internal.compactionCount).toBe(0);
         expect(internal.writeCompactionCount).not.toHaveBeenCalled();
@@ -2674,11 +2680,9 @@ describe('AgentHost', () => {
         internal.compactionCount = 0;
         internal.writeCompactionCount = vi.fn();
 
-        internal.handleCompactionTracking({
-          type: 'compaction_end',
-          result: { firstKeptEntryId: 'abc' },
-          aborted: true,
-        });
+        internal.handleCompactionTracking(
+          compactionEnd({ result: { firstKeptEntryId: 'abc' }, aborted: true })
+        );
 
         expect(internal.compactionCount).toBe(0);
         expect(internal.writeCompactionCount).not.toHaveBeenCalled();
@@ -2689,12 +2693,12 @@ describe('AgentHost', () => {
         internal.compactionCount = 0;
         internal.writeCompactionCount = vi.fn();
 
-        internal.handleCompactionTracking({
-          type: 'compaction_end',
-          result: undefined,
-          aborted: false,
-          errorMessage: 'Auto-compaction failed: HTTP 400',
-        });
+        internal.handleCompactionTracking(
+          compactionEnd({
+            result: undefined,
+            errorMessage: 'Auto-compaction failed: HTTP 400',
+          })
+        );
 
         expect(internal.compactionCount).toBe(0);
         expect(internal.writeCompactionCount).not.toHaveBeenCalled();
@@ -2704,11 +2708,7 @@ describe('AgentHost', () => {
         const { internal } = makeHostForPruning(0);
         internal.compactionCount = 0;
 
-        internal.handleCompactionTracking({
-          type: 'compaction_end',
-          result: { firstKeptEntryId: 'abc' },
-          aborted: false,
-        });
+        internal.handleCompactionTracking(compactionEnd({ result: { firstKeptEntryId: 'abc' } }));
 
         expect(internal.compactionCount).toBe(0);
       });
@@ -2721,7 +2721,7 @@ describe('AgentHost', () => {
         internal.compactionCount = 3;
         internal.writeCompactionCount = vi.fn();
 
-        internal.handleCompactionTracking({ type: 'agent_end' });
+        internal.handleCompactionTracking({ type: 'agent_end' } as unknown as AgentSessionEvent);
 
         expect(internal.isPruning).toBe(true);
         expect(session.compact).toHaveBeenCalled();
@@ -2740,7 +2740,7 @@ describe('AgentHost', () => {
           throw new Error('getContextUsage must not be consulted by pruning trigger');
         });
 
-        internal.handleCompactionTracking({ type: 'agent_end' });
+        internal.handleCompactionTracking({ type: 'agent_end' } as unknown as AgentSessionEvent);
 
         expect(internal.isPruning).toBe(true);
         expect(session.compact).toHaveBeenCalled();
@@ -2753,7 +2753,7 @@ describe('AgentHost', () => {
         internal._sessionDir = '/tmp/test-session';
         internal.compactionCount = 2;
 
-        internal.handleCompactionTracking({ type: 'agent_end' });
+        internal.handleCompactionTracking({ type: 'agent_end' } as unknown as AgentSessionEvent);
 
         expect(internal.isPruning).toBe(false);
       });
@@ -2767,7 +2767,7 @@ describe('AgentHost', () => {
         internal.isPruning = true;
         internal.writeCompactionCount = vi.fn();
 
-        internal.handleCompactionTracking({ type: 'agent_end' });
+        internal.handleCompactionTracking({ type: 'agent_end' } as unknown as AgentSessionEvent);
 
         // compact should not be called because isPruning was already true
         expect(session.compact).not.toHaveBeenCalled();
@@ -2777,8 +2777,12 @@ describe('AgentHost', () => {
         const { internal } = makeHostForPruning(3);
         internal.compactionCount = 0;
 
-        internal.handleCompactionTracking({ type: 'message_update' });
-        internal.handleCompactionTracking({ type: 'tool_execution_start' });
+        internal.handleCompactionTracking({
+          type: 'message_update',
+        } as unknown as AgentSessionEvent);
+        internal.handleCompactionTracking({
+          type: 'tool_execution_start',
+        } as unknown as AgentSessionEvent);
 
         expect(internal.compactionCount).toBe(0);
       });
@@ -3417,6 +3421,7 @@ describe('AgentHost', () => {
         compactionProvider?: string
       ) => Promise<boolean>;
       handleCompactionTracking: ReturnType<typeof vi.fn>;
+      bumpCompactionCount: ReturnType<typeof vi.fn>;
       reinitializeWithProvider: ReturnType<typeof vi.fn>;
       writeCompactionCount: ReturnType<typeof vi.fn>;
     };
@@ -3440,6 +3445,7 @@ describe('AgentHost', () => {
         internal.session = { compact: vi.fn().mockResolvedValue(undefined) };
       });
       internal.handleCompactionTracking = vi.fn();
+      internal.bumpCompactionCount = vi.fn();
       internal.session = { compact: vi.fn().mockResolvedValue(undefined) };
       return { host, internal };
     }
@@ -3476,11 +3482,11 @@ describe('AgentHost', () => {
 
       // After compact+tail-append the file has head+tail; reinitialize was called twice
       expect(internal.reinitializeWithProvider).toHaveBeenCalledTimes(2);
-      // compact() was called once (on the session after first reinit)
-      // handleCompactionTracking was called with compaction_end
-      expect(internal.handleCompactionTracking).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'compaction_end' })
-      );
+      // session.compact() succeeded, so bumpCompactionCount was called directly
+      // (overflow recovery used to synthesize a compaction_end event; we now
+      // bump the counter directly to keep handleCompactionTracking strictly
+      // typed against AgentSessionEvent).
+      expect(internal.bumpCompactionCount).toHaveBeenCalledTimes(1);
       // The overflow entry (index 3) should be in the tail and appended back
       expect(remaining.at(-1)).toMatchObject({
         type: 'message',

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -1800,30 +1800,20 @@ export class AgentHost {
    * silent no-ops (early exits in the SDK's _runAutoCompaction) and failures
    * don't burn the pruning-depth budget.
    */
-  private handleCompactionTracking(
-    event:
-      | Pick<AgentSessionEvent, 'type'>
-      | {
-          type: 'compaction_end';
-          result?: { firstKeptEntryId: string } | undefined;
-          aborted?: boolean;
-          errorMessage?: string;
-        }
-  ): void {
+  private handleCompactionTracking(event: AgentSessionEvent): void {
     if (this.compactionDepth <= 0) return;
 
     // Track compaction counter — only on real, completed compactions.
-    if (event.type === 'compaction_end') {
-      const e = event as {
-        result?: unknown;
-        aborted?: boolean;
-        errorMessage?: string;
-      };
-      const succeeded = e.result != null && !e.aborted && !e.errorMessage;
-      if (succeeded) {
-        this.compactionCount++;
-        this.writeCompactionCount(this.compactionCount);
-      }
+    // Using AgentSessionEvent (the SDK's discriminated union) lets TypeScript
+    // narrow `event` to the full `compaction_end` shape here, so we can read
+    // result/aborted/errorMessage directly without a cast.
+    if (
+      event.type === 'compaction_end' &&
+      event.result != null &&
+      !event.aborted &&
+      !event.errorMessage
+    ) {
+      this.bumpCompactionCount();
     }
 
     // Trigger pruning compaction on agent_end when counter reaches depth
@@ -1845,6 +1835,18 @@ export class AgentHost {
           this.flushDeferredAgentEnd();
         });
     }
+  }
+
+  /**
+   * Increment the pruning counter and persist it. Called from
+   * `handleCompactionTracking` for SDK-driven `compaction_end` events that
+   * actually produced a summary, and directly from `handleContextOverflow`
+   * after a successful manual `session.compact()` (since the overflow path
+   * doesn't go through `handleCompactionTracking` with a real SDK event).
+   */
+  private bumpCompactionCount(): void {
+    this.compactionCount++;
+    this.writeCompactionCount(this.compactionCount);
   }
 
   /**
@@ -2248,13 +2250,13 @@ export class AgentHost {
       if (this.session) {
         log.info('[AgentHost] Context overflow: compacting...');
         await this.session.compact();
-        // Synthesize compaction_end so the pruning counter stays accurate.
-        // session.compact() throws on failure, so reaching here means success —
-        // pass a non-null `result` marker so handleCompactionTracking counts it.
-        this.handleCompactionTracking({
-          type: 'compaction_end',
-          result: { firstKeptEntryId: 'overflow-recovery' },
-        });
+        // session.compact() throws on failure, so reaching here means success.
+        // Bump the pruning counter directly instead of synthesizing a fake
+        // SDK event — handleCompactionTracking is strictly typed against the
+        // SDK's AgentSessionEvent union now.
+        if (this.compactionDepth > 0) {
+          this.bumpCompactionCount();
+        }
         log.info('[AgentHost] Context overflow: compaction complete');
       }
 

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -1796,15 +1796,34 @@ export class AgentHost {
 
   /**
    * Handle compaction tracking for pruning.
-   * Increments counter on compaction_end and triggers pruning when threshold is met.
+   * Increments counter only when a compaction actually produced a summary, so
+   * silent no-ops (early exits in the SDK's _runAutoCompaction) and failures
+   * don't burn the pruning-depth budget.
    */
-  private handleCompactionTracking(event: Pick<AgentSessionEvent, 'type'>): void {
+  private handleCompactionTracking(
+    event:
+      | Pick<AgentSessionEvent, 'type'>
+      | {
+          type: 'compaction_end';
+          result?: { firstKeptEntryId: string } | undefined;
+          aborted?: boolean;
+          errorMessage?: string;
+        }
+  ): void {
     if (this.compactionDepth <= 0) return;
 
-    // Track compaction counter
+    // Track compaction counter — only on real, completed compactions.
     if (event.type === 'compaction_end') {
-      this.compactionCount++;
-      this.writeCompactionCount(this.compactionCount);
+      const e = event as {
+        result?: unknown;
+        aborted?: boolean;
+        errorMessage?: string;
+      };
+      const succeeded = e.result != null && !e.aborted && !e.errorMessage;
+      if (succeeded) {
+        this.compactionCount++;
+        this.writeCompactionCount(this.compactionCount);
+      }
     }
 
     // Trigger pruning compaction on agent_end when counter reaches depth
@@ -2229,8 +2248,13 @@ export class AgentHost {
       if (this.session) {
         log.info('[AgentHost] Context overflow: compacting...');
         await this.session.compact();
-        // Synthesize compaction_end so the pruning counter stays accurate
-        this.handleCompactionTracking({ type: 'compaction_end' });
+        // Synthesize compaction_end so the pruning counter stays accurate.
+        // session.compact() throws on failure, so reaching here means success —
+        // pass a non-null `result` marker so handleCompactionTracking counts it.
+        this.handleCompactionTracking({
+          type: 'compaction_end',
+          result: { firstKeptEntryId: 'overflow-recovery' },
+        });
         log.info('[AgentHost] Context overflow: compaction complete');
       }
 

--- a/src/server/chat/history-capture.test.ts
+++ b/src/server/chat/history-capture.test.ts
@@ -96,24 +96,33 @@ describe('createHistoryCaptureSubscriber', () => {
     const cache = mockCache();
     const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
-    sub({ type: 'compaction_start' } as unknown as AgentSessionEvent);
+    sub({ type: 'compaction_start', reason: 'threshold' } as unknown as AgentSessionEvent);
 
     expect(cache.push).toHaveBeenCalledOnce();
     const msg = cache.messages[0] as { role: string; content: string };
     expect(msg.role).toBe('system');
-    expect(msg.content).toBe('Context compaction started');
+    expect(msg.content).toContain('Context compaction started');
+    expect(msg.content).toContain('reason=threshold');
   });
 
-  it('captures compaction_end as system message', () => {
+  it('captures compaction_end as system message with diagnostic detail', () => {
     const cache = mockCache();
     const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
-    sub({ type: 'compaction_end' } as unknown as AgentSessionEvent);
+    sub({
+      type: 'compaction_end',
+      reason: 'threshold',
+      result: undefined,
+      aborted: false,
+      willRetry: false,
+    } as unknown as AgentSessionEvent);
 
     expect(cache.push).toHaveBeenCalledOnce();
     const msg = cache.messages[0] as { role: string; content: string };
     expect(msg.role).toBe('system');
-    expect(msg.content).toBe('Context compacted');
+    expect(msg.content).toContain('Context compacted');
+    expect(msg.content).toContain('reason=threshold');
+    expect(msg.content).toContain('result=undefined (silent no-op)');
   });
 
   it('captures text + tool calls in the same turn', () => {

--- a/src/server/chat/history-capture.test.ts
+++ b/src/server/chat/history-capture.test.ts
@@ -92,7 +92,7 @@ describe('createHistoryCaptureSubscriber', () => {
     expect(cache.push).not.toHaveBeenCalled();
   });
 
-  it('captures compaction_start as system message', () => {
+  it('captures compaction_start as a clean system message', () => {
     const cache = mockCache();
     const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
@@ -101,11 +101,63 @@ describe('createHistoryCaptureSubscriber', () => {
     expect(cache.push).toHaveBeenCalledOnce();
     const msg = cache.messages[0] as { role: string; content: string };
     expect(msg.role).toBe('system');
-    expect(msg.content).toContain('Context compaction started');
-    expect(msg.content).toContain('reason=threshold');
+    expect(msg.content).toBe('Context compaction started');
   });
 
-  it('captures compaction_end as system message with diagnostic detail', () => {
+  it('captures successful compaction_end as a clean system message', () => {
+    const cache = mockCache();
+    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+
+    sub({
+      type: 'compaction_end',
+      reason: 'threshold',
+      result: { firstKeptEntryId: 'abc', tokensBefore: 100000 },
+      aborted: false,
+      willRetry: false,
+    } as unknown as AgentSessionEvent);
+
+    expect(cache.push).toHaveBeenCalledOnce();
+    const msg = cache.messages[0] as { role: string; content: string };
+    expect(msg.role).toBe('system');
+    expect(msg.content).toBe('Context compacted');
+  });
+
+  it('surfaces errorMessage on failed compaction_end', () => {
+    const cache = mockCache();
+    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+
+    sub({
+      type: 'compaction_end',
+      reason: 'threshold',
+      result: undefined,
+      aborted: false,
+      willRetry: false,
+      errorMessage: 'Auto-compaction failed: HTTP 400 max_tokens exceeds cap',
+    } as unknown as AgentSessionEvent);
+
+    const msg = cache.messages[0] as { role: string; content: string };
+    expect(msg.content).toBe(
+      'Context compaction failed: Auto-compaction failed: HTTP 400 max_tokens exceeds cap'
+    );
+  });
+
+  it('surfaces aborted compaction_end distinctly from failure', () => {
+    const cache = mockCache();
+    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+
+    sub({
+      type: 'compaction_end',
+      reason: 'manual',
+      result: undefined,
+      aborted: true,
+      willRetry: false,
+    } as unknown as AgentSessionEvent);
+
+    const msg = cache.messages[0] as { role: string; content: string };
+    expect(msg.content).toBe('Context compaction aborted');
+  });
+
+  it('surfaces silent no-op (result undefined, no flags) as a failure', () => {
     const cache = mockCache();
     const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
@@ -117,12 +169,9 @@ describe('createHistoryCaptureSubscriber', () => {
       willRetry: false,
     } as unknown as AgentSessionEvent);
 
-    expect(cache.push).toHaveBeenCalledOnce();
     const msg = cache.messages[0] as { role: string; content: string };
-    expect(msg.role).toBe('system');
-    expect(msg.content).toContain('Context compacted');
-    expect(msg.content).toContain('reason=threshold');
-    expect(msg.content).toContain('result=undefined (silent no-op)');
+    expect(msg.content).toContain('Context compaction failed');
+    expect(msg.content).toContain('silent no-op');
   });
 
   it('captures text + tool calls in the same turn', () => {

--- a/src/server/chat/history-capture.ts
+++ b/src/server/chat/history-capture.ts
@@ -147,7 +147,7 @@ export function createHistoryCaptureSubscriber(
         // end fire in the same millisecond (silent-failure no-ops do that).
         // React keys collide otherwise and timeline items get dropped.
         getChatCache().push({
-          id: `msg-compaction-start-${randomUUID().slice(0, 8)}`,
+          id: `msg-compaction-start-${randomUUID()}`,
           role: 'system',
           content: 'Context compaction started',
           timestamp: Date.now(),
@@ -170,7 +170,7 @@ export function createHistoryCaptureSubscriber(
           content = 'Context compacted';
         }
         getChatCache().push({
-          id: `msg-compaction-end-${randomUUID().slice(0, 8)}`,
+          id: `msg-compaction-end-${randomUUID()}`,
           role: 'system',
           content,
           timestamp: Date.now(),

--- a/src/server/chat/history-capture.ts
+++ b/src/server/chat/history-capture.ts
@@ -6,6 +6,7 @@
  * independently.
  */
 
+import { randomUUID } from 'node:crypto';
 import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 import type { ChatMessage, ChatTurnEvent } from '../../shared/index.js';
 import type { MessageHistory } from './history.js';
@@ -142,34 +143,36 @@ export function createHistoryCaptureSubscriber(
       }
 
       case 'compaction_start':
+        // Use randomUUID suffix to guarantee uniqueness even when start and
+        // end fire in the same millisecond (silent-failure no-ops do that).
+        // React keys collide otherwise and timeline items get dropped.
         getChatCache().push({
-          id: `msg-${Date.now()}`,
+          id: `msg-compaction-start-${randomUUID().slice(0, 8)}`,
           role: 'system',
-          content: `Context compaction started (reason=${event.reason})`,
+          content: 'Context compaction started',
           timestamp: Date.now(),
         });
         break;
 
       case 'compaction_end': {
-        // DIAGNOSTIC: surface why a compaction ended so silently-failing
-        // compactions (early-exit in _runAutoCompaction) are visible. The SDK
-        // emits compaction_end for both success and several no-op paths.
-        const parts: string[] = [`reason=${event.reason}`];
-        if (event.aborted) parts.push('aborted=true');
-        if (event.willRetry) parts.push('willRetry=true');
-        if (event.errorMessage) parts.push(`error=${event.errorMessage}`);
-        if (event.result) {
-          parts.push(
-            `tokensBefore=${event.result.tokensBefore}`,
-            `firstKeptEntryId=${event.result.firstKeptEntryId}`
-          );
-        } else if (!event.aborted && !event.errorMessage) {
-          parts.push('result=undefined (silent no-op)');
+        // Clean message on success; surface diagnostic detail only when
+        // something went wrong so silent failures don't pose as successes.
+        let content: string;
+        if (event.aborted) {
+          content = 'Context compaction aborted';
+        } else if (event.errorMessage) {
+          content = `Context compaction failed: ${event.errorMessage}`;
+        } else if (!event.result) {
+          // SDK fired compaction_end without a result and without flagging
+          // abort/error. Treat as a silent no-op and surface it.
+          content = 'Context compaction failed: no result (silent no-op)';
+        } else {
+          content = 'Context compacted';
         }
         getChatCache().push({
-          id: `msg-${Date.now()}`,
+          id: `msg-compaction-end-${randomUUID().slice(0, 8)}`,
           role: 'system',
-          content: `Context compacted [${parts.join(', ')}]`,
+          content,
           timestamp: Date.now(),
         });
         break;

--- a/src/server/chat/history-capture.ts
+++ b/src/server/chat/history-capture.ts
@@ -142,15 +142,38 @@ export function createHistoryCaptureSubscriber(
       }
 
       case 'compaction_start':
-      case 'compaction_end':
         getChatCache().push({
           id: `msg-${Date.now()}`,
           role: 'system',
-          content:
-            event.type === 'compaction_start' ? 'Context compaction started' : 'Context compacted',
+          content: `Context compaction started (reason=${event.reason})`,
           timestamp: Date.now(),
         });
         break;
+
+      case 'compaction_end': {
+        // DIAGNOSTIC: surface why a compaction ended so silently-failing
+        // compactions (early-exit in _runAutoCompaction) are visible. The SDK
+        // emits compaction_end for both success and several no-op paths.
+        const parts: string[] = [`reason=${event.reason}`];
+        if (event.aborted) parts.push('aborted=true');
+        if (event.willRetry) parts.push('willRetry=true');
+        if (event.errorMessage) parts.push(`error=${event.errorMessage}`);
+        if (event.result) {
+          parts.push(
+            `tokensBefore=${event.result.tokensBefore}`,
+            `firstKeptEntryId=${event.result.firstKeptEntryId}`
+          );
+        } else if (!event.aborted && !event.errorMessage) {
+          parts.push('result=undefined (silent no-op)');
+        }
+        getChatCache().push({
+          id: `msg-${Date.now()}`,
+          role: 'system',
+          content: `Context compacted [${parts.join(', ')}]`,
+          timestamp: Date.now(),
+        });
+        break;
+      }
     }
   };
 }

--- a/src/ui/stores/chat.ts
+++ b/src/ui/stores/chat.ts
@@ -35,7 +35,7 @@ export interface PerAgentState {
   isStreaming: boolean;
   isWaitingForResponse: boolean;
   provider: string | null;
-  compactionStatus: 'idle' | 'compacting' | 'compacted';
+  compactionStatus: 'idle' | 'compacting';
   compactionTimestamp: number | null;
 }
 
@@ -477,10 +477,14 @@ export const useChatStore = create<ChatState>()(
       },
 
       finishCompaction: (agentId: number) => {
+        // Transition straight back to idle on compaction_end. The persisted
+        // "Context compacted" system message from history-capture records the
+        // event in correct chronological position; the transient indicator
+        // only needs to exist during the in-flight window.
         set((state) => ({
           agentStates: updateAgentState(state.agentStates, agentId, () => ({
-            compactionStatus: 'compacted' as const,
-            compactionTimestamp: Date.now(),
+            compactionStatus: 'idle' as const,
+            compactionTimestamp: null,
             isStreaming: false,
           })),
         }));


### PR DESCRIPTION
Fixes #173.

## Summary

Four interlocking compaction bugs, captured in #173. The root cause is in `@mariozechner/pi-coding-agent@0.71.1`; the other three are downstream surface issues in system2 that masked the SDK failure and would have caused secondary damage even after a fix. All four are addressed here.

## Commits

### 1. `fix(compaction): patch pi-coding-agent to clamp summarization maxTokens at model cap`

Root cause. The SDK's `generateSummary` and `generateTurnPrefixSummary` compute `maxTokens` as `Math.floor(0.8 × reserveTokens)` and `Math.floor(0.5 × reserveTokens)` respectively, then send that to the provider without consulting `model.maxTokens`. On any model where `0.25 × contextWindow > maxTokens`, the API rejects every summarization with HTTP 400.

Conductor on Opus 4.7 1M-context with `reserveTokens = 500K` was computing `maxTokens = 250K`, exceeding Anthropic's 128K output cap. Every auto-compaction on this Conductor has been silently failing since it moved to the 1M variant.

Patch via `pnpm patch @mariozechner/pi-coding-agent@0.71.1` clamps both call sites at `model.maxTokens ?? Infinity`. The patch targets `dist/*.js` because pi-coding-agent ships pre-built JS; will need re-creation if the SDK is upgraded past 0.71.1. Filed upstream as [badlogic/pi-mono#4390](https://github.com/badlogic/pi-mono/issues/4390) with the same diff.

Side-effects of the clamp:
- Compaction trigger point is unchanged (still 50% of context window).
- Summary output budget is now 128K instead of 250K on affected models; empirically summaries land in the 5-20K range so there's ample headroom.
- No effect on models where the math already fits (200K Opus and below).

### 2. `fix(compaction): surface real failure reason, gate counter on success, drop stuck 'compacted' UI state`

Three independent cleanups that would each have improved the system even without the SDK bug:

- **`history-capture.ts`** now reads `event.reason`, `event.aborted`, `event.errorMessage`, and `event.result.{tokensBefore,firstKeptEntryId}` from the `compaction_end` event. Previously the same generic "Context compacted" message was pushed regardless of outcome — exactly the silence that hid the SDK 400s for ~10 days. This is the patch that let us diagnose the bug; keeping it landed means future failure modes surface immediately.

- **`AgentHost.handleCompactionTracking`** in [`host.ts`](src/server/agents/host.ts#L1797) now only increments `compactionCount` when `result != null && !aborted && !errorMessage`. The synthetic call from [`handleContextOverflow`](src/server/agents/host.ts#L2247) passes a fake `result` so overflow recovery still counts. Without this, `conductor_5`'s on-disk counter reached **7 of 8** purely from failed attempts — one more silent failure and a doomed pruning compaction would have fired and produced confusing error logs.

- **`chat.ts`** drops the `'compacted'` status literal entirely. `finishCompaction` now transitions `compactionStatus` straight from `'compacting'` to `'idle'`. The persisted `Context compacted [...]` system message from `history-capture` already records the event in correct chronological position, so the transient in-flight indicator only needs to exist while the LLM call is actually running. Fixes the "bottom-pinned out of chronological order" symptom from #173.

## Test plan

- [x] `pnpm check` — Biome clean across 174 files
- [x] `pnpm typecheck` — `tsc --noEmit` clean
- [x] `pnpm test` — 1010/1010 tests passing, including 4 new tests in `host.test.ts` covering counter behavior on aborted / undefined-result / error-message / success cases
- [x] `pnpm build` — clean build
- [ ] **End-to-end verification (requires daemon restart):** trigger a Conductor turn after rebuild, watch for: ~10-30s `Compacting...` pulse (not 250ms), new `compaction` JSONL entry, totalTokens drop on the next LLM call. Test plan in #173 comments.

## Out of scope (filed separately)

- Upstream SDK fix: [badlogic/pi-mono#4390](https://github.com/badlogic/pi-mono/issues/4390). Once that lands and we bump `pi-coding-agent`, the local `patches/` entry should be revisited (likely delete).
- Retroactively scrubbing the 6 fake "Context compacted" entries currently in `~/.system2/sessions/conductor_5/chat-cache.json` from previous failed attempts. Cosmetic artifact only; new attempts will record accurately.