### PR TITLE
fix(session-rotation): drop orphan tool_result entries to prevent post-rotation agent lockouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-05-12
+
 ### Fixed
 
 - Session rotation now drops orphan `tool_result` entries (and their dependent descendants) before writing the new JSONL. Pi-ai's compaction can place its cut between a `tool_use` and its matching `tool_result` — the compaction marker's `firstKeptEntryId` records the cut faithfully, but the kept range ends up with a `tool_result` whose `tool_use` was summarized away. Without this filter, the SDK reconstructs an API request containing an orphan `tool_result` block, and every LLM provider rejects it (Anthropic: `unexpected tool_use_id found in tool_result blocks`; Google: `function response turn must come immediately after a function call turn`), locking the agent out of every failover lane. The fix adds a post-rotation `filterOrphanToolResults` pass that scans assembled entries, identifies `toolResult`s whose `toolCallId` isn't emitted by any kept assistant `toolCall` block, and drops them together with any entries whose `parentId` chains back to a dropped entry (so a dangling assistant text response chained to the orphan goes too). Applied in both the anchored-rotation path (where the bug actually originates) and `forceBareBytesTailRotation` (defense in depth — `selectTailEntries` already aligns to user-turn boundaries and shouldn't produce orphans, but the filter is cheap). The root cause is upstream in pi-ai; this is a system2-side defense so future occurrences degrade gracefully (drop a few stranded entries + log a warning) instead of bricking the agent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Session rotation now drops orphan `tool_result` entries (and their dependent descendants) before writing the new JSONL. Pi-ai's compaction can place its cut between a `tool_use` and its matching `tool_result` — the compaction marker's `firstKeptEntryId` records the cut faithfully, but the kept range ends up with a `tool_result` whose `tool_use` was summarized away. Without this filter, the SDK reconstructs an API request containing an orphan `tool_result` block, and every LLM provider rejects it (Anthropic: `unexpected tool_use_id found in tool_result blocks`; Google: `function response turn must come immediately after a function call turn`), locking the agent out of every failover lane. The fix adds a post-rotation `filterOrphanToolResults` pass that scans assembled entries, identifies `toolResult`s whose `toolCallId` isn't emitted by any kept assistant `toolCall` block, and drops them together with any entries whose `parentId` chains back to a dropped entry (so a dangling assistant text response chained to the orphan goes too). Applied in both the anchored-rotation path (where the bug actually originates) and `forceBareBytesTailRotation` (defense in depth — `selectTailEntries` already aligns to user-turn boundaries and shouldn't produce orphans, but the filter is cheap). The root cause is upstream in pi-ai; this is a system2-side defense so future occurrences degrade gracefully (drop a few stranded entries + log a warning) instead of bricking the agent.
+
 ## [0.3.6] - 2026-05-12
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diegoscarabelli/system2",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "A multi-agent data platform for solo analysts",
   "author": "Diego Scarabelli",
   "license": "AGPL-3.0-only",

--- a/src/server/agents/session-rotation.test.ts
+++ b/src/server/agents/session-rotation.test.ts
@@ -55,6 +55,40 @@ function compactionEntry(id: string, parentId: string, firstKeptEntryId: string)
   };
 }
 
