### PR TITLE
fix(scheduler): bound trackJobExecution handler with timeoutMs backstop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Cron handlers can no longer hang the scheduler indefinitely. `trackJobExecution` now bounds every handler invocation by a `timeoutMs` (default 10 minutes, overridable per call). On expiry the execution row is marked `failed` with reason `'handler timed out after Xs'` and a `HandlerTimeoutError` is thrown so the scheduler unblocks. The handler's own promise is detached: a late rejection is logged at `warn` rather than crashing the daemon, and a late resolution is silently ignored. This is the universal backstop layer of issue [#194](https://github.com/diegoscarabelli/system2/issues/194), where a wedged narrator session caused 44 daily-summary rows to accumulate as `running` over 21 hours; targeted fixes for the underlying delivery path will follow.
+
 ## [0.3.12] - 2026-05-16
 
 ### Fixed

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -120,6 +120,8 @@ The `trigger_type` column distinguishes how the execution was initiated:
 
 **Startup recovery:** before Croner starts, the server marks any stale `running` rows as `failed` with error `'server shutdown'`. At that point no new jobs have fired, so every `running` row is definitively from the previous (crashed) process.
 
+**Handler timeout backstop:** every handler invoked via `trackJobExecution` is bounded by `DEFAULT_HANDLER_TIMEOUT_MS` (10 minutes, overridable per call). If the handler does not settle within that window, the execution row is marked `failed` with error `'handler timed out after Xs'` and the function rejects with a `HandlerTimeoutError` so the scheduler is not blocked. The handler promise itself is detached: its later settlement is logged at `warn` if it rejects, but cannot crash the daemon or alter the already-recorded row. This is a universal safety net for the silent-hang failure mode where a delivery silently queues into a wedged narrator session and never resolves (issue #194); narrower fixes for the underlying delivery path live in `AgentHost`.
+
 **Skip reasons** are stored in the `error` column when status is `skipped`. Common reasons: `no network connectivity`, `no activity since last run`, `no daily summaries to incorporate`.
 
 **Missing timestamps:** if daily summary files exist but none contain `last_narrator_update_ts` (and memory.md also lacks it), the job fails rather than silently falling back. This catches initialization errors where no cursor has been set yet.

--- a/src/server/scheduler/jobs.test.ts
+++ b/src/server/scheduler/jobs.test.ts
@@ -2442,7 +2442,7 @@ describe('trackJobExecution', () => {
       throw new Error('broadcast failed');
     });
 
-    await trackJobExecution(db, 'test-job', 'cron', handler, onJobChange);
+    await trackJobExecution(db, 'test-job', 'cron', handler, { onJobChange });
 
     expect(handler).toHaveBeenCalled();
     expect(db.completeJobExecution).toHaveBeenCalledWith(42);
@@ -2458,9 +2458,9 @@ describe('trackJobExecution', () => {
       throw new Error('broadcast failed');
     });
 
-    await expect(trackJobExecution(db, 'test-job', 'cron', handler, onJobChange)).rejects.toThrow(
-      'handler failed'
-    );
+    await expect(
+      trackJobExecution(db, 'test-job', 'cron', handler, { onJobChange })
+    ).rejects.toThrow('handler failed');
 
     expect(db.failJobExecution).toHaveBeenCalledWith(42, expect.stringContaining('handler failed'));
   });
