### PR TITLE
ui: WebSocket auto-reconnect + per-agent message drafts

### DIFF
--- a/src/ui/components/MessageInput.tsx
+++ b/src/ui/components/MessageInput.tsx
@@ -87,8 +87,10 @@ export function MessageInput({ onSend, onSteer, onAbort }: MessageInputProps) {
 
   // When switching agents, the value swaps to that agent's draft via the store,
   // but onChange doesn't fire — recompute textarea height so it matches the new
-  // draft instead of inheriting the previous agent's height.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: autoResize is stable across renders
+  // draft instead of inheriting the previous agent's height. autoResize is
+  // recreated each render but only reads from textareaRef + module constants,
+  // so we intentionally key this effect on activeAgentId alone.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: only re-run on agent switch
   useEffect(() => {
     autoResize();
   }, [activeAgentId]);

--- a/src/ui/components/MessageInput.tsx
+++ b/src/ui/components/MessageInput.tsx
@@ -8,7 +8,7 @@
 
 import { ArrowUpIcon, SquareFillIcon } from '@primer/octicons-react';
 import { Box } from '@primer/react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { EMPTY_AGENT_STATE, useChatStore } from '../stores/chat';
 import { usePushStore } from '../stores/push';
 import { colors, contextColor } from '../theme/colors';
@@ -26,7 +26,6 @@ interface MessageInputProps {
 }
 
 export function MessageInput({ onSend, onSteer, onAbort }: MessageInputProps) {
-  const [input, setInput] = useState('');
   const isConnected = useChatStore((s) => s.isConnected);
   const activeAgentId = useChatStore((s) => s.activeAgentId);
   const activeAgentRole = useChatStore((s) => s.activeAgentRole);
@@ -35,6 +34,12 @@ export function MessageInput({ onSend, onSteer, onAbort }: MessageInputProps) {
     return s.agentStates.get(s.activeAgentId) ?? EMPTY_AGENT_STATE;
   });
   const { isStreaming, isWaitingForResponse, provider } = activeState;
+  // Per-agent input draft: switching agents preserves each agent's unsent text.
+  const input = activeState.inputDraft;
+  const setInputDraft = useChatStore((s) => s.setInputDraft);
+  const setInput = (value: string) => {
+    if (activeAgentId !== null) setInputDraft(value, activeAgentId);
+  };
   // contextPercent comes from the push store (driven by agent_busy_state) — same
   // source AgentPane uses, so the chat input and table can never disagree.
   const contextPercent = usePushStore((s) =>
@@ -79,6 +84,14 @@ export function MessageInput({ onSend, onSteer, onAbort }: MessageInputProps) {
     textarea.style.height = `${newHeight}px`;
     textarea.style.overflowY = textarea.scrollHeight > maxHeight ? 'auto' : 'hidden';
   };
+
+  // When switching agents, the value swaps to that agent's draft via the store,
+  // but onChange doesn't fire — recompute textarea height so it matches the new
+  // draft instead of inheriting the previous agent's height.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: autoResize is stable across renders
+  useEffect(() => {
+    autoResize();
+  }, [activeAgentId]);
 
   const ctxColor = contextPercent !== null ? contextColor(contextPercent, accent) : colors.teal;
 

--- a/src/ui/hooks/useWebSocket.ts
+++ b/src/ui/hooks/useWebSocket.ts
@@ -335,6 +335,13 @@ export function useWebSocket() {
       document.removeEventListener('visibilitychange', onVisibility);
       window.removeEventListener('online', onOnline);
       wsRef.current?.close();
+      // The onclose guard short-circuits because unmounted is now true, so the
+      // store would otherwise keep isConnected=true and stale streaming state
+      // after teardown (route change, HMR, StrictMode dev double-mount). Apply
+      // the same store mutations onclose would have, minus scheduleReconnect.
+      const state = useChatStore.getState();
+      state.setConnected(false);
+      state.clearAllStreamingState();
     };
   }, []);
 