+/** Assistant message carrying one `toolCall` block (pi-ai's JSONL serialization
+ *  of an Anthropic `tool_use`). The agent emits these, then the runtime
+ *  responds with a matching `toolResult` entry. */
+function assistantToolCallEntry(id: string, parentId: string | null, toolCallId: string): object {
+  return {
+    type: 'message',
+    id,
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: 'assistant',
+      content: [{ type: 'toolCall', id: toolCallId, name: 'bash', input: { command: 'echo hi' } }],
+      stopReason: 'toolUse',
+    },
+  };
+}
+
+/** ToolResult message responding to an `assistantToolCallEntry`. */
+function toolResultEntry(id: string, parentId: string, toolCallId: string): object {
+  return {
+    type: 'message',
+    id,
+    parentId,
+    timestamp: new Date().toISOString(),
+    message: {
+      role: 'toolResult',
+      toolCallId,
+      toolName: 'bash',
+      content: [{ type: 'text', text: 'hi' }],
+      isError: false,
+    },
+  };
+}
+
 let tmpDir: string;
 
 beforeEach(() => {
@@ -652,6 +686,156 @@ describe('rotateSessionIfNeeded — archive pruning', () => {
     const remainingPaths = archives.map((f) => join(tmpDir, f)).sort();
     const expectedKept = archivedPaths.slice(2).sort();
     expect(remainingPaths).toEqual(expectedKept);
+  });
+
+  it('anchored rotation drops orphan toolResult whose toolCall was pruned by upstream compaction', () => {
+    // Repro of the conductor-stuck bug (2026-05-12): pi-ai's compaction
+    // selected a firstKeptEntryId that placed the cut between a tool_use
+    // (pruned, summarized away) and its corresponding tool_result (kept).
+    // Without the orphan filter, the rotated JSONL contained a toolResult
+    // whose toolCallId had no matching toolCall, and every LLM provider
+    // rejected the next API call (Anthropic 400 unexpected tool_use_id,
+    // Google "function response must come after function call").
+    //
+    // Reproduction:
+    //   header → compaction(firstKept=tr1) → tr1 (orphan: toolCall was in
+    //     a pre-compaction entry that got summarized) → asst-text (parent=tr1)
+    //     → user → ...
+    // After rotation, both tr1 and asst-text must be dropped; the rest of
+    // the conversation continues from the user turn.
+    const file = join(tmpDir, 'session.jsonl');
+    const entries: object[] = [
+      sessionHeader(),
+      // Pre-compaction work that was summarized (not in file — fine, just
+      // illustrative of where the orphan tool_use was).
+      compactionEntry('c1', 'header-parent', 'tr1-orphan'),
+      // Orphan: toolResult whose toolCallId is NOT emitted by any kept
+      // assistant toolCall block.
+      toolResultEntry('tr1-orphan', 'pruned-toolcall', 'toolu_PRUNED_BY_COMPACTION'),
+      // Dependent: assistant text response chained to the orphan toolResult.
+      // Drops too — its parent reference would dangle, and the SDK would
+      // surface it as the leading message in the API request which Anthropic
+      // would reject (first message must be `user`).
+      messageEntry('asst-text-dep', 'tr1-orphan', 'assistant'),
+      // Resume point: a valid user turn whose parent is the compaction marker
+      // (NOT the orphan or its dependent). This is how a real session looks
+      // after the conductor receives a new user message post-compaction —
+      // parent points back to the compaction anchor, not into the stranded
+      // pre-compaction branch. Without this break in the parent chain, the
+      // filter would (correctly) drop everything downstream of the orphan.
+      messageEntry('u1', 'c1', 'user'),
+      assistantToolCallEntry('a1', 'u1', 'toolu_GOOD'),
+      toolResultEntry('tr-good', 'a1', 'toolu_GOOD'),
+    ];
+    writeJsonl(file, entries);
+
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+    const rotated = rotateSessionIfNeeded(tmpDir, '/tmp', 0);
+    expect(rotated).toBe(true);
+
+    // Filter fired and logged a warning.
+    const warnMessages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(warnMessages.some((m) => m.includes('orphan tool_result'))).toBe(true);
+    warnSpy.mockRestore();
+
+    // Inspect the rotated file: orphan toolResult and its dependent must be
+    // gone; the valid tool_use/tool_result pair must remain.
+    const newFile = readdirSync(tmpDir).find(
+      (f) => f.endsWith('.jsonl') && !f.endsWith('.archived')
+    );
+    expect(newFile).toBeDefined();
+    const rotatedLines = readFileSync(join(tmpDir, newFile as string), 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l));
+    const ids = rotatedLines.map((e) => e.id);
+    expect(ids).not.toContain('tr1-orphan');
+    expect(ids).not.toContain('asst-text-dep');
+    expect(ids).toContain('u1');
+    expect(ids).toContain('a1');
+    expect(ids).toContain('tr-good');
+  });
+
+  it('anchored rotation: no-op for sessions with matching tool_use/tool_result pairs', () => {
+    // Regression guard: the filter must NOT drop entries when every
+    // toolResult has a matching toolCall in the kept range. Tests the
+    // happy path (most rotations) is unaffected by the filter.
+    const file = join(tmpDir, 'session.jsonl');
+    const entries: object[] = [
+      sessionHeader(),
+      compactionEntry('c1', 'header-parent', 'u1'),
+      messageEntry('u1', 'pre-comp-parent', 'user'),
+      assistantToolCallEntry('a1', 'u1', 'toolu_A'),
+      toolResultEntry('tr1', 'a1', 'toolu_A'),
+      assistantToolCallEntry('a2', 'tr1', 'toolu_B'),
+      toolResultEntry('tr2', 'a2', 'toolu_B'),
+    ];
+    writeJsonl(file, entries);
+
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+    const rotated = rotateSessionIfNeeded(tmpDir, '/tmp', 0);
+    expect(rotated).toBe(true);
+    // No orphan warning when every pair is intact.
+    const warnMessages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(warnMessages.some((m) => m.includes('orphan tool_result'))).toBe(false);
+    warnSpy.mockRestore();
+
+    const newFile = readdirSync(tmpDir).find(
+      (f) => f.endsWith('.jsonl') && !f.endsWith('.archived')
+    );
+    const rotatedLines = readFileSync(join(tmpDir, newFile as string), 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l));
+    const ids = rotatedLines.map((e) => e.id);
+    // All four user/assistant/toolResult entries preserved.
+    expect(ids).toEqual(expect.arrayContaining(['u1', 'a1', 'tr1', 'a2', 'tr2']));
+  });
+
+  it('anchored rotation drops a chain of multiple dependents on a single orphan', () => {
+    // Generalization of the conductor case: the orphan toolResult was followed
+    // by *several* dependent entries (assistant text → user → assistant ...).
+    // The transitive drop loop must reach all of them so no descendant of the
+    // orphan survives.
+    const file = join(tmpDir, 'session.jsonl');
+    const entries: object[] = [
+      sessionHeader(),
+      compactionEntry('c1', 'header-parent', 'tr-orphan'),
+      toolResultEntry('tr-orphan', 'pruned-toolcall', 'toolu_PRUNED'),
+      messageEntry('asst-1', 'tr-orphan', 'assistant'),
+      messageEntry('user-1', 'asst-1', 'user'),
+      messageEntry('asst-2', 'user-1', 'assistant'),
+      // A clean restart point: a user message whose parent chain DOES NOT
+      // touch the orphan. This is the survivor.
+      messageEntry('user-clean', 'asst-2', 'user'),
+    ];
+    writeJsonl(file, entries);
+
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+    const rotated = rotateSessionIfNeeded(tmpDir, '/tmp', 0);
+    expect(rotated).toBe(true);
+    warnSpy.mockRestore();
+
+    const newFile = readdirSync(tmpDir).find(
+      (f) => f.endsWith('.jsonl') && !f.endsWith('.archived')
+    );
+    const rotatedLines = readFileSync(join(tmpDir, newFile as string), 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l));
+    const ids = rotatedLines.map((e) => e.id);
+    // Orphan AND all four downstream dependents must be dropped.
+    expect(ids).not.toContain('tr-orphan');
+    expect(ids).not.toContain('asst-1');
+    expect(ids).not.toContain('user-1');
+    expect(ids).not.toContain('asst-2');
+    expect(ids).not.toContain('user-clean');
+    // user-clean was rooted (transitively) on the orphan via asst-2/user-1/
+    // asst-1/tr-orphan — so it drops too. This is the correct outcome: the
+    // chain is poisoned at its root, so the safest resume point is the next
+    // fresh user turn (none in this fixture, so the kept range collapses to
+    // header + compaction marker, and the conductor cold-starts on the
+    // compaction summary alone).
   });
 
   it('bare-bytes-tail rotation also prunes archives', () => {

--- a/src/server/agents/session-rotation.test.ts
+++ b/src/server/agents/session-rotation.test.ts
@@ -914,6 +914,57 @@ describe('rotateSessionIfNeeded — archive pruning', () => {
     expect(ids).toContain('survivor-user');
   });
 
+  it('anchored rotation drops a malformed toolResult missing toolCallId', () => {
+    // Defensive coverage: a toolResult with no `toolCallId` (or a non-string
+    // one) cannot be matched to any toolCall and would fail provider
+    // validation on reconstruction just like a normal orphan. The filter
+    // treats both cases identically. This isn't a failure mode observed in
+    // production — pi-ai's serialization always emits a string toolCallId —
+    // but the filter's mission is to keep the rotated JSONL self-consistent
+    // for the SDK regardless of source corruption.
+    const file = join(tmpDir, 'session.jsonl');
+    const entries: object[] = [
+      sessionHeader(),
+      messageEntry('u1', 'pre-comp-parent', 'user'),
+      assistantToolCallEntry('a1', 'u1', 'toolu_A'),
+      toolResultEntry('tr1', 'a1', 'toolu_A'),
+      // Malformed toolResult: `toolCallId` omitted entirely.
+      {
+        type: 'message',
+        id: 'tr-malformed',
+        parentId: 'a1',
+        timestamp: new Date().toISOString(),
+        message: { role: 'toolResult' },
+      },
+      compactionEntry('c1', 'tr-malformed', 'u1'),
+      messageEntry('survivor', 'c1', 'user'),
+    ];
+    writeJsonl(file, entries);
+
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+    const rotated = rotateSessionIfNeeded(tmpDir, '/tmp', 0);
+    expect(rotated).toBe(true);
+    // Filter fired and warn-logged because tr-malformed was dropped.
+    const warnMessages = warnSpy.mock.calls.map((c) => String(c[0]));
+    expect(warnMessages.some((m) => m.includes('orphan tool_result'))).toBe(true);
+    warnSpy.mockRestore();
+
+    const newFile = readdirSync(tmpDir).find(
+      (f) => f.endsWith('.jsonl') && !f.endsWith('.archived')
+    );
+    const rotatedLines = readFileSync(join(tmpDir, newFile as string), 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l));
+    const ids = rotatedLines.map((e) => e.id);
+    // Malformed entry dropped; valid pair and survivor preserved.
+    expect(ids).not.toContain('tr-malformed');
+    expect(ids).toContain('u1');
+    expect(ids).toContain('a1');
+    expect(ids).toContain('tr1');
+    expect(ids).toContain('survivor');
+  });
+
   it('bare-bytes-tail rotation also prunes archives', () => {
     // Pre-seed 6 stale archives with old mtimes so the prune step has work to do.
     for (let i = 0; i < 6; i++) {

--- a/src/server/agents/session-rotation.test.ts
+++ b/src/server/agents/session-rotation.test.ts
@@ -756,26 +756,34 @@ describe('rotateSessionIfNeeded — archive pruning', () => {
     // rejected the next API call (Anthropic 400 unexpected tool_use_id,
     // Google "function response must come after function call").
     //
-    // Reproduction:
-    //   header → compaction(firstKept=tr1) → tr1 (orphan: toolCall was in
-    //     a pre-compaction entry that got summarized) → asst-text (parent=tr1)
-    //     → user → ...
-    // After rotation, both tr1 and asst-text must be dropped; the rest of
-    // the conversation continues from the user turn.
+    // Realistic session layout (matches how rotateSessionIfNeeded interprets
+    // the file): the compaction marker sits *after* the kept pre-compaction
+    // tail it anchors, and `firstKeptEntryId` points back into that tail.
+    //
+    //   header
+    //   tr1-orphan         <- firstKeptEntryId (orphan: matching toolCall
+    //                         lived in a pre-compaction entry that was
+    //                         summarized away)
+    //   asst-text-dep      <- dependent on the orphan
+    //   compaction(parent=asst-text-dep, firstKept=tr1-orphan)
+    //   u1 (post-compaction user turn, parented on the compaction anchor)
+    //   a1 / tr-good       <- valid tool_use / tool_result pair
+    //
+    // After rotation, the orphan and its dependent must be dropped; the
+    // post-compaction conversation continues from u1.
     const file = join(tmpDir, 'session.jsonl');
     const entries: object[] = [
       sessionHeader(),
-      // Pre-compaction work that was summarized (not in file — fine, just
-      // illustrative of where the orphan tool_use was).
-      compactionEntry('c1', 'header-parent', 'tr1-orphan'),
-      // Orphan: toolResult whose toolCallId is NOT emitted by any kept
-      // assistant toolCall block.
+      // firstKeptEntryId target — orphan toolResult at the start of the
+      // pre-compaction kept tail.
       toolResultEntry('tr1-orphan', 'pruned-toolcall', 'toolu_PRUNED_BY_COMPACTION'),
       // Dependent: assistant text response chained to the orphan toolResult.
       // Drops too — its parent reference would dangle, and the SDK would
       // surface it as the leading message in the API request which Anthropic
       // would reject (first message must be `user`).
       messageEntry('asst-text-dep', 'tr1-orphan', 'assistant'),
+      // Compaction marker closes the pre-compaction tail.
+      compactionEntry('c1', 'asst-text-dep', 'tr1-orphan'),
       // Resume point: a valid user turn whose parent is the compaction marker
       // (NOT the orphan or its dependent). This is how a real session looks
       // after the conductor receives a new user message post-compaction —
@@ -819,14 +827,17 @@ describe('rotateSessionIfNeeded — archive pruning', () => {
     // Regression guard: the filter must NOT drop entries when every
     // toolResult has a matching toolCall in the kept range. Tests the
     // happy path (most rotations) is unaffected by the filter.
+    // Realistic layout: firstKeptEntryId points back into the pre-compaction
+    // tail (u1, a1, tr1) and the compaction marker sits at the end of it.
+    // Post-compaction continues with another valid pair (a2, tr2).
     const file = join(tmpDir, 'session.jsonl');
     const entries: object[] = [
       sessionHeader(),
-      compactionEntry('c1', 'header-parent', 'u1'),
       messageEntry('u1', 'pre-comp-parent', 'user'),
       assistantToolCallEntry('a1', 'u1', 'toolu_A'),
       toolResultEntry('tr1', 'a1', 'toolu_A'),
-      assistantToolCallEntry('a2', 'tr1', 'toolu_B'),
+      compactionEntry('c1', 'tr1', 'u1'),
+      assistantToolCallEntry('a2', 'c1', 'toolu_B'),
       toolResultEntry('tr2', 'a2', 'toolu_B'),
     ];
     writeJsonl(file, entries);
@@ -853,20 +864,30 @@ describe('rotateSessionIfNeeded — archive pruning', () => {
 
   it('anchored rotation drops a chain of multiple dependents on a single orphan', () => {
     // Generalization of the conductor case: the orphan toolResult was followed
-    // by *several* dependent entries (assistant text → user → assistant ...).
-    // The transitive drop loop must reach all of them so no descendant of the
+    // by *several* dependent entries (assistant → user → assistant → user).
+    // The transitive drop must reach all of them so no descendant of the
     // orphan survives.
+    //
+    // Realistic layout — kept pre-compaction tail (rooted on the orphan), then
+    // the compaction marker, then a post-compaction user turn parented back
+    // on the compaction anchor (NOT chained through the orphan) which is the
+    // safe resume point and the only entry expected to survive the filter.
     const file = join(tmpDir, 'session.jsonl');
     const entries: object[] = [
       sessionHeader(),
-      compactionEntry('c1', 'header-parent', 'tr-orphan'),
+      // firstKeptEntryId target.
       toolResultEntry('tr-orphan', 'pruned-toolcall', 'toolu_PRUNED'),
-      messageEntry('asst-1', 'tr-orphan', 'assistant'),
-      messageEntry('user-1', 'asst-1', 'user'),
-      messageEntry('asst-2', 'user-1', 'assistant'),
-      // A clean restart point: a user message whose parent chain DOES NOT
-      // touch the orphan. This is the survivor.
-      messageEntry('user-clean', 'asst-2', 'user'),
+      // Four-deep transitive chain — every entry rooted on tr-orphan.
+      messageEntry('desc-1-asst', 'tr-orphan', 'assistant'),
+      messageEntry('desc-2-user', 'desc-1-asst', 'user'),
+      messageEntry('desc-3-asst', 'desc-2-user', 'assistant'),
+      messageEntry('desc-4-user', 'desc-3-asst', 'user'),
+      // Compaction marker at the end of the pre-compaction tail.
+      compactionEntry('c1', 'desc-4-user', 'tr-orphan'),
+      // Survivor: a fresh post-compaction user turn parented on the compaction
+      // anchor. Its parent chain does NOT touch the orphan, so it is the
+      // expected safe resume point.
+      messageEntry('survivor-user', 'c1', 'user'),
     ];
     writeJsonl(file, entries);
 
@@ -883,18 +904,14 @@ describe('rotateSessionIfNeeded — archive pruning', () => {
       .filter((l) => l.trim())
       .map((l) => JSON.parse(l));
     const ids = rotatedLines.map((e) => e.id);
-    // Orphan AND all four downstream dependents must be dropped.
+    // Orphan and all four descendants drop.
     expect(ids).not.toContain('tr-orphan');
-    expect(ids).not.toContain('asst-1');
-    expect(ids).not.toContain('user-1');
-    expect(ids).not.toContain('asst-2');
-    expect(ids).not.toContain('user-clean');
-    // user-clean was rooted (transitively) on the orphan via asst-2/user-1/
-    // asst-1/tr-orphan — so it drops too. This is the correct outcome: the
-    // chain is poisoned at its root, so the safest resume point is the next
-    // fresh user turn (none in this fixture, so the kept range collapses to
-    // header + compaction marker, and the conductor cold-starts on the
-    // compaction summary alone).
+    expect(ids).not.toContain('desc-1-asst');
+    expect(ids).not.toContain('desc-2-user');
+    expect(ids).not.toContain('desc-3-asst');
+    expect(ids).not.toContain('desc-4-user');
+    // Post-compaction survivor preserved.
+    expect(ids).toContain('survivor-user');
   });
 
   it('bare-bytes-tail rotation also prunes archives', () => {

--- a/src/server/agents/session-rotation.test.ts
+++ b/src/server/agents/session-rotation.test.ts
@@ -386,6 +386,65 @@ describe('rotateSessionIfNeeded', () => {
       warnSpy.mockRestore();
     });
 
+    it('bare-bytes-tail rotation drops orphan toolResult that slipped past the user-turn cut', () => {
+      // Defense-in-depth coverage for filterOrphanToolResults's wire-up into
+      // the bare-bytes-tail path. `selectTailEntries` aligns to user-turn
+      // boundaries so it SHOULDN'T produce orphans, but the filter is wired
+      // in as belt-and-braces against a future bug there. This test
+      // synthesizes the failure mode the filter is supposed to guard against:
+      // a kept tail that starts at a user turn but contains an orphan
+      // tool_result (a hypothetical regression in selectTailEntries that
+      // forgot to enforce tool_use/tool_result pairing within the kept
+      // window). If the filter is correctly wired, the orphan and any
+      // descendants are dropped.
+      const file = join(tmpDir, 'session.jsonl');
+      const entries: object[] = [
+        sessionHeader(),
+        // User turn — this is where selectTailEntries' cut would land.
+        messageEntry('u1', null, 'user'),
+        // Orphan: toolResult whose toolCallId is NOT emitted by any kept
+        // assistant in the file. The matching toolCall existed in some
+        // hypothetical pre-cut entry that didn't survive `selectTailEntries`.
+        toolResultEntry('tr-orphan', 'u1', 'toolu_NOT_IN_FILE'),
+        // Dependent: an assistant text response chained to the orphan.
+        messageEntry('asst-dep', 'tr-orphan', 'assistant'),
+        // Clean continuation: a user turn whose parent does NOT chain through
+        // the orphan (parented on u1 directly), then a valid tool_use /
+        // tool_result pair. These survive the filter.
+        messageEntry('u2', 'u1', 'user'),
+        assistantToolCallEntry('a-good', 'u2', 'toolu_GOOD'),
+        toolResultEntry('tr-good', 'a-good', 'toolu_GOOD'),
+      ];
+      writeJsonl(file, entries);
+
+      const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
+      const rotated = rotateSessionIfNeeded(tmpDir, '/tmp', 0);
+      expect(rotated).toBe(true);
+
+      // Filter fired with the orphan-warn message.
+      const warnMessages = warnSpy.mock.calls.map((c) => String(c[0]));
+      expect(warnMessages.some((m) => m.includes('orphan tool_result'))).toBe(true);
+      warnSpy.mockRestore();
+
+      const newFile = findMostRecentSession(tmpDir);
+      const rotatedLines = readFileSync(newFile as string, 'utf-8')
+        .split('\n')
+        .filter(Boolean)
+        .map((l) => JSON.parse(l));
+      const ids = rotatedLines.map((e) => e.id);
+
+      // Orphan and its dependent dropped.
+      expect(ids).not.toContain('tr-orphan');
+      expect(ids).not.toContain('asst-dep');
+      // Clean continuation preserved: u1 is the cut anchor; u2 and the valid
+      // pair below it survive because their parent chain (u2 -> u1) doesn't
+      // pass through the orphan.
+      expect(ids).toContain('u1');
+      expect(ids).toContain('u2');
+      expect(ids).toContain('a-good');
+      expect(ids).toContain('tr-good');
+    });
+
     it('returns header-only when the newest entry alone exceeds the tail cap', () => {
       // Single entry larger than HARD_FALLBACK_TAIL_BYTES (1 MB). Strict cap means
       // we drop it rather than writing a rotated file still > 1 MB.

--- a/src/server/agents/session-rotation.ts
+++ b/src/server/agents/session-rotation.ts
@@ -189,6 +189,94 @@ function selectTailEntries(entries: SessionEntry[], tailBytes: number): SessionE
 }
 
 /**
+ * Drop orphan `toolResult` entries (and any descendants rooted on them) from a
+ * rotated entry list. An orphan is a `toolResult` whose `toolCallId` is not
+ * emitted by any kept assistant message's `toolCall` content block — meaning
+ * the matching `tool_use` was pruned by an upstream compaction or rotation
+ * step, but the `toolResult` slipped through.
+ *
+ * Without this filter, the SDK reconstructs an API request with a
+ * `tool_result` block referencing a `tool_use_id` that has no corresponding
+ * `tool_use` block, and the LLM provider rejects the request (Anthropic:
+ * `unexpected tool_use_id found in tool_result blocks`; Google:
+ * `function response turn must come immediately after a function call turn`).
+ *
+ * The root cause is upstream — pi-ai's compaction can place its cut between a
+ * `tool_use` and its `tool_result`, and the compaction marker's
+ * `firstKeptEntryId` records the cut without ensuring the kept range is
+ * internally consistent. We can't change that from here; what we can do is
+ * audit the post-rotation entry list and drop the inconsistency before the
+ * file is written.
+ *
+ * Why we also drop descendants: an assistant message whose `parentId` chains
+ * to a dropped `toolResult` was generated in response to that result. If we
+ * keep it, its `parentId` becomes a dangling reference; even if the SDK
+ * tolerates that, the assistant message often ends up as the first message in
+ * the constructed API request, which Anthropic rejects (first message must be
+ * `user`). Drop the whole stranded sub-chain so the next valid `user`-turn
+ * boundary is the resume point.
+ *
+ * Returns the filtered list. Logs at warn level when any entries are dropped
+ * so operators can correlate with upstream compaction events.
+ */
+export function filterOrphanToolResults(entries: SessionEntry[]): SessionEntry[] {
+  if (entries.length === 0) return entries;
+
+  // Step 1: collect all `toolCall.id` values emitted by assistant messages in
+  // the kept range. These are the valid targets for `toolResult.toolCallId`.
+  const emittedToolCallIds = new Set<string>();
+  for (const e of entries) {
+    if (e.type !== 'message') continue;
+    const msg = (e as SessionEntry & { message?: unknown }).message as
+      | { role?: string; content?: Array<{ type?: string; id?: string }> }
+      | undefined;
+    if (!msg || msg.role !== 'assistant' || !Array.isArray(msg.content)) continue;
+    for (const block of msg.content) {
+      if (block?.type === 'toolCall' && typeof block.id === 'string') {
+        emittedToolCallIds.add(block.id);
+      }
+    }
+  }
+
+  // Step 2: identify orphan `toolResult` entry ids.
+  const droppedIds = new Set<string>();
+  for (const e of entries) {
+    if (e.type !== 'message' || !e.id) continue;
+    const msg = (e as SessionEntry & { message?: unknown }).message as
+      | { role?: string; toolCallId?: string }
+      | undefined;
+    if (msg?.role === 'toolResult' && typeof msg.toolCallId === 'string') {
+      if (!emittedToolCallIds.has(msg.toolCallId)) {
+        droppedIds.add(e.id);
+      }
+    }
+  }
+
+  if (droppedIds.size === 0) return entries;
+
+  // Step 3: transitively mark any entry whose `parentId` chains to a dropped
+  // entry. Bounded loop — at most `entries.length` iterations needed since
+  // each pass adds at least one id until stable.
+  for (let pass = 0; pass < entries.length; pass++) {
+    let changed = false;
+    for (const e of entries) {
+      if (!e.id || droppedIds.has(e.id)) continue;
+      if (e.parentId && droppedIds.has(e.parentId)) {
+        droppedIds.add(e.id);
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+
+  log.warn(
+    `[SessionRotation] Dropped ${droppedIds.size} orphan tool_result/dependent entries from rotated session (likely upstream compaction cut between a tool_use and its tool_result; without this filter the SDK would construct an invalid API request).`
+  );
+
+  return entries.filter((e) => !e.id || !droppedIds.has(e.id));
+}
+
+/**
  * Write rotated entries to a new JSONL and archive the old file.
  */
 export function writeRotatedFile(
@@ -277,7 +365,12 @@ function forceBareBytesTailRotation(
   reason: string
 ): true {
   const tailEntries = selectTailEntries(entries, HARD_FALLBACK_TAIL_BYTES);
-  const newEntries: SessionEntry[] = [createSessionHeader(cwd), ...tailEntries];
+  // Defense-in-depth: selectTailEntries already cuts on a user-turn boundary
+  // so the tail SHOULD be self-consistent, but the filter is cheap and the
+  // alternative (an orphan-tool_result slips through and locks the conductor
+  // out of every LLM provider) is unrecoverable without manual JSONL surgery.
+  const filteredTail = filterOrphanToolResults(tailEntries);
+  const newEntries: SessionEntry[] = [createSessionHeader(cwd), ...filteredTail];
   const newFilename = writeRotatedFile(sessionDir, currentFile, newEntries);
   log.info(
     `[SessionRotation] Created new session file: ${newFilename} with ${newEntries.length} entries (bare-bytes-tail fallback: ${reason})`
@@ -433,7 +526,17 @@ export function rotateSessionIfNeeded(
   // 2. Entries from firstKeptEntryId up to (not including) compaction entry
   // 3. The compaction entry
   // 4. All entries after the compaction entry
-  const newEntries: SessionEntry[] = [];
+  //
+  // Pi-ai's compaction selects a `firstKeptEntryId` that defines the cut
+  // between the summary and the kept tail, but the implementation can place
+  // that cut between a `tool_use` and its corresponding `tool_result` —
+  // leaving the result orphaned in the kept range. The filter below scans
+  // the assembled list for orphan `toolResult` entries and drops them (plus
+  // any descendants chaining back to them) before the file is written.
+  // Without this, the SDK reconstructs an API request the LLM provider
+  // rejects on the very first turn after rotation, locking the agent out
+  // until manual JSONL surgery.
+  let newEntries: SessionEntry[] = [];
 
   // Add new header
   newEntries.push(createSessionHeader(cwd));
@@ -450,6 +553,9 @@ export function rotateSessionIfNeeded(
   for (let i = compactionIndex + 1; i < entries.length; i++) {
     newEntries.push(entries[i]);
   }
+
+  // Drop orphan tool_result/dependents (see comment above the assignment).
+  newEntries = filterOrphanToolResults(newEntries);
 
   // Write new file (and archive old)
   const newFilename = writeRotatedFile(sessionDir, currentFile, newEntries);

--- a/src/server/agents/session-rotation.ts
+++ b/src/server/agents/session-rotation.ts
@@ -216,11 +216,18 @@ function selectTailEntries(entries: SessionEntry[], tailBytes: number): SessionE
  * `user`). Drop the whole stranded sub-chain so the next valid `user`-turn
  * boundary is the resume point.
  *
- * Returns the filtered list. Logs at warn level when any entries are dropped
- * so operators can correlate with upstream compaction events.
+ * Returns `{ filtered, droppedIds }`. The helper does NOT log — callers
+ * own the warn emission so they can include file-level context (session
+ * basename, rotation path tag) that the helper has no access to.
+ * `droppedIds` is the list of every entry id removed (orphans plus their
+ * transitive descendants) so callers can include sample ids in the log
+ * for operator triage.
  */
-export function filterOrphanToolResults(entries: SessionEntry[]): SessionEntry[] {
-  if (entries.length === 0) return entries;
+export function filterOrphanToolResults(entries: SessionEntry[]): {
+  filtered: SessionEntry[];
+  droppedIds: string[];
+} {
+  if (entries.length === 0) return { filtered: entries, droppedIds: [] };
 
   // Step 1: collect all `toolCall.id` values emitted by assistant messages in
   // the kept range. These are the valid targets for `toolResult.toolCallId`.
@@ -252,7 +259,7 @@ export function filterOrphanToolResults(entries: SessionEntry[]): SessionEntry[]
     }
   }
 
-  if (droppedIds.size === 0) return entries;
+  if (droppedIds.size === 0) return { filtered: entries, droppedIds: [] };
 
   // Step 3: transitively mark every descendant of a dropped entry. Build a
   // `parentId → child ids` index and an id → entry lookup in one pass, then
@@ -293,11 +300,29 @@ export function filterOrphanToolResults(entries: SessionEntry[]): SessionEntry[]
     }
   }
 
-  log.warn(
-    `[SessionRotation] Dropped ${droppedIds.size} orphan tool_result/dependent entries from rotated session (likely upstream compaction cut between a tool_use and its tool_result; without this filter the SDK would construct an invalid API request).`
-  );
+  return {
+    filtered: entries.filter((e) => !e.id || !droppedIds.has(e.id)),
+    droppedIds: Array.from(droppedIds),
+  };
+}
 
-  return entries.filter((e) => !e.id || !droppedIds.has(e.id));
+/**
+ * Emit the orphan-filter warn log with file-level context. Centralized so the
+ * two rotation paths (anchored, bare-bytes-tail) share the same format. Caller
+ * supplies a short path tag identifying which rotation path triggered the
+ * filter, so operators can correlate the warning with the right code path.
+ */
+function logOrphanFilterDrop(
+  currentFile: string,
+  pathTag: 'anchored-rotation' | 'bare-bytes-tail',
+  droppedIds: string[]
+): void {
+  if (droppedIds.length === 0) return;
+  const sample = droppedIds.slice(0, 5).join(', ');
+  const overflow = droppedIds.length > 5 ? `, ... (${droppedIds.length - 5} more)` : '';
+  log.warn(
+    `[SessionRotation] Filter dropped ${droppedIds.length} orphan tool_result/dependent entries from ${basename(currentFile)} (${pathTag}; sample ids: ${sample}${overflow}). Upstream compaction or tail-selection cut between a tool_use and its tool_result; without this filter the SDK would construct an invalid API request.`
+  );
 }
 
 /**
@@ -393,7 +418,9 @@ function forceBareBytesTailRotation(
   // so the tail SHOULD be self-consistent, but the filter is cheap and the
   // alternative (an orphan-tool_result slips through and locks the conductor
   // out of every LLM provider) is unrecoverable without manual JSONL surgery.
-  const filteredTail = filterOrphanToolResults(tailEntries);
+  const { filtered: filteredTail, droppedIds: tailDroppedIds } =
+    filterOrphanToolResults(tailEntries);
+  logOrphanFilterDrop(currentFile, 'bare-bytes-tail', tailDroppedIds);
   const newEntries: SessionEntry[] = [createSessionHeader(cwd), ...filteredTail];
   const newFilename = writeRotatedFile(sessionDir, currentFile, newEntries);
   log.info(
@@ -579,7 +606,10 @@ export function rotateSessionIfNeeded(
   }
 
   // Drop orphan tool_result/dependents (see comment above the assignment).
-  newEntries = filterOrphanToolResults(newEntries);
+  const { filtered: filteredEntries, droppedIds: anchoredDroppedIds } =
+    filterOrphanToolResults(newEntries);
+  logOrphanFilterDrop(currentFile, 'anchored-rotation', anchoredDroppedIds);
+  newEntries = filteredEntries;
 
   // Write new file (and archive old)
   const newFilename = writeRotatedFile(sessionDir, currentFile, newEntries);

--- a/src/server/agents/session-rotation.ts
+++ b/src/server/agents/session-rotation.ts
@@ -245,17 +245,26 @@ export function filterOrphanToolResults(entries: SessionEntry[]): {
     }
   }
 
-  // Step 2: identify orphan `toolResult` entry ids.
+  // Step 2: identify orphan `toolResult` entry ids. A toolResult is dropped
+  // when either:
+  //  - its `toolCallId` isn't a string (malformed/corrupted entry — cannot
+  //    match any toolCall and would fail provider validation on
+  //    reconstruction), or
+  //  - its `toolCallId` is a string absent from the emitted set (the
+  //    matching `tool_use` was pruned by upstream compaction).
+  // Both cases produce the same downstream failure (LLM provider rejects
+  // the API request) and the same recovery (drop the toolResult plus any
+  // descendants chained on it), so they share one predicate.
   const droppedIds = new Set<string>();
   for (const e of entries) {
     if (e.type !== 'message' || !e.id) continue;
     const msg = (e as SessionEntry & { message?: unknown }).message as
-      | { role?: string; toolCallId?: string }
+      | { role?: string; toolCallId?: unknown }
       | undefined;
-    if (msg?.role === 'toolResult' && typeof msg.toolCallId === 'string') {
-      if (!emittedToolCallIds.has(msg.toolCallId)) {
-        droppedIds.add(e.id);
-      }
+    if (msg?.role !== 'toolResult') continue;
+    const toolCallId = msg.toolCallId;
+    if (typeof toolCallId !== 'string' || !emittedToolCallIds.has(toolCallId)) {
+      droppedIds.add(e.id);
     }
   }
 

--- a/src/server/agents/session-rotation.ts
+++ b/src/server/agents/session-rotation.ts
@@ -254,19 +254,43 @@ export function filterOrphanToolResults(entries: SessionEntry[]): SessionEntry[]
 
   if (droppedIds.size === 0) return entries;
 
-  // Step 3: transitively mark any entry whose `parentId` chains to a dropped
-  // entry. Bounded loop — at most `entries.length` iterations needed since
-  // each pass adds at least one id until stable.
-  for (let pass = 0; pass < entries.length; pass++) {
-    let changed = false;
-    for (const e of entries) {
-      if (!e.id || droppedIds.has(e.id)) continue;
-      if (e.parentId && droppedIds.has(e.parentId)) {
-        droppedIds.add(e.id);
-        changed = true;
-      }
+  // Step 3: transitively mark every descendant of a dropped entry. Build a
+  // `parentId → child ids` index and an id → entry lookup in one pass, then
+  // BFS from the seed orphans. O(N) total — large rotated sessions can have
+  // tens of thousands of entries, and a naive fixed-point loop would be O(N^2)
+  // in the worst case (a long linear parent chain).
+  //
+  // Compaction markers act as structural anchors, not as continuations of the
+  // pre-compaction chain: their `parentId` typically points at the last entry
+  // of the kept pre-compaction tail, but the marker itself represents the
+  // *boundary* between summarized history and the post-compaction
+  // conversation. If we propagated the drop through the marker, every
+  // post-compaction entry chained back to it would also drop — wiping the
+  // resume point and effectively cold-starting the agent every time the
+  // entire kept tail happens to chain to an orphan. Treat compaction entries
+  // as BFS sinks: they (and everything past them) survive even when their
+  // parentId resolves to a dropped entry.
+  const childrenByParent = new Map<string, string[]>();
+  const entryById = new Map<string, SessionEntry>();
+  for (const e of entries) {
+    if (!e.id) continue;
+    entryById.set(e.id, e);
+    if (!e.parentId) continue;
+    const list = childrenByParent.get(e.parentId);
+    if (list) list.push(e.id);
+    else childrenByParent.set(e.parentId, [e.id]);
+  }
+  const queue: string[] = Array.from(droppedIds);
+  while (queue.length > 0) {
+    const parentId = queue.pop() as string;
+    const children = childrenByParent.get(parentId);
+    if (!children) continue;
+    for (const childId of children) {
+      if (droppedIds.has(childId)) continue;
+      if (entryById.get(childId)?.type === 'compaction') continue;
+      droppedIds.add(childId);
+      queue.push(childId);
     }
-    if (!changed) break;
   }
 
   log.warn(


### PR DESCRIPTION
## The incident

Today (2026-05-12), after restarting the server post-v0.3.6 release, the conductor was stuck — every message to it produced cascading LLM provider errors:

- Anthropic: `400 invalid_request_error: unexpected tool_use_id found in tool_result blocks: toolu_01JaqQxrwPWvMk37wfEjaRGS`
- Google: `function response turn must come immediately after a function call turn`
- ChatGPT-via-OpenAI-codex: usage-limit (failover hit a soft cap, unrelated downstream)

Same underlying issue surfacing through each provider's validation: the conductor's rotated JSONL contained an orphan `tool_result` whose matching `tool_use` had been pruned by an upstream pi-ai compaction. The failover chain couldn't recover because the failure was structural, not transient — every provider rebuilds the same API request from the same broken state.

## Root cause

When pi-ai's compaction selects its `firstKeptEntryId`, it can place the cut between a `tool_use` (older, summarized into the marker's text) and its `tool_result` (newer, in the kept tail). The compaction marker faithfully records the cut, and system2's `rotateSessionIfNeeded` faithfully trusts the marker. The resulting kept range contains a `tool_result` with no matching `tool_use` anywhere in the file. The SDK reconstructs an API request from this list, and every provider rejects.

This is an upstream pi-ai bug we can't fix from system2. What we **can** do is audit the post-rotation entry list and drop the inconsistency before writing the new JSONL.

## Fix

New `filterOrphanToolResults(entries)` helper in `session-rotation.ts`:

1. Collect every `toolCall.id` emitted by kept assistant messages (pi-ai's JSONL serializes Anthropic `tool_use` as `toolCall`).
2. Identify `toolResult` entries whose `toolCallId` isn't in the emitted set — orphans.
3. Transitively mark any entry whose `parentId` chains to a dropped entry. An assistant text response that consumed the orphan's output would otherwise survive with a dangling parent pointer; even if the SDK tolerated it, it would often land as the first message in the constructed API request, which Anthropic rejects (first message must be `user`). Dropping the whole stranded sub-chain lets the next valid user turn become the resume point.
4. Return the filtered list. Warn-level log with the drop count so operators can correlate with upstream compaction events.

Wired into both rotation paths:

- **Anchored rotation** (the bug's actual source): called after assembling `newEntries` from `firstKeptIndex` through compaction marker through post-compaction entries.
- **`forceBareBytesTailRotation`** (defense in depth): `selectTailEntries` already cuts on a user-turn boundary so the tail should be self-consistent, but the filter is cheap and the alternative (orphan slipping through → agent locked out) is unrecoverable without manual JSONL surgery.

## Test plan

- [x] **"anchored rotation drops orphan toolResult whose toolCall was pruned by upstream compaction"** — exact reproduction of today's conductor bug: `header → compaction(firstKept=orphan-id) → orphan toolResult → dependent text assistant → valid user → assistant toolCall → toolResult`. After rotation, orphan + dependent gone; valid pair survives.
- [x] **"anchored rotation: no-op for sessions with matching tool_use/tool_result pairs"** — happy-path regression guard.
- [x] **"anchored rotation drops a chain of multiple dependents on a single orphan"** — transitive drop coverage: the orphan's downstream branch (4 entries) is dropped wholesale; only header + compaction marker survive, agent cold-starts on the compaction summary alone (correct outcome).
- [x] `pnpm check` / `pnpm build` / `pnpm test` — **1,056 / 1,056 passing** (+3 new).

## Recovery for already-stuck sessions

Manual one-time surgery for the conductor that's stuck right now:

```bash
# Stop server, backup, identify orphan and dependent line numbers, drop both.
kill $(cat ~/.system2/server.pid)
cp ~/.system2/sessions/conductor_5/<file>.jsonl{,.bak}
sed -i '' -e '<orphan_line>d' -e '<dependent_line>d' ~/.system2/sessions/conductor_5/<file>.jsonl
# Restart server.
```

(For the specific case I diagnosed: the orphan is at line 7, dependent assistant at line 4. Run `-e '7d' -e '4d'` — delete 7 first so line 4's index stays valid.)

This PR fixes the issue going forward; sessions rotated after this lands won't produce orphans.

## Out of scope

- The root cause (pi-ai compaction picking a cut between a tool_use and its tool_result) is upstream. Not fixing here. System2 degrades gracefully via this defensive filter.
- No tests for `forceBareBytesTailRotation`'s filter call: the existing `selectTailEntries` user-turn-aligned cut should prevent orphans on that path; the filter is purely belt-and-braces.