@@ -2478,7 +2478,7 @@ describe('trackJobExecution', () => {
       const db = mockDbForTracking();
       const handler = vi.fn(() => new Promise<void>(() => {})); // never resolves
 
-      const promise = trackJobExecution(db, 'test-job', 'cron', handler, undefined, 1_000);
+      const promise = trackJobExecution(db, 'test-job', 'cron', handler, { timeoutMs: 1_000 });
       // Surface the rejection synchronously so the unhandled-rejection guard does not fire
       // while we are still advancing fake timers.
       const settled = expect(promise).rejects.toBeInstanceOf(HandlerTimeoutError);
@@ -2494,13 +2494,29 @@ describe('trackJobExecution', () => {
       expect(db.completeJobExecution).not.toHaveBeenCalled();
     });
 
+    it('renders sub-second timeouts as at least 1s (no "0s" message)', async () => {
+      const db = mockDbForTracking();
+      const handler = vi.fn(() => new Promise<void>(() => {}));
+
+      const promise = trackJobExecution(db, 'test-job', 'cron', handler, { timeoutMs: 250 });
+      const settled = expect(promise).rejects.toBeInstanceOf(HandlerTimeoutError);
+
+      await vi.advanceTimersByTimeAsync(250);
+      await settled;
+
+      expect(db.failJobExecution).toHaveBeenCalledWith(
+        42,
+        expect.stringContaining('handler timed out after 1s')
+      );
+    });
+
     it('clears the timer when handler resolves before timeout (no false-positive failure)', async () => {
       const db = mockDbForTracking();
       const handler = vi.fn(async () => {
         await new Promise((resolve) => setTimeout(resolve, 500));
       });
 
-      const promise = trackJobExecution(db, 'test-job', 'cron', handler, undefined, 5_000);
+      const promise = trackJobExecution(db, 'test-job', 'cron', handler, { timeoutMs: 5_000 });
       await vi.advanceTimersByTimeAsync(500);
       await promise;
 
@@ -2522,7 +2538,7 @@ describe('trackJobExecution', () => {
           })
       );
 
-      const promise = trackJobExecution(db, 'test-job', 'cron', handler, undefined, 1_000);
+      const promise = trackJobExecution(db, 'test-job', 'cron', handler, { timeoutMs: 1_000 });
       const settled = expect(promise).rejects.toBeInstanceOf(HandlerTimeoutError);
 
       await vi.advanceTimersByTimeAsync(1_000);
@@ -2530,13 +2546,19 @@ describe('trackJobExecution', () => {
 
       // Now let the handler's own promise reject — this would crash the process if
       // trackJobExecution did not attach a .catch() to it after timing out.
-      rejectHandler(new Error('late SDK failure'));
+      const lateError = new Error('late SDK failure');
+      rejectHandler(lateError);
       await vi.runAllTimersAsync();
       // Allow microtasks for the swallow handler to run.
       await Promise.resolve();
       await Promise.resolve();
 
-      expect(handlerLog).toHaveBeenCalledWith(expect.stringContaining('late SDK failure'));
+      // The error object is passed as a separate logger argument so stack/context is
+      // preserved (we don't interpolate `late.message` into the template).
+      expect(handlerLog).toHaveBeenCalledWith(
+        expect.stringContaining('handler eventually rejected after timeout'),
+        lateError
+      );
       handlerLog.mockRestore();
     });
 

--- a/src/server/scheduler/jobs.test.ts
+++ b/src/server/scheduler/jobs.test.ts
@@ -12,7 +12,9 @@ import {
   collectAgentActivity,
   collectAgentActivityWithTimestamps,
   type DbChangeTable,
+  DEFAULT_HANDLER_TIMEOUT_MS,
   formatMarkdownTable,
+  HandlerTimeoutError,
   JobSkipped,
   NARRATOR_MESSAGE_EXCERPT_BYTES,
   readFrontmatterField,
@@ -2461,5 +2463,102 @@ describe('trackJobExecution', () => {
     );
 
     expect(db.failJobExecution).toHaveBeenCalledWith(42, expect.stringContaining('handler failed'));
+  });
+
+  describe('handler timeout', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('marks the row failed and throws HandlerTimeoutError when handler exceeds timeoutMs', async () => {
+      const db = mockDbForTracking();
+      const handler = vi.fn(() => new Promise<void>(() => {})); // never resolves
+
+      const promise = trackJobExecution(db, 'test-job', 'cron', handler, undefined, 1_000);
+      // Surface the rejection synchronously so the unhandled-rejection guard does not fire
+      // while we are still advancing fake timers.
+      const settled = expect(promise).rejects.toBeInstanceOf(HandlerTimeoutError);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await settled;
+
+      expect(handler).toHaveBeenCalled();
+      expect(db.failJobExecution).toHaveBeenCalledWith(
+        42,
+        expect.stringContaining('handler timed out after 1s')
+      );
+      expect(db.completeJobExecution).not.toHaveBeenCalled();
+    });
+
+    it('clears the timer when handler resolves before timeout (no false-positive failure)', async () => {
+      const db = mockDbForTracking();
+      const handler = vi.fn(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      });
+
+      const promise = trackJobExecution(db, 'test-job', 'cron', handler, undefined, 5_000);
+      await vi.advanceTimersByTimeAsync(500);
+      await promise;
+
+      // Advance well past the timeout — if the timer were still pending it would fire now.
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      expect(db.completeJobExecution).toHaveBeenCalledWith(42);
+      expect(db.failJobExecution).not.toHaveBeenCalled();
+    });
+
+    it('does not produce an unhandled rejection if the handler eventually rejects after timeout', async () => {
+      const db = mockDbForTracking();
+      const handlerLog = vi.spyOn(log, 'warn').mockImplementation(() => {});
+      let rejectHandler!: (err: Error) => void;
+      const handler = vi.fn(
+        () =>
+          new Promise<void>((_, reject) => {
+            rejectHandler = reject;
+          })
+      );
+
+      const promise = trackJobExecution(db, 'test-job', 'cron', handler, undefined, 1_000);
+      const settled = expect(promise).rejects.toBeInstanceOf(HandlerTimeoutError);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      await settled;
+
+      // Now let the handler's own promise reject — this would crash the process if
+      // trackJobExecution did not attach a .catch() to it after timing out.
+      rejectHandler(new Error('late SDK failure'));
+      await vi.runAllTimersAsync();
+      // Allow microtasks for the swallow handler to run.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(handlerLog).toHaveBeenCalledWith(expect.stringContaining('late SDK failure'));
+      handlerLog.mockRestore();
+    });
+
+    it('uses DEFAULT_HANDLER_TIMEOUT_MS when timeoutMs is omitted', async () => {
+      const db = mockDbForTracking();
+      const handler = vi.fn(() => new Promise<void>(() => {}));
+
+      const promise = trackJobExecution(db, 'test-job', 'cron', handler);
+      const settled = expect(promise).rejects.toBeInstanceOf(HandlerTimeoutError);
+
+      // Just under the default — should still be running.
+      await vi.advanceTimersByTimeAsync(DEFAULT_HANDLER_TIMEOUT_MS - 1);
+      expect(db.failJobExecution).not.toHaveBeenCalled();
+
+      // Cross the default.
+      await vi.advanceTimersByTimeAsync(1);
+      await settled;
+
+      expect(db.failJobExecution).toHaveBeenCalledWith(
+        42,
+        expect.stringContaining(`handler timed out after ${DEFAULT_HANDLER_TIMEOUT_MS / 1000}s`)
+      );
+    });
   });
 });