--- a/src/ui/hooks/useWebSocket.ts
+++ b/src/ui/hooks/useWebSocket.ts
@@ -289,6 +289,12 @@ export function useWebSocket() {
       };
 
       ws.onerror = (error) => {
+        // Ignore stale events from a superseded socket: reconnectNow() can
+        // create a new socket while this one is still CLOSING, and React
+        // StrictMode's double-mount also produces a teardown-then-recreate
+        // cycle where the first socket's events would otherwise corrupt the
+        // second socket's connection state.
+        if (unmounted || wsRef.current !== ws) return;
         console.error('WebSocket error:', error);
         const state = useChatStore.getState();
         state.setConnected(false);
@@ -296,6 +302,7 @@ export function useWebSocket() {
       };
 
       ws.onclose = () => {
+        if (unmounted || wsRef.current !== ws) return;
         console.log('WebSocket disconnected');
         const state = useChatStore.getState();
         state.setConnected(false);

--- a/src/ui/hooks/useWebSocket.ts
+++ b/src/ui/hooks/useWebSocket.ts
@@ -37,241 +37,291 @@ export function useWebSocket() {
   }, [activeAgentId]);
 
   useEffect(() => {
-    const ws = new WebSocket(WS_URL);
-    wsRef.current = ws;
+    let unmounted = false;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let reconnectAttempts = 0;
 
-    ws.onopen = () => {
-      console.log('WebSocket connected');
-      const state = useChatStore.getState();
-      state.setConnected(true);
-      if (hasConnectedOnce.current) {
-        // On reconnect, clear stale busy state and bump all version counters
-        // so UI panels refetch any changes missed during the disconnect
-        const push = usePushStore.getState();
-        push.clearAgentBusy();
-        push.bumpAll();
-      }
-      hasConnectedOnce.current = true;
-      // Re-subscribe to the active agent if it's not the Guide
-      if (
-        state.activeAgentId !== null &&
-        state.guideAgentId !== null &&
-        state.activeAgentId !== state.guideAgentId
-      ) {
-        const msg: ClientMessage = { type: 'switch_agent', agentId: state.activeAgentId };
-        ws.send(JSON.stringify(msg));
-      }
+    const scheduleReconnect = () => {
+      if (unmounted || reconnectTimer) return;
+      // Exponential backoff: 1s, 2s, 4s, 8s, 16s, capped at 30s
+      const delay = Math.min(1000 * 2 ** reconnectAttempts, 30000);
+      reconnectAttempts += 1;
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        connect();
+      }, delay);
     };
 
-    ws.onmessage = (event) => {
-      const message = JSON.parse(event.data) as ServerMessage;
-      const state = useChatStore.getState();
+    const reconnectNow = () => {
+      if (unmounted) return;
+      const ws = wsRef.current;
+      if (ws && ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+        return; // connection is healthy or in flight
+      }
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      reconnectAttempts = 0;
+      connect();
+    };
 
-      switch (message.type) {
-        case 'thinking_chunk': {
-          const aid = message.agentId ?? state.guideAgentId;
-          if (aid === null) break;
-          const agentState = state.agentStates.get(aid);
-          if (!agentState?.activeThinkingId && message.content) {
-            state.startThinking(aid);
-          }
-          state.appendThinkingChunk(message.content, aid);
-          break;
+    const connect = () => {
+      if (unmounted) return;
+      const ws = new WebSocket(WS_URL);
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        console.log('WebSocket connected');
+        reconnectAttempts = 0;
+        const state = useChatStore.getState();
+        state.setConnected(true);
+        if (hasConnectedOnce.current) {
+          // On reconnect, clear stale busy state and bump all version counters
+          // so UI panels refetch any changes missed during the disconnect
+          const push = usePushStore.getState();
+          push.clearAgentBusy();
+          push.bumpAll();
         }
-
-        case 'thinking_end': {
-          const aid = message.agentId ?? state.guideAgentId;
-          if (aid !== null) state.finishThinking(aid);
-          break;
+        hasConnectedOnce.current = true;
+        // Re-subscribe to the active agent if it's not the Guide
+        if (
+          state.activeAgentId !== null &&
+          state.guideAgentId !== null &&
+          state.activeAgentId !== state.guideAgentId
+        ) {
+          const msg: ClientMessage = { type: 'switch_agent', agentId: state.activeAgentId };
+          ws.send(JSON.stringify(msg));
         }
+      };
 
-        case 'assistant_chunk': {
-          const aid = message.agentId ?? state.guideAgentId;
-          if (aid === null) break;
-          const agentState = state.agentStates.get(aid);
-          if (!agentState?.currentAssistantMessage && message.content) {
-            state.finishThinking(aid);
-            state.startAssistantMessage(aid);
-          }
-          state.appendAssistantChunk(message.content, aid);
-          break;
-        }
+      ws.onmessage = (event) => {
+        const message = JSON.parse(event.data) as ServerMessage;
+        const state = useChatStore.getState();
 
-        case 'assistant_end': {
-          const aid = message.agentId ?? state.guideAgentId;
-          if (aid !== null) {
-            state.finishThinking(aid);
-            state.finishAssistantMessage(aid);
-            // Show LLM errors in the chat timeline as collapsible system messages
-            if (message.errorMessage) {
-              state.addSystemMessage(`LLM error\n\n${message.errorMessage}`, aid);
+        switch (message.type) {
+          case 'thinking_chunk': {
+            const aid = message.agentId ?? state.guideAgentId;
+            if (aid === null) break;
+            const agentState = state.agentStates.get(aid);
+            if (!agentState?.activeThinkingId && message.content) {
+              state.startThinking(aid);
             }
+            state.appendThinkingChunk(message.content, aid);
+            break;
           }
-          break;
-        }
 
-        case 'tool_call_start': {
-          const aid = message.agentId ?? state.guideAgentId;
-          if (aid !== null) state.startToolCall(message.name, message.input, aid);
-          break;
-        }
-
-        case 'tool_call_progress': {
-          const aid = message.agentId ?? state.guideAgentId;
-          if (aid !== null) state.updateToolCallProgress(message.name, message.message, aid);
-          break;
-        }
-
-        case 'tool_call_end': {
-          const aid = message.agentId ?? state.guideAgentId;
-          if (aid !== null) state.finishToolCall(message.name, message.result, aid);
-          break;
-        }
-
-        case 'ready_for_input': {
-          const aid = message.agentId ?? state.guideAgentId;
-          if (aid !== null) {
-            state.setStreaming(false, aid);
-            state.setWaitingForResponse(false, aid);
-            state.resetCompaction(aid);
+          case 'thinking_end': {
+            const aid = message.agentId ?? state.guideAgentId;
+            if (aid !== null) state.finishThinking(aid);
+            break;
           }
-          break;
-        }
 
-        case 'chat_history': {
-          const aid = message.agentId;
-          // First chat_history is for the Guide (on initial connect)
-          if (state.guideAgentId === null) {
-            state.setGuideAgentId(aid);
-            if (state.activeAgentId === null) {
-              // No agent selected yet — default to Guide
-              state.setActiveAgent(aid, 'guide');
-            } else if (state.activeAgentId !== aid) {
-              // User pre-selected a different agent before history arrived —
-              // re-subscribe the server to the correct agent
-              const switchMsg: ClientMessage = {
-                type: 'switch_agent',
-                agentId: state.activeAgentId,
-              };
-              ws.send(JSON.stringify(switchMsg));
+          case 'assistant_chunk': {
+            const aid = message.agentId ?? state.guideAgentId;
+            if (aid === null) break;
+            const agentState = state.agentStates.get(aid);
+            if (!agentState?.currentAssistantMessage && message.content) {
+              state.finishThinking(aid);
+              state.startAssistantMessage(aid);
             }
+            state.appendAssistantChunk(message.content, aid);
+            break;
           }
-          state.loadHistory(message.messages, aid);
-          break;
-        }
 
-        case 'user_message_broadcast': {
-          const aid = message.agentId ?? state.guideAgentId;
-          if (aid !== null) {
-            state.addUserMessage(message.content, message.id, message.timestamp, aid);
+          case 'assistant_end': {
+            const aid = message.agentId ?? state.guideAgentId;
+            if (aid !== null) {
+              state.finishThinking(aid);
+              state.finishAssistantMessage(aid);
+              // Show LLM errors in the chat timeline as collapsible system messages
+              if (message.errorMessage) {
+                state.addSystemMessage(`LLM error\n\n${message.errorMessage}`, aid);
+              }
+            }
+            break;
           }
-          break;
-        }
 
-        case 'artifact': {
-          const artifactStore = useArtifactStore.getState();
-          if (message.filePath) {
-            const existingTab = artifactStore.tabs.find((t) => t.filePath === message.filePath);
-            if (existingTab) {
-              const separator = message.url.includes('?') ? '&' : '?';
-              artifactStore.reloadTab(
-                message.filePath,
-                `${message.url}${separator}t=${Date.now()}`
-              );
+          case 'tool_call_start': {
+            const aid = message.agentId ?? state.guideAgentId;
+            if (aid !== null) state.startToolCall(message.name, message.input, aid);
+            break;
+          }
+
+          case 'tool_call_progress': {
+            const aid = message.agentId ?? state.guideAgentId;
+            if (aid !== null) state.updateToolCallProgress(message.name, message.message, aid);
+            break;
+          }
+
+          case 'tool_call_end': {
+            const aid = message.agentId ?? state.guideAgentId;
+            if (aid !== null) state.finishToolCall(message.name, message.result, aid);
+            break;
+          }
+
+          case 'ready_for_input': {
+            const aid = message.agentId ?? state.guideAgentId;
+            if (aid !== null) {
+              state.setStreaming(false, aid);
+              state.setWaitingForResponse(false, aid);
+              state.resetCompaction(aid);
+            }
+            break;
+          }
+
+          case 'chat_history': {
+            const aid = message.agentId;
+            // First chat_history is for the Guide (on initial connect)
+            if (state.guideAgentId === null) {
+              state.setGuideAgentId(aid);
+              if (state.activeAgentId === null) {
+                // No agent selected yet — default to Guide
+                state.setActiveAgent(aid, 'guide');
+              } else if (state.activeAgentId !== aid) {
+                // User pre-selected a different agent before history arrived —
+                // re-subscribe the server to the correct agent
+                const switchMsg: ClientMessage = {
+                  type: 'switch_agent',
+                  agentId: state.activeAgentId,
+                };
+                ws.send(JSON.stringify(switchMsg));
+              }
+            }
+            state.loadHistory(message.messages, aid);
+            break;
+          }
+
+          case 'user_message_broadcast': {
+            const aid = message.agentId ?? state.guideAgentId;
+            if (aid !== null) {
+              state.addUserMessage(message.content, message.id, message.timestamp, aid);
+            }
+            break;
+          }
+
+          case 'artifact': {
+            const artifactStore = useArtifactStore.getState();
+            if (message.filePath) {
+              const existingTab = artifactStore.tabs.find((t) => t.filePath === message.filePath);
+              if (existingTab) {
+                const separator = message.url.includes('?') ? '&' : '?';
+                artifactStore.reloadTab(
+                  message.filePath,
+                  `${message.url}${separator}t=${Date.now()}`
+                );
+              } else {
+                artifactStore.openArtifact(message.url, message.title, message.filePath);
+              }
             } else {
-              artifactStore.openArtifact(message.url, message.title, message.filePath);
+              artifactStore.openArtifact(message.url, message.title);
             }
-          } else {
-            artifactStore.openArtifact(message.url, message.title);
+            break;
           }
-          break;
-        }
 
-        case 'provider_info':
-          state.setProvider(message.provider, message.agentId);
-          break;
+          case 'provider_info':
+            state.setProvider(message.provider, message.agentId);
+            break;
 
-        case 'provider_change':
-          state.setProvider(message.provider, message.agentId);
-          state.addSystemMessage(
-            message.reason ?? `Switched to ${message.provider}`,
-            message.agentId
-          );
-          break;
+          case 'provider_change':
+            state.setProvider(message.provider, message.agentId);
+            state.addSystemMessage(
+              message.reason ?? `Switched to ${message.provider}`,
+              message.agentId
+            );
+            break;
 
-        case 'compaction_start': {
-          const aid = message.agentId ?? state.guideAgentId;
-          if (aid !== null) state.startCompaction(aid);
-          break;
-        }
-
-        case 'compaction_end': {
-          const aid = message.agentId ?? state.guideAgentId;
-          if (aid !== null) state.finishCompaction(aid);
-          break;
-        }
-
-        case 'board_changed':
-          usePushStore.getState().bumpBoard();
-          break;
-
-        case 'agents_changed':
-          usePushStore.getState().bumpAgents();
-          break;
-
-        case 'artifacts_changed':
-          usePushStore.getState().bumpArtifacts();
-          break;
-
-        case 'job_executions_changed':
-          usePushStore.getState().bumpJobs();
-          break;
-
-        case 'agent_busy_state':
-          // Idempotent: handles both broadcast (transition) and unicast (snapshot) variants.
-          usePushStore
-            .getState()
-            .setAgentBusy(message.agentId, message.busy, message.contextPercent);
-          break;
-
-        case 'error': {
-          console.error('Server error:', message.message);
-          const aid = message.agentId ?? state.activeAgentId;
-          if (aid !== null) state.setWaitingForResponse(false, aid);
-          // If the failed agent is the active non-Guide agent, fall back to Guide
-          // (handles stale persisted agent IDs from localStorage)
-          if (
-            message.agentId &&
-            state.guideAgentId &&
-            message.agentId === state.activeAgentId &&
-            message.agentId !== state.guideAgentId
-          ) {
-            state.setActiveAgent(state.guideAgentId, 'guide');
+          case 'compaction_start': {
+            const aid = message.agentId ?? state.guideAgentId;
+            if (aid !== null) state.startCompaction(aid);
+            break;
           }
-          break;
+
+          case 'compaction_end': {
+            const aid = message.agentId ?? state.guideAgentId;
+            if (aid !== null) state.finishCompaction(aid);
+            break;
+          }
+
+          case 'board_changed':
+            usePushStore.getState().bumpBoard();
+            break;
+
+          case 'agents_changed':
+            usePushStore.getState().bumpAgents();
+            break;
+
+          case 'artifacts_changed':
+            usePushStore.getState().bumpArtifacts();
+            break;
+
+          case 'job_executions_changed':
+            usePushStore.getState().bumpJobs();
+            break;
+
+          case 'agent_busy_state':
+            // Idempotent: handles both broadcast (transition) and unicast (snapshot) variants.
+            usePushStore
+              .getState()
+              .setAgentBusy(message.agentId, message.busy, message.contextPercent);
+            break;
+
+          case 'error': {
+            console.error('Server error:', message.message);
+            const aid = message.agentId ?? state.activeAgentId;
+            if (aid !== null) state.setWaitingForResponse(false, aid);
+            // If the failed agent is the active non-Guide agent, fall back to Guide
+            // (handles stale persisted agent IDs from localStorage)
+            if (
+              message.agentId &&
+              state.guideAgentId &&
+              message.agentId === state.activeAgentId &&
+              message.agentId !== state.guideAgentId
+            ) {
+              state.setActiveAgent(state.guideAgentId, 'guide');
+            }
+            break;
+          }
+
+          default:
+            console.log('Unknown message type:', message);
         }
+      };
 
-        default:
-          console.log('Unknown message type:', message);
-      }
+      ws.onerror = (error) => {
+        console.error('WebSocket error:', error);
+        const state = useChatStore.getState();
+        state.setConnected(false);
+        state.clearAllStreamingState();
+      };
+
+      ws.onclose = () => {
+        console.log('WebSocket disconnected');
+        const state = useChatStore.getState();
+        state.setConnected(false);
+        state.clearAllStreamingState();
+        scheduleReconnect();
+      };
     };
 
-    ws.onerror = (error) => {
-      console.error('WebSocket error:', error);
-      const state = useChatStore.getState();
-      state.setConnected(false);
-      state.clearAllStreamingState();
+    // Retry immediately when the tab becomes visible or the network comes back,
+    // instead of waiting for the next backoff tick. Common after macOS display
+    // sleep, which suspends network activity and lets the socket time out.
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') reconnectNow();
     };
+    const onOnline = () => reconnectNow();
+    document.addEventListener('visibilitychange', onVisibility);
+    window.addEventListener('online', onOnline);
 
-    ws.onclose = () => {
-      console.log('WebSocket disconnected');
-      const state = useChatStore.getState();
-      state.setConnected(false);
-      state.clearAllStreamingState();
-    };
+    connect();
 
     return () => {
-      ws.close();
+      unmounted = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      document.removeEventListener('visibilitychange', onVisibility);
+      window.removeEventListener('online', onOnline);
+      wsRef.current?.close();
     };
   }, []);
 

--- a/src/ui/hooks/useWebSocket.ts
+++ b/src/ui/hooks/useWebSocket.ts
@@ -72,8 +72,13 @@ export function useWebSocket() {
       wsRef.current = ws;
 
       ws.onopen = () => {
+        if (unmounted || wsRef.current !== ws) return;
         console.log('WebSocket connected');
         reconnectAttempts = 0;
+        if (reconnectTimer) {
+          clearTimeout(reconnectTimer);
+          reconnectTimer = null;
+        }
         const state = useChatStore.getState();
         state.setConnected(true);
         if (hasConnectedOnce.current) {
@@ -96,6 +101,7 @@ export function useWebSocket() {
       };
 
       ws.onmessage = (event) => {
+        if (unmounted || wsRef.current !== ws) return;
         const message = JSON.parse(event.data) as ServerMessage;
         const state = useChatStore.getState();
 

--- a/src/ui/stores/chat.test.ts
+++ b/src/ui/stores/chat.test.ts
@@ -287,4 +287,48 @@ describe('useChatStore', () => {
       expect(useChatStore.getState().getAgentState(2).provider).toBeNull();
     });
   });
+
+  describe('setInputDraft (per-agent drafts)', () => {
+    it('isolates drafts between agents', () => {
+      useChatStore.getState().loadHistory([], 1);
+      useChatStore.getState().loadHistory([], 2);
+
+      useChatStore.getState().setInputDraft('hello A', 1);
+      useChatStore.getState().setInputDraft('hello B', 2);
+
+      expect(useChatStore.getState().getAgentState(1).inputDraft).toBe('hello A');
+      expect(useChatStore.getState().getAgentState(2).inputDraft).toBe('hello B');
+    });
+
+    it('defaults to active agent when agentId is omitted', () => {
+      useChatStore.getState().loadHistory([], 1);
+      useChatStore.getState().loadHistory([], 2);
+      useChatStore.setState({ activeAgentId: 1 });
+
+      useChatStore.getState().setInputDraft('typed for active');
+
+      expect(useChatStore.getState().getAgentState(1).inputDraft).toBe('typed for active');
+      expect(useChatStore.getState().getAgentState(2).inputDraft).toBe('');
+    });
+
+    it('clearing a draft on send leaves other agents untouched', () => {
+      useChatStore.getState().loadHistory([], 1);
+      useChatStore.getState().loadHistory([], 2);
+      useChatStore.getState().setInputDraft('half-written A', 1);
+      useChatStore.getState().setInputDraft('half-written B', 2);
+
+      // Simulate MessageInput's submit clearing the active agent's draft
+      useChatStore.getState().setInputDraft('', 1);
+
+      expect(useChatStore.getState().getAgentState(1).inputDraft).toBe('');
+      expect(useChatStore.getState().getAgentState(2).inputDraft).toBe('half-written B');
+    });
+
+    it('is a no-op when no agent is active and agentId is omitted', () => {
+      // activeAgentId is null (reset in beforeEach)
+      useChatStore.getState().setInputDraft('orphan text');
+
+      expect(useChatStore.getState().agentStates.size).toBe(0);
+    });
+  });
 });

--- a/src/ui/stores/chat.ts
+++ b/src/ui/stores/chat.ts
@@ -37,6 +37,7 @@ export interface PerAgentState {
   provider: string | null;
   compactionStatus: 'idle' | 'compacting';
   compactionTimestamp: number | null;
+  inputDraft: string;
 }
 
 function createDefaultAgentState(): PerAgentState {
@@ -50,6 +51,7 @@ function createDefaultAgentState(): PerAgentState {
     provider: null,
     compactionStatus: 'idle',
     compactionTimestamp: null,
+    inputDraft: '',
   };
 }
 
@@ -95,6 +97,7 @@ interface ChatState {
   startCompaction: (agentId: number) => void;
   finishCompaction: (agentId: number) => void;
   resetCompaction: (agentId: number) => void;
+  setInputDraft: (value: string, agentId?: number) => void;
 }
 
 /** Immutably update a specific agent's state within the Map. */
@@ -497,6 +500,16 @@ export const useChatStore = create<ChatState>()(
           agentStates: updateAgentState(state.agentStates, agentId, () => ({
             compactionStatus: 'idle' as const,
             compactionTimestamp: null,
+          })),
+        }));
+      },
+
+      setInputDraft: (value: string, agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, () => ({
+            inputDraft: value,
           })),
         }));
       },


### PR DESCRIPTION
## Summary

Two scoped UI fixes/features bundled for the 0.3.10 release.

### 1. WebSocket auto-reconnect (`src/ui/hooks/useWebSocket.ts`)

`useWebSocket` opened a single socket on mount; `onclose` only flipped `connected=false` and the `useEffect` had `[]` deps, so once the socket dropped the UI sat on "Connecting to server…" until the user reloaded. Most reproducible after macOS display sleep, which suspends network activity long enough for the browser, server, or an intermediary to close the socket.

- Wrap socket setup in a `connect()` closure inside the same `useEffect` and schedule a reconnect from `onclose` with exponential backoff (1s, 2s, 4s, 8s, 16s, capped at 30s). Attempt counter resets on successful `onopen`.
- Add `visibilitychange` + `online` listeners that call `reconnectNow()` to retry immediately when the tab becomes visible or the network comes back, skipping the wait for the next backoff tick. `reconnectNow` is a no-op when the socket is already `OPEN`/`CONNECTING` so a healthy in-flight connection isn't stomped.
- `unmounted` flag gates the timer and `connect()` body so StrictMode double-mount and component unmount paths don't leak sockets or schedule callbacks after teardown; the cleanup clears the pending timer, removes the listeners, and closes the current socket.

The server-handshake side already had reconnect plumbing (clearing stale `agent_busy` state and bumping push counters on `hasConnectedOnce`) but was unreachable because nothing ever triggered a second `onopen` — that path is now live.

### 2. Per-agent message-input drafts (`src/ui/components/MessageInput.tsx`, `src/ui/stores/chat.ts`)

The chat input held its unsent text in a local `useState` in `MessageInput`, so switching agents kept the previous agent's draft visible (and would send it to the new agent on Enter).

- Add `inputDraft: string` to `PerAgentState` (default `''`) and a `setInputDraft(value, agentId?)` action.
- Read/write the textarea value through the store via the active agent's draft. Switching agents swaps in that agent's saved draft (empty if none); switching back restores the original text.
- Run `autoResize` in a `useEffect` keyed on `activeAgentId` so the textarea height matches the new draft instead of inheriting the previous agent's height.

Drafts are intentionally **not** persisted across page reload — the chat store's `persist` partialize keeps `activeAgentId` / role / label only, and `inputDraft` lives inside `agentStates` which is excluded. Pure in-tab agent-switch scope.

## Test plan

WebSocket reconnect:

- [ ] Suspend the laptop (close lid or screen sleep) with the UI open, wake it: socket should reconnect on its own, no manual page refresh.
- [ ] Toggle airplane mode while UI is open: socket reconnects when network returns.
- [ ] Stop and restart the daemon: UI reconnects within 1–2 seconds rather than staying stuck.
- [ ] Switch tabs / minimize for >30s and come back: chat history and agent busy/context-usage state resync correctly.

Per-agent drafts:

- [ ] Type "hello A" while viewing Guide, switch to a Conductor agent: textarea clears (or shows that agent's saved draft).
- [ ] Type "hello B" on the second agent, switch back to Guide: "hello A" is restored, textarea height correct for that content.
- [ ] Send a message: that agent's draft clears, other agents' drafts untouched.
- [ ] Reload the page: drafts reset to empty (expected — not persisted).