### PR TITLE
fix(compaction): prevent race on shared auto-compaction abort controller

### DIFF
--- a/patches/@mariozechner__pi-coding-agent@0.71.1.patch
+++ b/patches/@mariozechner__pi-coding-agent@0.71.1.patch
@@ -1,3 +1,68 @@
+diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
+index 27aa76b416e44b9a813fedc00dbaf609e284f0d5..1f34eef9a8ad9a943dad23c8b88d3581a8787ca1 100644
+--- a/dist/core/agent-session.js
++++ b/dist/core/agent-session.js
+@@ -1471,9 +1471,20 @@ export class AgentSession {
+      * Internal: Run auto-compaction with events.
+      */
+     async _runAutoCompaction(reason, willRetry) {
++        // Guard against concurrent auto-compactions. Without this, the shared
++        // `_autoCompactionAbortController` field races between runs and the
++        // later run's `signal.aborted` check throws after the earlier run's
++        // finally has cleared the field.
++        if (this._autoCompactionAbortController !== undefined) {
++            return;
++        }
+         const settings = this.settingsManager.getCompactionSettings();
+         this._emit({ type: "compaction_start", reason });
+-        this._autoCompactionAbortController = new AbortController();
++        // Hold a local reference so the rest of this run is independent of the
++        // shared field — defense in depth in case a future caller bypasses the
++        // guard above.
++        const abortController = new AbortController();
++        this._autoCompactionAbortController = abortController;
+         try {
+             if (!this.model) {
+                 this._emit({
+@@ -1517,7 +1528,7 @@ export class AgentSession {
+                     preparation,
+                     branchEntries: pathEntries,
+                     customInstructions: undefined,
+-                    signal: this._autoCompactionAbortController.signal,
++                    signal: abortController.signal,
+                 }));
+                 if (extensionResult?.cancel) {
+                     this._emit({
+@@ -1547,13 +1558,13 @@ export class AgentSession {
+             }
+             else {
+                 // Generate compaction result
+-                const compactResult = await compact(preparation, this.model, apiKey, headers, undefined, this._autoCompactionAbortController.signal, this.thinkingLevel);
++                const compactResult = await compact(preparation, this.model, apiKey, headers, undefined, abortController.signal, this.thinkingLevel);
+                 summary = compactResult.summary;
+                 firstKeptEntryId = compactResult.firstKeptEntryId;
+                 tokensBefore = compactResult.tokensBefore;
+                 details = compactResult.details;
+             }
+-            if (this._autoCompactionAbortController.signal.aborted) {
++            if (abortController.signal.aborted) {
+                 this._emit({
+                     type: "compaction_end",
+                     reason,
+@@ -1615,7 +1626,12 @@ export class AgentSession {
+             });
+         }
+         finally {
+-            this._autoCompactionAbortController = undefined;
++            // Only clear the field if it still points at our controller — a
++            // future caller that bypasses the guard at the top must not have
++            // their controller wiped by an earlier run's finally.
++            if (this._autoCompactionAbortController === abortController) {
++                this._autoCompactionAbortController = undefined;
++            }
+         }
+     }
+     /**
 diff --git a/dist/core/compaction/compaction.js b/dist/core/compaction/compaction.js
 index 0658cb737dd13f5606ea9b5ebb98443c547a922d..33f848d0384eed496aa991b4147e7031de323ac7 100644
 --- a/dist/core/compaction/compaction.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@mariozechner/pi-coding-agent@0.71.1':
-    hash: loarssh6j74qyu4ihirmxx4ipy
+    hash: tl2qlv5rs26gkls2rfb3luf5hu
     path: patches/@mariozechner__pi-coding-agent@0.71.1.patch
 
 dependencies:
@@ -24,7 +24,7 @@ dependencies:
     version: 0.71.1(ws@8.20.0)(zod@4.4.1)
   '@mariozechner/pi-coding-agent':
     specifier: ^0.71.1
-    version: 0.71.1(patch_hash=loarssh6j74qyu4ihirmxx4ipy)(ws@8.20.0)(zod@4.4.1)
+    version: 0.71.1(patch_hash=tl2qlv5rs26gkls2rfb3luf5hu)(ws@8.20.0)(zod@4.4.1)
   '@mozilla/readability':
     specifier: ^0.6.0
     version: 0.6.0
@@ -1784,7 +1784,7 @@ packages:
       - zod
     dev: false
 
-  /@mariozechner/pi-coding-agent@0.71.1(patch_hash=loarssh6j74qyu4ihirmxx4ipy)(ws@8.20.0)(zod@4.4.1):
+  /@mariozechner/pi-coding-agent@0.71.1(patch_hash=tl2qlv5rs26gkls2rfb3luf5hu)(ws@8.20.0)(zod@4.4.1):
     resolution: {integrity: sha512-pP7ymz+MmZrcN5aUldm1q1cVbG3u04yZR/XsHEfidku5W3PP1uxsA0A4g4NOhXnkK5EZ+Qg6H12BAbVvl7Qq2Q==}
     engines: {node: '>=20.6.0'}
     hasBin: true


### PR DESCRIPTION
## Summary

The Guide UI was reporting "Context compaction failed: Auto-compaction failed: Cannot read properties of undefined (reading 'signal')" right after a successful "Context compacted" message. The compaction had actually succeeded; only the SDK's post-run abort check crashed.

**Root cause** (in `pi-coding-agent` v0.71.1, `dist/core/agent-session.js`): `_runAutoCompaction` writes to a single `this._autoCompactionAbortController` field at the top of its `try` block and clears it in `finally`. When two auto-compactions overlap (e.g., one from the agent-event queue on `agent_end`, another from `prompt()`'s pre-send compaction check at line 758), the second overwrites the first's controller. When run #1 finishes first, its `finally` clears the field; run #2 then reads `this._autoCompactionAbortController.signal.aborted` on `undefined` and throws. The catch wraps that into a misleading `compaction_end` with `errorMessage: "Auto-compaction failed: ..."`.

Evidence (from `~/.system2/sessions/guide_1/chat-cache.json`): 3 `compaction_start` events at 08:50:19 / 08:50:26 / 08:51:07, then 1 success and 2 "signal" failures, exactly matching the race.

## Fix (in the existing `patches/` pnpm patch)

This PR adds a new hunk to the existing pnpm patch of `@mariozechner/pi-coding-agent@0.71.1`, targeting `dist/core/agent-session.js`:

- **Guard at the top of `_runAutoCompaction`**: if `_autoCompactionAbortController` is already defined, return silently. Concurrent invocations no longer emit a misleading start/end pair.
- **Local `abortController`**: hold the controller in a local and use its `.signal` for all checks inside the run. The shared field can't be overwritten out from under us, so the `signal.aborted` check can't see `undefined`.
- **Conditional clear in `finally`** (defense in depth): only reset the field if it still points at our controller, so a future caller that bypasses the guard wouldn't have a newer controller wiped.

`isCompacting` and `abortAutoCompaction()` continue to read/abort the same field and remain correct.

### Note on the diff: `compaction.js` hunk is **not new**

The patch file diff also shows changes to `dist/core/compaction/compaction.js` (the `maxTokens` clamp around `generateSummary` and `generateTurnPrefixSummary`). **That hunk is pre-existing**, landed on main in commit `f75714e` ("fix(compaction): patch pi-coding-agent to clamp summarization maxTokens at model cap"). It appears in this PR's diff only because the pnpm patch hash regenerates whenever any part of the patch changes; no `compaction.js` logic is being added, removed, or modified here.

### Behavior trade-off

If an overflow-recovery call (`willRetry: true`) arrives while a threshold compaction is already in flight, it now skips silently instead of running concurrently, meaning the auto-retry `setTimeout` isn't scheduled. This case was already broken (it crashed with the same TypeError), and the in-flight threshold compaction still reduces context, so the user's prompt may still succeed without manual retry. Acceptable for a minimal patch; a fuller fix would await the in-flight compaction.

## Test plan

- [x] `pnpm check` clean (no new warnings)
- [x] `pnpm typecheck` clean
- [x] `pnpm build` clean
- [x] `pnpm test` — 1061/1061 passing locally
- [ ] Manual verification on next high-context Guide turn: only one compaction_start/compaction_end pair per logical compaction; no "Auto-compaction failed: ... reading 'signal'" entries appear in the chat timeline.