### PR TITLE
fix(host): skip retry-resend when turn emitted output before failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `AgentHost.handlePotentialError` no longer resends in-flight deliveries when the API call fails after the model has already emitted output (`message_start` / `message_update` / `tool_execution_start`). Previously, a `Request timed out` mid-turn would trigger the retry-resend path, re-feeding the same delivery to the model and re-running any side effects (e.g. file edits) the tool calls had already committed before the connection dropped. The narrator's ad-hoc dedup ("section already exists, skipping") masked the duplicates but did not prevent them. The host now tracks `currentTurnHasOutput` per turn (set on output events, reset on `turn_start`) and, when contamination is detected on failure, rejects all pending delivery promises with a transient error and skips the resend. The job's awaiter (e.g. `trackJobExecution`) marks the job failed, the cursor (`last_narrator_update_ts`) is not advanced, and the next cron tick redoes the window from scratch with the recipient's idempotency handling whatever partial work landed on disk. Fixes #175.
+
 ## [0.3.3] - 2026-05-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -95,5 +95,10 @@
     "vite": "^5.0.11",
     "vitest": "4.0.18"
   },
-  "packageManager": "pnpm@8.15.0"
+  "packageManager": "pnpm@8.15.0",
+  "pnpm": {
+    "patchedDependencies": {
+      "@mariozechner/pi-coding-agent@0.71.1": "patches/@mariozechner__pi-coding-agent@0.71.1.patch"
+    }
+  }
 }