--- a/src/server/scheduler/jobs.ts
+++ b/src/server/scheduler/jobs.ts
@@ -1373,10 +1373,28 @@ export async function trackJobExecution(
   };
   notifyChange();
 
+  let timedOut = false;
   let timeoutHandle: NodeJS.Timeout | undefined;
   const handlerPromise = Promise.resolve().then(handler);
+  // Attach a rejection handler at creation time rather than waiting until after
+  // the timeout is observed. Promise.race already attaches a rejection observer
+  // synchronously, so a rejection between now and the post-timeout branch is
+  // already "handled" per spec — but a defensive catch here removes the
+  // dependency on that internal detail and gives us a clear place to surface
+  // post-timeout rejections by their own kind. The `timedOut` flag lets us tell
+  // the two cases apart: pre-timeout rejections are routed through the
+  // Promise.race below and handled in the catch block, post-timeout rejections
+  // land here and are logged with full Error context.
+  handlerPromise.catch((late) => {
+    if (timedOut) {
+      log.warn(`[Jobs] ${jobName} handler eventually rejected after timeout:`, late);
+    }
+  });
   const timeoutPromise = new Promise<never>((_, reject) => {
-    timeoutHandle = setTimeout(() => reject(new HandlerTimeoutError(timeoutMs)), timeoutMs);
+    timeoutHandle = setTimeout(() => {
+      timedOut = true;
+      reject(new HandlerTimeoutError(timeoutMs));
+    }, timeoutMs);
   });
 
   try {
@@ -1385,14 +1403,6 @@ export async function trackJobExecution(
     notifyChange();
   } catch (error) {
     if (error instanceof HandlerTimeoutError) {
-      // Detach the still-pending handler so a later rejection from it does not become
-      // an unhandled-rejection process crash. A late completion is harmless — we have
-      // already recorded the row as failed. Pass the late error as a separate logger
-      // argument so console.warn preserves stack/context rather than dropping it.
-      handlerPromise.catch((late) => {
-        log.warn(`[Jobs] ${jobName} handler eventually rejected after timeout:`, late);
-      });
-      log.error(`[Jobs] ${jobName} ${error.message} (trigger=${triggerType}); marking failed`);
       db.failJobExecution(execution.id, error.message);
       notifyChange();
       throw error;

--- a/src/server/scheduler/jobs.ts
+++ b/src/server/scheduler/jobs.ts
@@ -1309,15 +1309,42 @@ export class JobSkipped extends Error {
 }
 
 /**
+ * Default upper bound for any single job handler invocation. Healthy daily-summary
+ * and memory-update runs complete in well under a minute; anything pushing past 10
+ * minutes is presumed wedged (see issue #194 for the silent-hang failure mode this
+ * backstops). Overridable per call via the `timeoutMs` parameter.
+ */
+export const DEFAULT_HANDLER_TIMEOUT_MS = 10 * 60 * 1000;
+
+/**
+ * Thrown by trackJobExecution when a handler exceeds its timeout. The handler's
+ * own promise is left to settle on its own (we cannot cancel arbitrary user code),
+ * but the execution row is marked `failed` immediately so the scheduler is no
+ * longer blocked.
+ */
+export class HandlerTimeoutError extends Error {
+  constructor(public timeoutMs: number) {
+    super(`handler timed out after ${Math.round(timeoutMs / 1000)}s`);
+    this.name = 'HandlerTimeoutError';
+  }
+}
+
+/**
  * Execute a job with execution tracking: inserts a 'running' record,
  * calls the handler, then marks it 'completed', 'skipped', or 'failed'.
+ *
+ * `timeoutMs` bounds how long the handler may run before the row is force-failed.
+ * The handler promise itself is detached on timeout (its eventual settlement is
+ * swallowed so it cannot surface as an unhandled rejection); this is intentional,
+ * since the failure mode the timeout exists for is a handler that never resolves.
  */
 export async function trackJobExecution(
   db: DatabaseClient,
   jobName: string,
   triggerType: JobExecution['trigger_type'],
   handler: () => void | Promise<void>,
-  onJobChange?: () => void
+  onJobChange?: () => void,
+  timeoutMs: number = DEFAULT_HANDLER_TIMEOUT_MS
 ): Promise<void> {
   const execution = db.createJobExecution(jobName, triggerType);
   const notifyChange = () => {
@@ -1328,11 +1355,34 @@ export async function trackJobExecution(
     }
   };
   notifyChange();
+
+  let timeoutHandle: NodeJS.Timeout | undefined;
+  const handlerPromise = Promise.resolve().then(handler);
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutHandle = setTimeout(() => reject(new HandlerTimeoutError(timeoutMs)), timeoutMs);
+  });
+
   try {
-    await handler();
+    await Promise.race([handlerPromise, timeoutPromise]);
     db.completeJobExecution(execution.id);
     notifyChange();
   } catch (error) {
+    if (error instanceof HandlerTimeoutError) {
+      // Detach the still-pending handler so a later rejection from it does not become
+      // an unhandled-rejection process crash. A late completion is harmless — we have
+      // already recorded the row as failed.
+      handlerPromise.catch((late) => {
+        log.warn(
+          `[Jobs] ${jobName} handler eventually rejected after timeout: ${
+            late instanceof Error ? late.message : String(late)
+          }`
+        );
+      });
+      log.error(`[Jobs] ${jobName} ${error.message} (trigger=${triggerType}); marking failed`);
+      db.failJobExecution(execution.id, error.message);
+      notifyChange();
+      throw error;
+    }
     if (error instanceof JobSkipped) {
       db.skipJobExecution(execution.id, error.reason);
       notifyChange();
@@ -1342,6 +1392,8 @@ export async function trackJobExecution(
     db.failJobExecution(execution.id, message);
     notifyChange();
     throw error;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 }
 

--- a/src/server/scheduler/jobs.ts
+++ b/src/server/scheduler/jobs.ts
@@ -1321,12 +1321,29 @@ export const DEFAULT_HANDLER_TIMEOUT_MS = 10 * 60 * 1000;
  * own promise is left to settle on its own (we cannot cancel arbitrary user code),
  * but the execution row is marked `failed` immediately so the scheduler is no
  * longer blocked.
+ *
+ * The message uses `Math.ceil` on the seconds conversion so sub-second timeouts
+ * never render as `0s`.
  */
 export class HandlerTimeoutError extends Error {
   constructor(public timeoutMs: number) {
-    super(`handler timed out after ${Math.round(timeoutMs / 1000)}s`);
+    super(`handler timed out after ${Math.ceil(timeoutMs / 1000)}s`);
     this.name = 'HandlerTimeoutError';
   }
+}
+
+/**
+ * Options accepted by trackJobExecution.
+ *
+ * Kept as an object so callers that want a custom `timeoutMs` do not have to
+ * pass an `undefined` placeholder for `onJobChange`, and so new options can be
+ * added without re-ordering positional arguments.
+ */
+export interface TrackJobExecutionOptions {
+  /** Fired whenever the execution row transitions to a new status. */
+  onJobChange?: () => void;
+  /** Override the default handler timeout. */
+  timeoutMs?: number;
 }
 
 /**
@@ -1343,9 +1360,9 @@ export async function trackJobExecution(
   jobName: string,
   triggerType: JobExecution['trigger_type'],
   handler: () => void | Promise<void>,
-  onJobChange?: () => void,
-  timeoutMs: number = DEFAULT_HANDLER_TIMEOUT_MS
+  opts: TrackJobExecutionOptions = {}
 ): Promise<void> {
+  const { onJobChange, timeoutMs = DEFAULT_HANDLER_TIMEOUT_MS } = opts;
   const execution = db.createJobExecution(jobName, triggerType);
   const notifyChange = () => {
     try {
@@ -1370,13 +1387,10 @@ export async function trackJobExecution(
     if (error instanceof HandlerTimeoutError) {
       // Detach the still-pending handler so a later rejection from it does not become
       // an unhandled-rejection process crash. A late completion is harmless — we have
-      // already recorded the row as failed.
+      // already recorded the row as failed. Pass the late error as a separate logger
+      // argument so console.warn preserves stack/context rather than dropping it.
       handlerPromise.catch((late) => {
-        log.warn(
-          `[Jobs] ${jobName} handler eventually rejected after timeout: ${
-            late instanceof Error ? late.message : String(late)
-          }`
-        );
+        log.warn(`[Jobs] ${jobName} handler eventually rejected after timeout:`, late);
       });
       log.error(`[Jobs] ${jobName} ${error.message} (trigger=${triggerType}); marking failed`);
       db.failJobExecution(execution.id, error.message);
@@ -1435,7 +1449,7 @@ export function registerNarratorJobs(
           narratorMessageExcerptBytes
         );
       },
-      onJobChange
+      { onJobChange }
     );
   });
 
@@ -1459,7 +1473,7 @@ export function registerNarratorJobs(
           narratorMessageExcerptBytes
         );
       },
-      onJobChange
+      { onJobChange }
     );
   });
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -701,7 +701,7 @@ export class Server {
                 this.config.deliveryConfig?.narrator_message_excerpt_bytes ??
                   NARRATOR_MESSAGE_EXCERPT_BYTES
               ),
-            onJobChange
+            { onJobChange }
           );
         } catch (error) {
           log.error('[Server] Daily summary catch-up failed:', error);
@@ -735,7 +735,7 @@ export class Server {
                 this.config.deliveryConfig?.narrator_message_excerpt_bytes ??
                   NARRATOR_MESSAGE_EXCERPT_BYTES
               ),
-            onJobChange
+            { onJobChange }
           );
         } catch (error) {
           log.error('[Server] Memory update catch-up failed:', error);


### PR DESCRIPTION
## Summary

PR A of three for [#194](https://github.com/diegoscarabelli/system2/issues/194) — the silent-hang failure mode that left 44 daily-summary rows accumulating as `running` over 21 hours.

`trackJobExecution` now wraps every handler invocation in a `Promise.race` against `setTimeout(timeoutMs)`. Default is **10 minutes** (`DEFAULT_HANDLER_TIMEOUT_MS`), overridable per call. On expiry:

- The execution row is marked `failed` with error `'handler timed out after Xs'` via the existing `db.failJobExecution` path.
- A `HandlerTimeoutError` is thrown so the caller (cron tick or catch-up) unblocks.
- The handler's own promise is detached. A late rejection is logged at `warn`; a late resolution is silently ignored. The handler itself can't be cancelled (arbitrary user code), but it can no longer block the scheduler row.

This is the universal backstop. PRs B (per-delivery SDK timeout in `AgentHost`) and C (session-wedge detection in `deliverMessage`) are planned follow-ups against the underlying delivery-path hang. Even after those land, this layer remains valuable as defense in depth: no handler should be able to hang forever.

## Test plan

- [x] `pnpm check` — passes (pre-existing warning in `bash.test.ts` is unrelated).
- [x] `pnpm build` — passes.
- [x] `pnpm test` — 1093 tests pass. 4 new tests cover: timeout marks row failed + throws `HandlerTimeoutError`; timer is cleared on successful resolution (no false-positive); late handler rejection does not surface as unhandled rejection; default `DEFAULT_HANDLER_TIMEOUT_MS` is used when `timeoutMs` is omitted.
- [ ] Manual smoke after merge: confirm no behavior change for normal daily-summary / memory-update runs (typically under 60s).

Fixes part of #194.