--- a/patches/@mariozechner__pi-coding-agent@0.71.1.patch
+++ b/patches/@mariozechner__pi-coding-agent@0.71.1.patch
@@ -1,0 +1,28 @@
+diff --git a/dist/core/compaction/compaction.js b/dist/core/compaction/compaction.js
+index 0658cb737dd13f5606ea9b5ebb98443c547a922d..33f848d0384eed496aa991b4147e7031de323ac7 100644
+--- a/dist/core/compaction/compaction.js
++++ b/dist/core/compaction/compaction.js
+@@ -430,7 +430,11 @@ Keep each section concise. Preserve exact file paths, function names, and error
+  * If previousSummary is provided, uses the update prompt to merge.
+  */
+ export async function generateSummary(currentMessages, model, reserveTokens, apiKey, headers, signal, customInstructions, previousSummary, thinkingLevel) {
+-    const maxTokens = Math.floor(0.8 * reserveTokens);
++    // Clamp at the model's per-response output cap. Without this, large-context
++    // models (e.g. claude-opus-4-7 with a 1M context window) compute a maxTokens
++    // that exceeds the provider's output limit and the API rejects every
++    // summarization request with HTTP 400.
++    const maxTokens = Math.min(Math.floor(0.8 * reserveTokens), model.maxTokens ?? Infinity);
+     // Use update prompt if we have a previous summary, otherwise initial prompt
+     let basePrompt = previousSummary ? UPDATE_SUMMARIZATION_PROMPT : SUMMARIZATION_PROMPT;
+     if (customInstructions) {
+@@ -590,7 +594,9 @@ export async function compact(preparation, model, apiKey, headers, customInstruc
+  * Generate a summary for a turn prefix (when splitting a turn).
+  */
+ async function generateTurnPrefixSummary(messages, model, reserveTokens, apiKey, headers, signal, thinkingLevel) {
+-    const maxTokens = Math.floor(0.5 * reserveTokens); // Smaller budget for turn prefix
++    // Smaller budget for turn prefix, clamped at the model's per-response cap
++    // (see generateSummary above for the rationale).
++    const maxTokens = Math.min(Math.floor(0.5 * reserveTokens), model.maxTokens ?? Infinity);
+     const llmMessages = convertToLlm(messages);
+     const conversationText = serializeConversation(llmMessages);
+     const promptText = `<conversation>\n${conversationText}\n</conversation>\n\n${TURN_PREFIX_SUMMARIZATION_PROMPT}`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@mariozechner/pi-coding-agent@0.71.1':
+    hash: loarssh6j74qyu4ihirmxx4ipy
+    path: patches/@mariozechner__pi-coding-agent@0.71.1.patch
+
 dependencies:
   '@clack/prompts':
     specifier: ^1.0.1
@@ -19,7 +24,7 @@ dependencies:
     version: 0.71.1(ws@8.20.0)(zod@4.4.1)
   '@mariozechner/pi-coding-agent':
     specifier: ^0.71.1
-    version: 0.71.1(ws@8.20.0)(zod@4.4.1)
+    version: 0.71.1(patch_hash=loarssh6j74qyu4ihirmxx4ipy)(ws@8.20.0)(zod@4.4.1)
   '@mozilla/readability':
     specifier: ^0.6.0
     version: 0.6.0
@@ -1779,7 +1784,7 @@ packages:
       - zod
     dev: false
 
-  /@mariozechner/pi-coding-agent@0.71.1(ws@8.20.0)(zod@4.4.1):
+  /@mariozechner/pi-coding-agent@0.71.1(patch_hash=loarssh6j74qyu4ihirmxx4ipy)(ws@8.20.0)(zod@4.4.1):
     resolution: {integrity: sha512-pP7ymz+MmZrcN5aUldm1q1cVbG3u04yZR/XsHEfidku5W3PP1uxsA0A4g4NOhXnkK5EZ+Qg6H12BAbVvl7Qq2Q==}
     engines: {node: '>=20.6.0'}
     hasBin: true
@@ -1816,6 +1821,7 @@ packages:
       - ws
       - zod
     dev: false
+    patched: true
 
   /@mariozechner/pi-tui@0.71.1:
     resolution: {integrity: sha512-jNMN9EmGiH8EIKG62fceOTonoJ9k0cohTdjQCDrOk77vnxPVK+3be/+S1xk4hxviltwxlRH0d7mGQXs+CuEL8g==}

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -166,7 +166,12 @@ describe('AgentHost', () => {
       const hostInternal = host as unknown as {
         pendingPrompt: string | null;
         session: { prompt: ReturnType<typeof vi.fn> };
-        handleSessionEvent: (event: { type: string }) => void;
+        handleSessionEvent: (event: {
+          type: string;
+          result?: unknown;
+          aborted?: boolean;
+          errorMessage?: string;
+        }) => void;
       };
 
       // Track pendingPrompt value during session.prompt()
@@ -211,7 +216,12 @@ describe('AgentHost', () => {
 
       const hostInternal = host as unknown as {
         pendingPrompt: string | null;
-        handleSessionEvent: (event: { type: string }) => void;
+        handleSessionEvent: (event: {
+          type: string;
+          result?: unknown;
+          aborted?: boolean;
+          errorMessage?: string;
+        }) => void;
         handlePotentialError: ReturnType<typeof vi.fn>;
         handleCompactionTracking: ReturnType<typeof vi.fn>;
       };
@@ -2477,7 +2487,12 @@ describe('AgentHost', () => {
         compact: ReturnType<typeof vi.fn>;
         getContextUsage: ReturnType<typeof vi.fn>;
       } | null;
-      handleCompactionTracking: (event: { type: string }) => void;
+      handleCompactionTracking: (event: {
+        type: string;
+        result?: unknown;
+        aborted?: boolean;
+        errorMessage?: string;
+      }) => void;
       triggerPruningCompaction: () => Promise<void>;
       findBaselineSummary: () => string | null;
       readCompactionCount: () => number;
@@ -2624,22 +2639,76 @@ describe('AgentHost', () => {
     });
 
     describe('handleCompactionTracking', () => {
-      it('increments counter on compaction_end and persists', () => {
+      it('increments counter on a successful compaction_end (non-null result)', () => {
         const { internal } = makeHostForPruning(3);
         internal.compactionCount = 0;
         internal.writeCompactionCount = vi.fn();
 
-        internal.handleCompactionTracking({ type: 'compaction_end' });
+        internal.handleCompactionTracking({
+          type: 'compaction_end',
+          result: { firstKeptEntryId: 'abc' },
+          aborted: false,
+        });
 
         expect(internal.compactionCount).toBe(1);
         expect(internal.writeCompactionCount).toHaveBeenCalledWith(1);
+      });
+
+      it('does NOT increment when result is undefined (silent no-op)', () => {
+        const { internal } = makeHostForPruning(3);
+        internal.compactionCount = 0;
+        internal.writeCompactionCount = vi.fn();
+
+        internal.handleCompactionTracking({
+          type: 'compaction_end',
+          result: undefined,
+          aborted: false,
+        });
+
+        expect(internal.compactionCount).toBe(0);
+        expect(internal.writeCompactionCount).not.toHaveBeenCalled();
+      });
+
+      it('does NOT increment when aborted', () => {
+        const { internal } = makeHostForPruning(3);
+        internal.compactionCount = 0;
+        internal.writeCompactionCount = vi.fn();
+
+        internal.handleCompactionTracking({
+          type: 'compaction_end',
+          result: { firstKeptEntryId: 'abc' },
+          aborted: true,
+        });
+
+        expect(internal.compactionCount).toBe(0);
+        expect(internal.writeCompactionCount).not.toHaveBeenCalled();
+      });
+
+      it('does NOT increment when errorMessage is set', () => {
+        const { internal } = makeHostForPruning(3);
+        internal.compactionCount = 0;
+        internal.writeCompactionCount = vi.fn();
+
+        internal.handleCompactionTracking({
+          type: 'compaction_end',
+          result: undefined,
+          aborted: false,
+          errorMessage: 'Auto-compaction failed: HTTP 400',
+        });
+
+        expect(internal.compactionCount).toBe(0);
+        expect(internal.writeCompactionCount).not.toHaveBeenCalled();
       });
 
       it('does not increment counter when compaction_depth is 0', () => {
         const { internal } = makeHostForPruning(0);
         internal.compactionCount = 0;
 
-        internal.handleCompactionTracking({ type: 'compaction_end' });
+        internal.handleCompactionTracking({
+          type: 'compaction_end',
+          result: { firstKeptEntryId: 'abc' },
+          aborted: false,
+        });
 
         expect(internal.compactionCount).toBe(0);
       });
@@ -2721,7 +2790,12 @@ describe('AgentHost', () => {
         onBusyChange?: (agentId: number, busy: boolean, contextPercent: number | null) => void;
         listeners: Set<(event: { type: string }) => void>;
         deferredAgentEnd: { type: string } | null;
-        handleSessionEvent: (event: { type: string }) => void;
+        handleSessionEvent: (event: {
+          type: string;
+          result?: unknown;
+          aborted?: boolean;
+          errorMessage?: string;
+        }) => void;
         handlePotentialError: (event: unknown) => Promise<void>;
       };
 
@@ -2856,7 +2930,11 @@ describe('AgentHost', () => {
         def.handlePotentialError = vi.fn().mockResolvedValue(undefined);
         def.listeners = new Set();
 
-        def.handleSessionEvent({ type: 'compaction_end' });
+        def.handleSessionEvent({
+          type: 'compaction_end',
+          result: { firstKeptEntryId: 'abc' },
+          aborted: false,
+        });
 
         expect(def.compactionCount).toBe(1);
       });

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -955,6 +955,194 @@ describe('AgentHost', () => {
       // fires when session.prompt() throws synchronously
       expect(hostInternal.pendingPrompt).toBe('hello world');
     });
+
+    it('rejects pending deliveries instead of resending when turn already emitted output (#175)', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        pendingPrompt: string | null;
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
+        }>;
+        currentTurnHasOutput: boolean;
+        session: {
+          prompt: ReturnType<typeof vi.fn>;
+          sendCustomMessage: ReturnType<typeof vi.fn>;
+        };
+        handlePotentialError: (event: unknown) => Promise<void>;
+        authResolver: {
+          markKeyFailed: ReturnType<typeof vi.fn>;
+          getNextProvider: ReturnType<typeof vi.fn>;
+          isKeyInCooldown: ReturnType<typeof vi.fn>;
+        };
+        retryAttempts: Map<string, number>;
+        currentProvider: string;
+        currentKeyIndex: number;
+      };
+
+      hostInternal.session = {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        sendCustomMessage: vi.fn().mockResolvedValue(undefined),
+      };
+      hostInternal.currentProvider = 'cerebras';
+      hostInternal.currentKeyIndex = 0;
+      hostInternal.pendingPrompt = null;
+
+      const details = { sender: 0, receiver: 2, timestamp: Date.now() };
+      const reject1 = vi.fn();
+      const reject2 = vi.fn();
+      hostInternal.pendingDeliveries = [
+        { content: 'project-log', details, urgent: false, resolve: vi.fn(), reject: reject1 },
+        { content: 'daily-summary', details, urgent: false, resolve: vi.fn(), reject: reject2 },
+      ];
+
+      // Simulate that the model emitted output before the failure (e.g. ran a tool call).
+      hostInternal.currentTurnHasOutput = true;
+
+      // Rate limit on first attempt would normally take the retry path and resend.
+      hostInternal.retryAttempts = new Map();
+      hostInternal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
+      hostInternal.authResolver.markKeyFailed = vi.fn().mockReturnValue(false);
+      hostInternal.authResolver.getNextProvider = vi.fn().mockReturnValue(null);
+
+      await hostInternal.handlePotentialError({
+        type: 'message_end',
+        message: { stopReason: 'error', errorMessage: 'Error 429: rate limit exceeded' },
+      });
+
+      expect(reject1).toHaveBeenCalledOnce();
+      expect(reject2).toHaveBeenCalledOnce();
+      const rejectArg = reject1.mock.calls[0][0] as Error;
+      expect(rejectArg).toBeInstanceOf(Error);
+      expect(rejectArg.message).toContain('API error after model output');
+      expect(hostInternal.pendingDeliveries).toHaveLength(0);
+      // No resend: sendCustomMessage must not have been called.
+      expect(hostInternal.session.sendCustomMessage).not.toHaveBeenCalled();
+    });
+
+    it('still resends pending deliveries when no output was emitted yet (#175 regression)', async () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        pendingPrompt: string | null;
+        pendingDeliveries: Array<{
+          content: string;
+          details: { sender: number; receiver: number; timestamp: number };
+          urgent?: boolean;
+          resolve: () => void;
+          reject: (reason: Error) => void;
+        }>;
+        currentTurnHasOutput: boolean;
+        session: {
+          prompt: ReturnType<typeof vi.fn>;
+          sendCustomMessage: ReturnType<typeof vi.fn>;
+        };
+        handlePotentialError: (event: unknown) => Promise<void>;
+        authResolver: {
+          markKeyFailed: ReturnType<typeof vi.fn>;
+          getNextProvider: ReturnType<typeof vi.fn>;
+          isKeyInCooldown: ReturnType<typeof vi.fn>;
+        };
+        retryAttempts: Map<string, number>;
+        currentProvider: string;
+        currentKeyIndex: number;
+      };
+
+      hostInternal.session = {
+        prompt: vi.fn().mockResolvedValue(undefined),
+        sendCustomMessage: vi.fn().mockResolvedValue(undefined),
+      };
+      hostInternal.currentProvider = 'cerebras';
+      hostInternal.currentKeyIndex = 0;
+      hostInternal.pendingPrompt = null;
+
+      const details = { sender: 0, receiver: 2, timestamp: Date.now() };
+      const reject1 = vi.fn();
+      hostInternal.pendingDeliveries = [
+        { content: 'project-log', details, urgent: false, resolve: vi.fn(), reject: reject1 },
+      ];
+
+      // No output emitted yet — safe to resend.
+      hostInternal.currentTurnHasOutput = false;
+
+      hostInternal.retryAttempts = new Map();
+      hostInternal.authResolver.isKeyInCooldown = vi.fn().mockReturnValue(false);
+      hostInternal.authResolver.markKeyFailed = vi.fn().mockReturnValue(false);
+      hostInternal.authResolver.getNextProvider = vi.fn().mockReturnValue(null);
+
+      await hostInternal.handlePotentialError({
+        type: 'message_end',
+        message: { stopReason: 'error', errorMessage: 'Error 429: rate limit exceeded' },
+      });
+
+      // Existing resend path runs.
+      expect(reject1).not.toHaveBeenCalled();
+      expect(hostInternal.session.sendCustomMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ content: 'project-log' }),
+        expect.objectContaining({ deliverAs: 'followUp', triggerTurn: true })
+      );
+    });
+
+    it('handleSessionEvent flips currentTurnHasOutput on output events and resets on turn_start (#175)', () => {
+      const host = new AgentHost({
+        db: makeDbStub(),
+        agentId: 1,
+        registry: makeRegistryStub(),
+        llmConfig: makeLlmConfig(),
+      });
+
+      const hostInternal = host as unknown as {
+        currentTurnHasOutput: boolean;
+        handleSessionEvent: (event: unknown) => void;
+        handlePotentialError: ReturnType<typeof vi.fn>;
+      };
+
+      hostInternal.handlePotentialError = vi.fn().mockResolvedValue(undefined);
+
+      expect(hostInternal.currentTurnHasOutput).toBe(false);
+
+      hostInternal.handleSessionEvent({ type: 'turn_start' });
+      expect(hostInternal.currentTurnHasOutput).toBe(false);
+
+      hostInternal.handleSessionEvent({ type: 'message_start', message: {} });
+      expect(hostInternal.currentTurnHasOutput).toBe(true);
+
+      // turn_start resets the flag for the next turn
+      hostInternal.handleSessionEvent({ type: 'turn_start' });
+      expect(hostInternal.currentTurnHasOutput).toBe(false);
+
+      hostInternal.handleSessionEvent({
+        type: 'tool_execution_start',
+        toolCallId: 'x',
+        toolName: 'Edit',
+        args: {},
+      });
+      expect(hostInternal.currentTurnHasOutput).toBe(true);
+
+      hostInternal.handleSessionEvent({ type: 'turn_start' });
+      expect(hostInternal.currentTurnHasOutput).toBe(false);
+
+      hostInternal.handleSessionEvent({
+        type: 'message_update',
+        message: {},
+        assistantMessageEvent: {},
+      });
+      expect(hostInternal.currentTurnHasOutput).toBe(true);
+    });
   });
 
   describe('busy state', () => {

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -1142,6 +1142,11 @@ describe('AgentHost', () => {
         assistantMessageEvent: {},
       });
       expect(hostInternal.currentTurnHasOutput).toBe(true);
+
+      // agent_end also resets the flag at the run boundary, matching the
+      // documented lifecycle.
+      hostInternal.handleSessionEvent({ type: 'agent_end', messages: [] });
+      expect(hostInternal.currentTurnHasOutput).toBe(false);
     });
   });
 

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -740,6 +740,11 @@ export class AgentHost {
         this.oauthRefreshAttempted = false;
       }
       this.lastTurnErrored = false;
+      // Clear the per-turn output flag at the run boundary, matching its
+      // documented lifecycle. turn_start of the next run will reset it too,
+      // but resetting here keeps the flag from carrying state across runs in
+      // any code path that might inspect it between agent_end and turn_start.
+      this.currentTurnHasOutput = false;
 
       // If this turn completed a scheduled-task delivery for a role configured to reset,
       // truncate the session JSONL to a fresh header. The Narrator's durable memory lives in

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -292,6 +292,13 @@ export class AgentHost {
    *  re-tries the family flagship. */
   private oauthFallbackUsedFor: Set<LlmProvider> = new Set();
   private deliverySendCount = 0;
+  /** True once the model has emitted any output (message_start, message_update,
+   *  or tool_execution_start) during the current turn. Reset on turn_start and
+   *  agent_end. Read in handlePotentialError to decide whether resending the
+   *  in-flight delivery is safe — a contaminated turn may have already triggered
+   *  tool side effects (e.g. file edits), so re-feeding it to the model would
+   *  duplicate work. See GitHub issue #175. */
+  private currentTurnHasOutput = false;
   private compactionCount = 0;
   private compactionDepth = 0;
   private isPruning = false;
@@ -687,6 +694,18 @@ export class AgentHost {
       log.error('[AgentHost] handlePotentialError threw unexpectedly:', err);
     });
 
+    // Track whether the current turn has emitted any model output. Used by
+    // handlePotentialError to detect contaminated turns (issue #175).
+    if (event.type === 'turn_start') {
+      this.currentTurnHasOutput = false;
+    } else if (
+      event.type === 'message_start' ||
+      event.type === 'message_update' ||
+      event.type === 'tool_execution_start'
+    ) {
+      this.currentTurnHasOutput = true;
+    }
+
     // Track busy state from agent activity
     if (event.type === 'message_update' || event.type === 'tool_execution_start') {
       if (!this.busy) {
@@ -859,6 +878,34 @@ export class AgentHost {
         d.reject(
           new Error('Delivery dropped: message exceeded wire-size limits across all providers.')
         );
+      }
+      this.pendingDeliveries = [];
+    }
+
+    // Contaminated-turn check (issue #175). If the model emitted any output
+    // before the failure, the in-flight delivery may have already triggered
+    // tool side effects (e.g. file edits). Resending it would re-run those
+    // side effects. Reject all pending deliveries instead and let the caller
+    // surface a failure — for scheduled deliveries the next cron tick reads
+    // the unchanged `last_narrator_update_ts` and redoes the window from
+    // scratch, with the recipient's idempotency check handling whatever
+    // partial work landed on disk.
+    //
+    // Queued-but-not-yet-processed deliveries behind the in-flight one are
+    // also rejected for simplicity. The cost is that any caller awaiting them
+    // sees a transient error; for scheduled tasks this just means waiting for
+    // the next cron tick (~30 min).
+    if (this.currentTurnHasOutput && this.pendingDeliveries.length > 0) {
+      log.warn(
+        `[AgentHost] Turn already emitted output before failure; ` +
+          `rejecting ${this.pendingDeliveries.length} pending delivery(ies) ` +
+          `instead of resending to avoid duplicate side effects.`
+      );
+      const contaminationError = new Error(
+        `Delivery aborted: API error after model output (${errorMessage})`
+      );
+      for (const d of this.pendingDeliveries) {
+        d.reject(contaminationError);
       }
       this.pendingDeliveries = [];
     }

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -1796,15 +1796,34 @@ export class AgentHost {
 
   /**
    * Handle compaction tracking for pruning.
-   * Increments counter on compaction_end and triggers pruning when threshold is met.
+   * Increments counter only when a compaction actually produced a summary, so
+   * silent no-ops (early exits in the SDK's _runAutoCompaction) and failures
+   * don't burn the pruning-depth budget.
    */
-  private handleCompactionTracking(event: Pick<AgentSessionEvent, 'type'>): void {
+  private handleCompactionTracking(
+    event:
+      | Pick<AgentSessionEvent, 'type'>
+      | {
+          type: 'compaction_end';
+          result?: { firstKeptEntryId: string } | undefined;
+          aborted?: boolean;
+          errorMessage?: string;
+        }
+  ): void {
     if (this.compactionDepth <= 0) return;
 
-    // Track compaction counter
+    // Track compaction counter — only on real, completed compactions.
     if (event.type === 'compaction_end') {
-      this.compactionCount++;
-      this.writeCompactionCount(this.compactionCount);
+      const e = event as {
+        result?: unknown;
+        aborted?: boolean;
+        errorMessage?: string;
+      };
+      const succeeded = e.result != null && !e.aborted && !e.errorMessage;
+      if (succeeded) {
+        this.compactionCount++;
+        this.writeCompactionCount(this.compactionCount);
+      }
     }
 
     // Trigger pruning compaction on agent_end when counter reaches depth
@@ -2229,8 +2248,13 @@ export class AgentHost {
       if (this.session) {
         log.info('[AgentHost] Context overflow: compacting...');
         await this.session.compact();
-        // Synthesize compaction_end so the pruning counter stays accurate
-        this.handleCompactionTracking({ type: 'compaction_end' });
+        // Synthesize compaction_end so the pruning counter stays accurate.
+        // session.compact() throws on failure, so reaching here means success —
+        // pass a non-null `result` marker so handleCompactionTracking counts it.
+        this.handleCompactionTracking({
+          type: 'compaction_end',
+          result: { firstKeptEntryId: 'overflow-recovery' },
+        });
         log.info('[AgentHost] Context overflow: compaction complete');
       }
 

--- a/src/server/chat/history-capture.test.ts
+++ b/src/server/chat/history-capture.test.ts
@@ -96,24 +96,33 @@ describe('createHistoryCaptureSubscriber', () => {
     const cache = mockCache();
     const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
-    sub({ type: 'compaction_start' } as unknown as AgentSessionEvent);
+    sub({ type: 'compaction_start', reason: 'threshold' } as unknown as AgentSessionEvent);
 
     expect(cache.push).toHaveBeenCalledOnce();
     const msg = cache.messages[0] as { role: string; content: string };
     expect(msg.role).toBe('system');
-    expect(msg.content).toBe('Context compaction started');
+    expect(msg.content).toContain('Context compaction started');
+    expect(msg.content).toContain('reason=threshold');
   });
 
-  it('captures compaction_end as system message', () => {
+  it('captures compaction_end as system message with diagnostic detail', () => {
     const cache = mockCache();
     const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
-    sub({ type: 'compaction_end' } as unknown as AgentSessionEvent);
+    sub({
+      type: 'compaction_end',
+      reason: 'threshold',
+      result: undefined,
+      aborted: false,
+      willRetry: false,
+    } as unknown as AgentSessionEvent);
 
     expect(cache.push).toHaveBeenCalledOnce();
     const msg = cache.messages[0] as { role: string; content: string };
     expect(msg.role).toBe('system');
-    expect(msg.content).toBe('Context compacted');
+    expect(msg.content).toContain('Context compacted');
+    expect(msg.content).toContain('reason=threshold');
+    expect(msg.content).toContain('result=undefined (silent no-op)');
   });
 
   it('captures text + tool calls in the same turn', () => {

--- a/src/server/chat/history-capture.test.ts
+++ b/src/server/chat/history-capture.test.ts
@@ -92,7 +92,7 @@ describe('createHistoryCaptureSubscriber', () => {
     expect(cache.push).not.toHaveBeenCalled();
   });
 
-  it('captures compaction_start as system message', () => {
+  it('captures compaction_start as a clean system message', () => {
     const cache = mockCache();
     const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
@@ -101,11 +101,63 @@ describe('createHistoryCaptureSubscriber', () => {
     expect(cache.push).toHaveBeenCalledOnce();
     const msg = cache.messages[0] as { role: string; content: string };
     expect(msg.role).toBe('system');
-    expect(msg.content).toContain('Context compaction started');
-    expect(msg.content).toContain('reason=threshold');
+    expect(msg.content).toBe('Context compaction started');
   });
 
-  it('captures compaction_end as system message with diagnostic detail', () => {
+  it('captures successful compaction_end as a clean system message', () => {
+    const cache = mockCache();
+    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+
+    sub({
+      type: 'compaction_end',
+      reason: 'threshold',
+      result: { firstKeptEntryId: 'abc', tokensBefore: 100000 },
+      aborted: false,
+      willRetry: false,
+    } as unknown as AgentSessionEvent);
+
+    expect(cache.push).toHaveBeenCalledOnce();
+    const msg = cache.messages[0] as { role: string; content: string };
+    expect(msg.role).toBe('system');
+    expect(msg.content).toBe('Context compacted');
+  });
+
+  it('surfaces errorMessage on failed compaction_end', () => {
+    const cache = mockCache();
+    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+
+    sub({
+      type: 'compaction_end',
+      reason: 'threshold',
+      result: undefined,
+      aborted: false,
+      willRetry: false,
+      errorMessage: 'Auto-compaction failed: HTTP 400 max_tokens exceeds cap',
+    } as unknown as AgentSessionEvent);
+
+    const msg = cache.messages[0] as { role: string; content: string };
+    expect(msg.content).toBe(
+      'Context compaction failed: Auto-compaction failed: HTTP 400 max_tokens exceeds cap'
+    );
+  });
+
+  it('surfaces aborted compaction_end distinctly from failure', () => {
+    const cache = mockCache();
+    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+
+    sub({
+      type: 'compaction_end',
+      reason: 'manual',
+      result: undefined,
+      aborted: true,
+      willRetry: false,
+    } as unknown as AgentSessionEvent);
+
+    const msg = cache.messages[0] as { role: string; content: string };
+    expect(msg.content).toBe('Context compaction aborted');
+  });
+
+  it('surfaces silent no-op (result undefined, no flags) as a failure', () => {
     const cache = mockCache();
     const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
 
@@ -117,12 +169,9 @@ describe('createHistoryCaptureSubscriber', () => {
       willRetry: false,
     } as unknown as AgentSessionEvent);
 
-    expect(cache.push).toHaveBeenCalledOnce();
     const msg = cache.messages[0] as { role: string; content: string };
-    expect(msg.role).toBe('system');
-    expect(msg.content).toContain('Context compacted');
-    expect(msg.content).toContain('reason=threshold');
-    expect(msg.content).toContain('result=undefined (silent no-op)');
+    expect(msg.content).toContain('Context compaction failed');
+    expect(msg.content).toContain('silent no-op');
   });
 
   it('captures text + tool calls in the same turn', () => {

--- a/src/server/chat/history-capture.ts
+++ b/src/server/chat/history-capture.ts
@@ -147,7 +147,7 @@ export function createHistoryCaptureSubscriber(
         // end fire in the same millisecond (silent-failure no-ops do that).
         // React keys collide otherwise and timeline items get dropped.
         getChatCache().push({
-          id: `msg-compaction-start-${randomUUID().slice(0, 8)}`,
+          id: `msg-compaction-start-${randomUUID()}`,
           role: 'system',
           content: 'Context compaction started',
           timestamp: Date.now(),
@@ -170,7 +170,7 @@ export function createHistoryCaptureSubscriber(
           content = 'Context compacted';
         }
         getChatCache().push({
-          id: `msg-compaction-end-${randomUUID().slice(0, 8)}`,
+          id: `msg-compaction-end-${randomUUID()}`,
           role: 'system',
           content,
           timestamp: Date.now(),

--- a/src/server/chat/history-capture.ts
+++ b/src/server/chat/history-capture.ts
@@ -6,6 +6,7 @@
  * independently.
  */
 
+import { randomUUID } from 'node:crypto';
 import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 import type { ChatMessage, ChatTurnEvent } from '../../shared/index.js';
 import type { MessageHistory } from './history.js';
@@ -142,34 +143,36 @@ export function createHistoryCaptureSubscriber(
       }
 
       case 'compaction_start':
+        // Use randomUUID suffix to guarantee uniqueness even when start and
+        // end fire in the same millisecond (silent-failure no-ops do that).
+        // React keys collide otherwise and timeline items get dropped.
         getChatCache().push({
-          id: `msg-${Date.now()}`,
+          id: `msg-compaction-start-${randomUUID().slice(0, 8)}`,
           role: 'system',
-          content: `Context compaction started (reason=${event.reason})`,
+          content: 'Context compaction started',
           timestamp: Date.now(),
         });
         break;
 
       case 'compaction_end': {
-        // DIAGNOSTIC: surface why a compaction ended so silently-failing
-        // compactions (early-exit in _runAutoCompaction) are visible. The SDK
-        // emits compaction_end for both success and several no-op paths.
-        const parts: string[] = [`reason=${event.reason}`];
-        if (event.aborted) parts.push('aborted=true');
-        if (event.willRetry) parts.push('willRetry=true');
-        if (event.errorMessage) parts.push(`error=${event.errorMessage}`);
-        if (event.result) {
-          parts.push(
-            `tokensBefore=${event.result.tokensBefore}`,
-            `firstKeptEntryId=${event.result.firstKeptEntryId}`
-          );
-        } else if (!event.aborted && !event.errorMessage) {
-          parts.push('result=undefined (silent no-op)');
+        // Clean message on success; surface diagnostic detail only when
+        // something went wrong so silent failures don't pose as successes.
+        let content: string;
+        if (event.aborted) {
+          content = 'Context compaction aborted';
+        } else if (event.errorMessage) {
+          content = `Context compaction failed: ${event.errorMessage}`;
+        } else if (!event.result) {
+          // SDK fired compaction_end without a result and without flagging
+          // abort/error. Treat as a silent no-op and surface it.
+          content = 'Context compaction failed: no result (silent no-op)';
+        } else {
+          content = 'Context compacted';
         }
         getChatCache().push({
-          id: `msg-${Date.now()}`,
+          id: `msg-compaction-end-${randomUUID().slice(0, 8)}`,
           role: 'system',
-          content: `Context compacted [${parts.join(', ')}]`,
+          content,
           timestamp: Date.now(),
         });
         break;

--- a/src/server/chat/history-capture.ts
+++ b/src/server/chat/history-capture.ts
@@ -142,15 +142,38 @@ export function createHistoryCaptureSubscriber(
       }
 
       case 'compaction_start':
-      case 'compaction_end':
         getChatCache().push({
           id: `msg-${Date.now()}`,
           role: 'system',
-          content:
-            event.type === 'compaction_start' ? 'Context compaction started' : 'Context compacted',
+          content: `Context compaction started (reason=${event.reason})`,
           timestamp: Date.now(),
         });
         break;
+
+      case 'compaction_end': {
+        // DIAGNOSTIC: surface why a compaction ended so silently-failing
+        // compactions (early-exit in _runAutoCompaction) are visible. The SDK
+        // emits compaction_end for both success and several no-op paths.
+        const parts: string[] = [`reason=${event.reason}`];
+        if (event.aborted) parts.push('aborted=true');
+        if (event.willRetry) parts.push('willRetry=true');
+        if (event.errorMessage) parts.push(`error=${event.errorMessage}`);
+        if (event.result) {
+          parts.push(
+            `tokensBefore=${event.result.tokensBefore}`,
+            `firstKeptEntryId=${event.result.firstKeptEntryId}`
+          );
+        } else if (!event.aborted && !event.errorMessage) {
+          parts.push('result=undefined (silent no-op)');
+        }
+        getChatCache().push({
+          id: `msg-${Date.now()}`,
+          role: 'system',
+          content: `Context compacted [${parts.join(', ')}]`,
+          timestamp: Date.now(),
+        });
+        break;
+      }
     }
   };
 }

--- a/src/ui/stores/chat.ts
+++ b/src/ui/stores/chat.ts
@@ -35,7 +35,7 @@ export interface PerAgentState {
   isStreaming: boolean;
   isWaitingForResponse: boolean;
   provider: string | null;
-  compactionStatus: 'idle' | 'compacting' | 'compacted';
+  compactionStatus: 'idle' | 'compacting';
   compactionTimestamp: number | null;
 }
 
@@ -477,10 +477,14 @@ export const useChatStore = create<ChatState>()(
       },
 
       finishCompaction: (agentId: number) => {
+        // Transition straight back to idle on compaction_end. The persisted
+        // "Context compacted" system message from history-capture records the
+        // event in correct chronological position; the transient indicator
+        // only needs to exist during the in-flight window.
         set((state) => ({
           agentStates: updateAgentState(state.agentStates, agentId, () => ({
-            compactionStatus: 'compacted' as const,
-            compactionTimestamp: Date.now(),
+            compactionStatus: 'idle' as const,
+            compactionTimestamp: null,
             isStreaming: false,
           })),
         }));


### PR DESCRIPTION
Fixes #175.

## Summary

When the API errors mid-turn after the model has already emitted output (`message_start`, `message_update`, or `tool_execution_start`), the retry path was resending the in-flight delivery and re-running any tool side effects that committed before the connection dropped. The narrator's ad-hoc dedup ("section already exists, skipping") masked the duplicates but did not prevent them.

Track `currentTurnHasOutput` per turn (set on output events, reset on `turn_start`). On API failure with the flag set, reject all pending delivery promises with a transient error and skip the resend. The awaiter (e.g. `trackJobExecution`) marks the job failed, `last_narrator_update_ts` stays put, and the next cron tick redoes the window from scratch with the recipient's idempotency handling whatever partial work landed on disk.

## Trade-off

Transient timeouts that were previously retried invisibly (~1 s) now become visible job failures and wait up to one cron interval (~30 min) to redo. Acceptable given that the alternative is silently duplicating side effects.

## Out of scope

Prompt-retry has the same contamination risk but a different blast radius (duplicate user-visible response, not state corruption). Left for a follow-up.

Formalizing stable delivery IDs + recipient-side dedup is the deeper layer underneath. Deferred until another recipient (Conductor, Guide) actually duplicates side effects.

## Test plan

- [x] New unit test: `rejects pending deliveries instead of resending when turn already emitted output (#175)` — verifies deliveries are rejected with an "API error after model output" error and `sendCustomMessage` is not called.
- [x] Regression test: `still resends pending deliveries when no output was emitted yet (#175 regression)` — verifies the existing resend path still runs when no output had been emitted.
- [x] Event-handling test: `handleSessionEvent flips currentTurnHasOutput on output events and resets on turn_start (#175)` — verifies the flag is driven by `turn_start`, `message_start`, `message_update`, and `tool_execution_start`.
- [x] Full test suite: 1016/1016 passing.
- [x] `pnpm check` clean.
- [x] `pnpm typecheck` clean.
- [x] `pnpm build` succeeds.