### PR TITLE
refactor(chat): unify live chat-cache via observable MessageHistory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.14] - 2026-05-19
+## [0.4.0] - 2026-05-20
+
+### Fixed
+
+- The "Run `system2 config` to refresh `<provider>` authentication and restart the server" hint now actually appears in the live chat after an Anthropic OAuth 401, without waiting for a page reload. The root cause was structural: the chat view was built by two parallel systems that drifted. The server-side `MessageHistory` (`chatCache`) is authoritative and complete — failover system rows pushed by `AgentHost.reinitializeWithProvider` include the hint inside their `detail` body. But the live wire path was `provider_change.reason → addSystemMessage(reason)`, which dropped the `detail` field entirely; the UI saw only "401 auth error, switched to google" and never received the body with the hint. Only a reload (which calls `chat_history` and rehydrates from `chatCache`) made the hint visible. Fixes [#197](https://github.com/diegoscarabelli/system2/issues/197).
+
+### Changed
+
+- `MessageHistory` is now observable: every `push()` notifies subscribers, and `WebSocketHandler` forwards each push as a new `chat_message_added` event carrying the full `ChatMessage`. The UI's committed-message list mirrors `chatCache` exactly via that single event — user messages, finalized assistant turns, failover system rows, LLM-error system rows, and compaction notices all flow through it. The parallel UI-side synthesis paths (`provider_change.reason → addSystemMessage`, `assistant_end.errorMessage → addSystemMessage`, `compaction_start/end → addSystemMessage`, `user_message_broadcast → addUserMessage`) are gone. Streaming events (`assistant_chunk`, `thinking_chunk`, `tool_call_*`) still drive a transient draft above the committed list; when the turn ends, the canonical assistant row arrives via `chat_message_added` and the draft is cleared atomically with the append. The new invariant: **anything visible as a row in the chat lives in `MessageHistory`**.
+- Steering ordering is now chronologically correct in `chatCache`. Pre-refactor the UI-side `addUserMessage` action committed any in-flight assistant content as a "partial" message ABOVE the user's steering text, so the active tab saw `[assistant_partial, user_steering]` — but `chatCache` itself had `[user_steering, assistant_partial]` because the server pushed the user row before the SDK's `streamingBehavior: 'steer'` interrupt fired `message_end`. Other tabs and post-reload renders saw the wrong order. `createHistoryCaptureSubscriber` now returns `{ subscriber, flushPartial }`; `Server` installs `flushPartial` on `AgentHost` via a new `setHistoryFlushHook` method, and `WebSocketHandler` calls `host.flushPartialTurn()` on `steering_message` BEFORE pushing the user row. The flush commits whatever thinking / tool calls / text the history-capture accumulator currently holds and resets it, so the SDK's eventual `message_end` for the interrupted turn finds empty buffers and is a no-op for the partial-commit branch. The persisted order is now `[assistant_partial, user_steering]` for every tab and every reload.
+- The LLM-error row is now the sole carrier of the raw error text. Pre-refactor every failover system row (`reinitializeWithProvider`'s `detail`) interpolated `${errorMessage}` into its body — once visible in the UI-only synthesized "LLM error" row, once embedded in the failover row, so the error appeared twice. The "LLM error" row used to be a client-only synthesis from `assistant_end.errorMessage`; now `history-capture` pushes a `LLM error\n\n${errorMessage}` system row into `chatCache` on `stopReason='error'` (so it persists across reload), and all five failover detail strings in `host.ts` (cooldown-by-another-agent rotate/switch, post-`markKeyFailed` rotate/switch, all-providers-unavailable) drop the embedded `errorMessage`. They now carry only the routing description (`"on anthropic, switching to google"`) and the re-auth hint when applicable.
+
+### Removed
+
+- WebSocket protocol cleanup. The server and UI ship together (single npm package), so these changes are not breaking for any external consumer:
+  - **Removed** `user_message_broadcast` (folded into `chat_message_added`).
+  - **Removed** `provider_change.reason` (chat row arrives via `chat_message_added`; event is now indicator-only).
+  - **Removed** `assistant_end.errorMessage` (LLM-error row arrives via `chat_message_added` from history-capture).
+  - **Added** optional `id` on `user_message` / `steering_message` client events; server reuses it as the `ChatMessage.id`, so the originating tab's optimistic insert dedups against its own echo by id.
+
+
 
 ### Added
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -12,7 +12,7 @@ The UI communicates with the server over a single WebSocket connection. The serv
 
 WebSocket connects to the server port (default 4242). In development, Vite proxies `ws://localhost:3001/ws` to the backend.
 
-On connect, the server sends a `chat_history` message with the Guide agent's recent messages from its per-agent `MessageHistory` (ring buffer, default 1000 messages). The server is the single source of truth for chat history: the UI does not persist messages.
+On connect, the server sends a `chat_history` message with the Guide agent's recent messages from its per-agent `MessageHistory` (ring buffer, default 1000 messages). The server is the single source of truth for chat history: the UI mirrors `MessageHistory` exactly. Every push to `MessageHistory` is broadcast to subscribed clients as a `chat_message_added` event so the UI's committed-message list never drifts from the server.
 
 ## Multi-Agent Routing
 
@@ -24,16 +24,16 @@ The client tracks an `activeAgentId` (the agent currently displayed in the chat 
 
 ```typescript
 type ClientMessage =
-  | { type: 'user_message'; content: string; agentId?: number }
-  | { type: 'steering_message'; content: string; agentId?: number }
+  | { type: 'user_message'; content: string; agentId?: number; id?: string }
+  | { type: 'steering_message'; content: string; agentId?: number; id?: string }
   | { type: 'abort'; agentId?: number }
   | { type: 'switch_agent'; agentId: number };
 ```
 
 | Message | Description |
 | --- | --- |
-| `user_message` | Standard user input. `agentId` targets a specific agent (defaults to active). |
-| `steering_message` | Priority message inserted ASAP into the agent loop (interrupts current work). |
+| `user_message` | Standard user input. `agentId` targets a specific agent (defaults to active). Optional `id` is reused as the `ChatMessage.id` when the server pushes to `chatCache`, so the echoed `chat_message_added` dedups against the originating tab's optimistic insert. |
+| `steering_message` | Priority message inserted ASAP into the agent loop (interrupts current work). Same `id` convention as `user_message`. |
 | `abort` | Cancel current agent execution for the specified (or active) agent. |
 | `switch_agent` | Switch the active chat to a different agent. Server responds with that agent's `chat_history`, `provider_info`, an `agent_busy_state` snapshot (seeds busy + context usage), and `ready_for_input` (if idle). |
 
@@ -44,17 +44,17 @@ type ServerMessage =
   | { type: 'thinking_chunk'; content: string; agentId?: number }
   | { type: 'thinking_end'; agentId?: number }
   | { type: 'assistant_chunk'; content: string; agentId?: number }
-  | { type: 'assistant_end'; agentId?: number; errorMessage?: string }
+  | { type: 'assistant_end'; agentId?: number }
   | { type: 'tool_call_start'; name: string; input?: string; agentId?: number }
   | { type: 'tool_call_end'; name: string; result: string; agentId?: number }
   | { type: 'tool_call_progress'; name: string; message: string; agentId?: number }
   | { type: 'artifact'; url: string; title?: string; filePath?: string }
   | { type: 'provider_info'; provider: string; agentId: number }
-  | { type: 'provider_change'; provider: string; reason?: string; agentId: number }
+  | { type: 'provider_change'; provider: string; agentId: number }
   | { type: 'error'; message: string; agentId?: number }
   | { type: 'ready_for_input'; agentId?: number }
   | { type: 'chat_history'; messages: ChatMessage[]; agentId: number }
-  | { type: 'user_message_broadcast'; id: string; content: string; timestamp: number; agentId?: number }
+  | { type: 'chat_message_added'; message: ChatMessage; agentId: number }
   | { type: 'compaction_start'; agentId?: number }
   | { type: 'compaction_end'; agentId?: number }
   // Push notifications for UI panels
@@ -68,17 +68,17 @@ type ServerMessage =
 | Message | Description |
 | --- | --- |
 | `thinking_chunk` / `thinking_end` | Streaming extended thinking blocks |
-| `assistant_chunk` / `assistant_end` | Streaming response text. `assistant_end` carries `errorMessage` when the LLM stop reason was an error; the UI renders it as a collapsible system message in the chat timeline. |
+| `assistant_chunk` / `assistant_end` | Streaming response text. `assistant_end` is a stream-over signal; the canonical assistant row (and any LLM-error system row) arrives via `chat_message_added`. |
 | `tool_call_start` / `tool_call_end` | Tool execution lifecycle |
 | `tool_call_progress` | Heartbeat progress from a long-running tool (e.g., bash `::system2::` sentinel). Carries the progress `message` for UI display. |
 | `artifact` | Display artifact in a UI tab. Includes `title` (from DB or filename) and `filePath` (absolute path for tab dedup). Sent when `show_artifact` completes. |
 | `provider_info` | Sent on connect/switch: current LLM provider for an agent |
-| `provider_change` | Sent on failover: provider switched. Includes `reason` (e.g., "503 server error, switched to anthropic") and `agentId` so the UI routes the system message to the correct agent chat |
+| `provider_change` | Sent on failover: provider switched. Indicator-only — the chat row describing the switch arrives via `chat_message_added` from the server-side `pushSystemMessage` in `reinitializeWithProvider`. |
 | `error` | Error message |
 | `ready_for_input` | Agent finished, ready for next message |
 | `chat_history` | Sent on connect (Guide) and on `switch_agent`: recent messages for the specified agent |
-| `user_message_broadcast` | User message from another tab, broadcast to all other connected clients |
-| `compaction_start` / `compaction_end` | Auto-compaction lifecycle (context window management). UI shows a transient "Compacting..." indicator while in flight; on `compaction_end` the indicator clears and the chat timeline gets a persisted "Context compacted" (or `failed: ...` / `aborted`) system message in chronological position |
+| `chat_message_added` | Fired on every push to the target agent's `chatCache`. Carries the full `ChatMessage`. Every committed chat row — user, assistant, failover system messages, LLM errors, compaction notices — reaches the UI through this single event. UI dedups by `id`. |
+| `compaction_start` / `compaction_end` | Auto-compaction lifecycle. UI shows a transient "Compacting..." indicator while in flight; the persisted "Context compacted" / `failed: ...` / `aborted` system row arrives via `chat_message_added`. |
 | `board_changed` | Broadcast when `write_system2_db` modifies a project, task, task_link, or task_comment. UI panels refetch `/api/kanban`. |
 | `agents_changed` | Broadcast when an agent is spawned, terminated, or resurrected. UI panels refetch `/api/agents`. |
 | `artifacts_changed` | Broadcast when `write_system2_db` modifies an artifact. UI panels refetch `/api/artifacts`. |
@@ -93,28 +93,41 @@ All database writes by agents go through `write_system2_db`, which fires an `onW
 
 ```text
 User types message
-  -> UI sends { type: 'user_message', content, agentId }
+  -> UI optimistically adds the user row locally (with a client-generated id)
+  -> UI sends { type: 'user_message', content, agentId, id }
     -> WebSocketHandler resolves target agent via agentId (default: active)
-      -> Captures user message in agent's chatCache
-      -> Broadcasts user_message_broadcast (with agentId) to other tabs
+      -> Pushes user message into agent's chatCache (using the client's id)
+        -> chatCache fires its push listener
+          -> chat_message_added (carrying the full ChatMessage) is sent to every
+             subscribed client. The originating tab dedups against its
+             optimistic insert by id; other tabs see the message for the first
+             time.
       -> Calls agentHost.prompt(content)
         -> Agent processes (may use tools, think, generate text)
-          -> Events stream back (all tagged with agentId):
+          -> Streaming events flow to clients (all tagged with agentId):
              thinking_chunk* -> thinking_end
              tool_call_start -> tool_call_end (repeated per tool)
-             assistant_chunk* -> assistant_end
-             agent_busy_state (busy=false, broadcast — carries contextPercent)
-             ready_for_input
+             assistant_chunk* -> assistant_end (stream-over signal only)
+          -> history-capture finalizes the turn, pushes the assistant message
+             (and, on stopReason='error', a "LLM error" system row) into
+             chatCache -> chat_message_added carries each row to the UI; the
+             draft is cleared atomically with the canonical assistant append.
+          -> agent_busy_state (busy=false, broadcast — carries contextPercent)
+          -> ready_for_input
 ```
 
 ### Steering Message
 
 ```text
 User sends steering while agent is working
-  -> UI sends { type: 'steering_message', content, agentId }
-    -> WebSocketHandler calls agentHost.prompt(content, { isSteering: true })
-      -> Pi SDK inserts message ASAP into agent loop
-      -> Agent responds, streaming continues
+  -> UI optimistically adds the user row locally
+  -> UI sends { type: 'steering_message', content, agentId, id }
+    -> WebSocketHandler pushes user to chatCache (echoes via chat_message_added)
+    -> Calls agentHost.prompt(content, { isSteering: true })
+      -> Pi SDK inserts message ASAP into agent loop, interrupting the current
+         turn. history-capture's message_end pushes the partial assistant
+         (which arrives via chat_message_added and clears the streaming draft),
+         then the steered turn begins.
 ```
 
 ### Agent Switching
@@ -135,7 +148,7 @@ User clicks agent in AgentPane
 
 ### Steering
 
-Messages sent while an agent is streaming are delivered immediately as `steering_message`, which uses `streamingBehavior: 'steer'` to interrupt the current turn. The UI commits any in-progress turn events (thinking blocks, tool calls, partial text) as a snapshot message so they remain visible, then adds the user's message below them.
+Messages sent while an agent is streaming are delivered immediately as `steering_message`, which uses `streamingBehavior: 'steer'` to interrupt the current turn. The interrupt causes the Pi SDK to fire `message_end` for the in-flight turn; `history-capture` finalizes that turn into a persisted assistant message (and, on error, an LLM-error system row), which the UI receives via `chat_message_added`. The new steered turn then begins.
 
 ## Artifact postMessage Bridge
 
@@ -172,11 +185,18 @@ On shutdown, the server sends a WebSocket close frame with code `1001` ("Going A
 
 Multiple browser tabs each open their own WebSocket connection. All tabs receive the same agent events (thinking, text, tool calls) because each handler subscribes independently to the agent.
 
-User messages are broadcast to other tabs: when tab A sends a message, the handler sends `user_message_broadcast` (with `agentId`) to all other connected clients so they display the message immediately. The sending tab adds the message locally (optimistic UI). On reconnect, all tabs receive the full history via `chat_history`.
+User messages reach other tabs through the same `chat_message_added` event used for all chat rows: when tab A sends, the server pushes to `chatCache` and every subscribed tab — including tab A — receives the row. The originating tab dedups against its optimistic insert by `id` (the client generates the id and the server reuses it). On reconnect, all tabs receive the full history via `chat_history`.
 
 ## History Capture
 
-Each `AgentHost` owns its own `MessageHistory` (chat cache) stored at `~/.system2/sessions/{role}_{id}/chat-cache.json`. Assistant message history is captured by a **single subscriber** registered in `Server` per agent (not per-handler), preventing duplicate entries when multiple tabs are open. User messages are captured by the handler that receives them (one per user action). Tool-only turns (thinking + tool calls with no text output) are also persisted, and compaction events (`compaction_start`/`compaction_end`) are recorded as system messages in the cache.
+Each `AgentHost` owns its own `MessageHistory` (chat cache) stored at `~/.system2/sessions/{role}_{id}/chat-cache.json`. `MessageHistory` is observable: every `push()` notifies subscribers, and `WebSocketHandler` subscribes per active agent to forward each push as `chat_message_added`. This single mechanism delivers:
+
+- Assistant turns (and LLM-error system rows) captured by `historyCaptureSubscriber` on `message_end` (registered once in `Server`, not per-handler — duplicate captures would write the row twice).
+- User messages captured by `WebSocketHandler.handleClientMessage` (one push per user action; client-generated `id` is reused so the originating tab can dedup).
+- Failover system rows pushed by `AgentHost.pushSystemMessage` in `reinitializeWithProvider` (e.g., `"401 auth error, switched to google"` with the `detail` body containing the re-auth hint).
+- Compaction system rows pushed by `historyCaptureSubscriber` on `compaction_start` / `compaction_end`.
+
+The invariant: anything visible as a row in the chat lives in `MessageHistory`. The UI's committed-message list mirrors it exactly.
 
 ## WebSocketHandler (`handler.ts`)
 
@@ -188,15 +208,16 @@ Each WebSocket connection gets its own `WebSocketHandler` instance. It:
 4. Converts Pi SDK events to `ServerMessage` types (all tagged with `agentId`):
    - `message_update` (with thinking) -> `thinking_chunk`; transition to text/tool/end -> `thinking_end`
    - `message_update` (with text) -> `assistant_chunk`
-   - `message_end` -> `assistant_end` (with `errorMessage` when `stopReason` is `'error'`)
+   - `message_end` -> `assistant_end` (stream-over signal only; the canonical assistant row and any LLM-error row reach the UI via `chat_message_added`)
    - `tool_execution_start` -> `tool_call_start`
    - `tool_execution_update` (heartbeat only) -> `tool_call_progress`
    - `tool_execution_end` -> `tool_call_end`
    - `agent_end` -> `ready_for_input` (context usage delivery happens via `AgentHost.onBusyChange` -> `agent_busy_state` broadcast)
-5. Captures user messages in the target agent's chat cache and broadcasts to other tabs
-6. Handles `switch_agent` by adding a subscription (if not already subscribed) and sending the new agent's state
-7. Records non-Guide user messages in the `ConversationSummarizer` for Guide notification
-8. Emits `artifact` message when `show_artifact` completes (live reload is handled by UI polling)
+5. Subscribes to the agent's `chatCache.push` events and forwards each push as `chat_message_added` — single mechanism for delivering user / assistant / system rows to every connected client
+6. Captures the user message into the target agent's chatCache (which fires `chat_message_added` to every subscribed client, including this one)
+7. Handles `switch_agent` by adding a subscription pair (agent events + chatCache pushes; if not already subscribed) and sending the new agent's state
+8. Records non-Guide user messages in the `ConversationSummarizer` for Guide notification
+9. Emits `artifact` message when `show_artifact` completes (live reload is handled by UI polling)
 
 ## See Also
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -165,7 +165,7 @@ User clicks agent in AgentPane
 
 ### Steering
 
-Messages sent while an agent is streaming are delivered immediately as `steering_message`, which uses `streamingBehavior: 'steer'` to interrupt the current turn. The interrupt causes the Pi SDK to fire `message_end` for the in-flight turn; `history-capture` finalizes that turn into a persisted assistant message (and, on error, an LLM-error system row), which the UI receives via `chat_message_added`. The new steered turn then begins.
+Messages sent while an agent is streaming are delivered as `steering_message`, which uses `streamingBehavior: 'steer'` to interrupt the current turn. Persistence order is driven server-side: `WebSocketHandler` first calls `host.flushPartialTurn()` (which commits whatever thinking / tool calls / text the in-flight turn has accumulated into chatCache via `history-capture`), then pushes the steering user row, then calls `agentHost.prompt(content, { isSteering: true })`. The SDK's eventual `message_end` for the interrupted turn finds the history-capture accumulator empty (already flushed) and is a no-op for the partial-commit branch. If any tool was still running at flush time, its later `tool_execution_end` produces a follow-up assistant row carrying the completed tool_call so the result isn't lost; the new steered turn proceeds after that.
 
 ## Artifact postMessage Bridge
 

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -94,6 +94,8 @@ All database writes by agents go through `write_system2_db`, which fires an `onW
 ```text
 User types message
   -> UI optimistically adds the user row locally (with a client-generated id)
+     when the agent is idle. For steering (mid-stream) the optimistic insert
+     is skipped — see "Steering Message" below.
   -> UI sends { type: 'user_message', content, agentId, id }
     -> WebSocketHandler resolves target agent via agentId (default: active)
       -> Pushes user message into agent's chatCache (using the client's id)
@@ -120,17 +122,23 @@ User types message
 
 ```text
 User sends steering while agent is working
-  -> UI optimistically adds the user row locally
+  -> UI does NOT optimistically insert the user row (skipped when streaming):
+     server flushes the in-flight assistant partial BEFORE pushing the user
+     row, so a local insert would land the user row before the partial in
+     the UI — contradicting the persisted order. Both rows arrive via
+     chat_message_added in correct order.
   -> UI sends { type: 'steering_message', content, agentId, id }
     -> WebSocketHandler:
        1. host.flushPartialTurn() — commits whatever the in-flight assistant
           turn has accumulated (thinking + tool calls + text) into chatCache
           first, so the persisted order is [assistant_partial, user_steering]
           rather than racing the SDK's eventual message_end against the
-          user-row push. No-op when nothing is in flight.
+          user-row push. No-op when nothing is in flight. If any tool_calls
+          were still running at flush time, their toolName+input is queued
+          in history-capture so the later tool_execution_end can be matched
+          and recorded as a follow-up assistant row (no data lost).
        2. host.chatCache.push(user message) — echoes back via
-          chat_message_added; the optimistic row in the originating tab
-          dedups by id; other tabs see the row for the first time.
+          chat_message_added; other tabs see the row for the first time.
        3. agentHost.prompt(content, { isSteering: true })
           -> Pi SDK inserts message ASAP into agent loop, interrupting the
              current turn. The SDK's eventual message_end finds the

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -122,12 +122,21 @@ User types message
 User sends steering while agent is working
   -> UI optimistically adds the user row locally
   -> UI sends { type: 'steering_message', content, agentId, id }
-    -> WebSocketHandler pushes user to chatCache (echoes via chat_message_added)
-    -> Calls agentHost.prompt(content, { isSteering: true })
-      -> Pi SDK inserts message ASAP into agent loop, interrupting the current
-         turn. history-capture's message_end pushes the partial assistant
-         (which arrives via chat_message_added and clears the streaming draft),
-         then the steered turn begins.
+    -> WebSocketHandler:
+       1. host.flushPartialTurn() — commits whatever the in-flight assistant
+          turn has accumulated (thinking + tool calls + text) into chatCache
+          first, so the persisted order is [assistant_partial, user_steering]
+          rather than racing the SDK's eventual message_end against the
+          user-row push. No-op when nothing is in flight.
+       2. host.chatCache.push(user message) — echoes back via
+          chat_message_added; the optimistic row in the originating tab
+          dedups by id; other tabs see the row for the first time.
+       3. agentHost.prompt(content, { isSteering: true })
+          -> Pi SDK inserts message ASAP into agent loop, interrupting the
+             current turn. The SDK's eventual message_end finds the
+             history-capture accumulator empty (already flushed in step 1)
+             and is a no-op for the partial-commit branch; the steered turn
+             begins.
 ```
 
 ### Agent Switching

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diegoscarabelli/system2",
-  "version": "0.3.14",
+  "version": "0.4.0",
   "description": "A multi-agent data platform for solo analysts",
   "author": "Diego Scarabelli",
   "license": "AGPL-3.0-only",

--- a/src/server/agents/host.test.ts
+++ b/src/server/agents/host.test.ts
@@ -2367,7 +2367,7 @@ describe('AgentHost', () => {
         null,
         [],
         '429 rate limited, switched to anthropic',
-        'on google, switching to anthropic\n\nError 429: rate limit exceeded'
+        'on google, switching to anthropic'
       );
     });
 
@@ -2413,7 +2413,7 @@ describe('AgentHost', () => {
         null,
         [],
         '429 rate limited, rotating to next key',
-        'on google, rotating to next key\n\nError 429: rate limit exceeded'
+        'on google, rotating to next key'
       );
     });
 
@@ -2457,7 +2457,7 @@ describe('AgentHost', () => {
       const pushed = internal._chatCache.push.mock.calls[0][0];
       expect(pushed.role).toBe('system');
       expect(pushed.content).toBe(
-        '401 auth error, all providers unavailable\n\non cerebras, all providers unavailable\n\nError 401: Unauthorized'
+        '401 auth error, all providers unavailable\n\non cerebras, all providers unavailable'
       );
     });
   });
@@ -2586,7 +2586,7 @@ describe('AgentHost', () => {
         null,
         [],
         '400 client error, switched to google',
-        'on anthropic, switching to google\n\nError 400: credit balance too low'
+        'on anthropic, switching to google'
       );
     });
 
@@ -2635,10 +2635,11 @@ describe('AgentHost', () => {
       expect(internal.reinitializeWithProvider).not.toHaveBeenCalled();
       // Busy should be cleared
       expect(internal.busy).toBe(false);
-      // Should show error details in the exhausted message
+      // Error detail isn't duplicated here — the "LLM error" system row
+      // pushed by history-capture on the same message_end already carries it.
       const pushed = internal._chatCache.push.mock.calls[0][0];
       expect(pushed.content).toBe(
-        '400 client error, all providers unavailable\n\non anthropic, all providers unavailable\n\nError 400: credit balance too low'
+        '400 client error, all providers unavailable\n\non anthropic, all providers unavailable'
       );
     });
 

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -5,6 +5,7 @@
  * Includes automatic failover when API errors occur.
  */
 
+import { randomUUID } from 'node:crypto';
 import {
   appendFileSync,
   existsSync,
@@ -1629,7 +1630,10 @@ export class AgentHost {
   private pushSystemMessage(content: string): void {
     if (!this._chatCache) return;
     this._chatCache.push({
-      id: `msg-${Date.now()}`,
+      // randomUUID, not msg-${Date.now()}: dedup-by-id in the UI's appendMessage
+      // makes id uniqueness load-bearing — failover rows often fire close
+      // together (e.g. refresh-then-failover) and millisecond ids would collide.
+      id: `msg-${randomUUID()}`,
       role: 'system',
       content,
       timestamp: Date.now(),
@@ -1985,7 +1989,7 @@ export class AgentHost {
       }
 
       this._chatCache.push({
-        id: `msg-${Date.now()}`,
+        id: `msg-${randomUUID()}`,
         role: 'system',
         content: cacheContent,
         timestamp: details.timestamp,

--- a/src/server/agents/host.ts
+++ b/src/server/agents/host.ts
@@ -264,6 +264,9 @@ export class AgentHost {
   private authResolver: AuthResolver;
   private modelRegistry: ModelRegistry;
   private listeners: Set<(event: AgentSessionEvent) => void> = new Set();
+  /** Set by Server via setHistoryFlushHook so WebSocketHandler can commit the
+   *  in-flight assistant draft to chatCache before pushing a steering user row. */
+  private historyFlushHook: (() => void) | null = null;
   private currentProvider: LlmProvider;
   private currentKeyIndex = 0;
   private currentTier: AuthTier = 'api_keys';
@@ -1123,10 +1126,13 @@ export class AgentHost {
           this.currentTier,
           statusCode
         );
+        // No errorMessage interpolation: the full error text already lives in
+        // the "LLM error" system row pushed by history-capture on the same
+        // message_end. Embedding it again here would duplicate it in the chat.
         const detail =
           nextProvider === this.currentProvider
-            ? `on ${this.currentProvider}, rotating to next key\n\n${errorMessage}${reauthHint}`
-            : `on ${this.currentProvider} (key already in cooldown), switching to ${nextProvider}\n\n${errorMessage}${reauthHint}`;
+            ? `on ${this.currentProvider}, rotating to next key${reauthHint}`
+            : `on ${this.currentProvider} (key already in cooldown), switching to ${nextProvider}${reauthHint}`;
         log.info(
           `[AgentHost] Key ${this.currentProvider}:${this.currentKeyIndex} already in cooldown`
         );
@@ -1262,7 +1268,7 @@ export class AgentHost {
         if (nextProvider) {
           if (nextProvider === this.currentProvider) {
             const reason = `${errorPrefix}, rotating to next key`;
-            const detail = `on ${this.currentProvider}, rotating to next key\n\n${errorMessage}${this.oauthReauthHintFor(this.currentProvider, this.currentTier, statusCode)}`;
+            const detail = `on ${this.currentProvider}, rotating to next key${this.oauthReauthHintFor(this.currentProvider, this.currentTier, statusCode)}`;
             log.info(`[AgentHost] Rotating to next key for ${this.currentProvider}`);
             await this.reinitializeWithProvider(
               nextProvider,
@@ -1282,7 +1288,7 @@ export class AgentHost {
             await this.compactForProvider(nextProvider);
 
             const reason = `${errorPrefix}, switched to ${nextProvider}`;
-            const detail = `on ${fromProvider}, switching to ${nextProvider}\n\n${errorMessage}${this.oauthReauthHintFor(fromProvider, fromTier, statusCode)}`;
+            const detail = `on ${fromProvider}, switching to ${nextProvider}${this.oauthReauthHintFor(fromProvider, fromTier, statusCode)}`;
             log.info(`[AgentHost] Failing over from ${fromProvider} to ${nextProvider}`);
             await this.reinitializeWithProvider(
               nextProvider,
@@ -1297,7 +1303,7 @@ export class AgentHost {
       }
 
       this.pushSystemMessage(
-        `${errorPrefix}, all providers unavailable\n\non ${this.currentProvider}, all providers unavailable\n\n${errorMessage}${this.oauthReauthHintFor(this.currentProvider, this.currentTier, statusCode)}`
+        `${errorPrefix}, all providers unavailable\n\non ${this.currentProvider}, all providers unavailable${this.oauthReauthHintFor(this.currentProvider, this.currentTier, statusCode)}`
       );
       log.info('[AgentHost] No fallback providers available, error will be surfaced to user');
 
@@ -1821,6 +1827,24 @@ export class AgentHost {
   subscribe(listener: (event: AgentSessionEvent) => void): () => void {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
+  }
+
+  /**
+   * Server installs the history-capture's flushPartial here. Called from
+   * WebSocketHandler before pushing a steering user message: commits the
+   * in-flight assistant draft into chatCache so the persisted order is
+   * [assistant_partial, user_steering] instead of the race-prone reverse.
+   * After this fires, the SDK's eventual message_end for the interrupted
+   * turn finds the history-capture buffers empty and is a no-op for the
+   * partial-commit branch.
+   */
+  setHistoryFlushHook(fn: () => void): void {
+    this.historyFlushHook = fn;
+  }
+
+  /** Invoke the installed history-capture flush hook (no-op if not wired). */
+  flushPartialTurn(): void {
+    this.historyFlushHook?.();
   }
 
   /**

--- a/src/server/chat/history-capture.test.ts
+++ b/src/server/chat/history-capture.test.ts
@@ -340,5 +340,94 @@ describe('createHistoryCaptureSubscriber', () => {
       flushPartial();
       expect(cache.push).not.toHaveBeenCalled();
     });
+
+    it('records tool_execution_end as a follow-up row when the tool was flushed mid-run', () => {
+      // Steering during tool use: flushPartial pushes the assistant message
+      // with the tool_call still in 'running' state. When tool_execution_end
+      // fires later, history-capture must push a follow-up assistant row so
+      // the result isn't dropped.
+      const cache = mockCache();
+      const { subscriber: sub, flushPartial } = createHistoryCaptureSubscriber(
+        () => cache as unknown as MessageHistory
+      );
+
+      sub(toolStart('bash', 'ls'));
+      flushPartial();
+      // First push: assistant row with tool_call still 'running'.
+      expect(cache.push).toHaveBeenCalledOnce();
+      const flushedMsg = cache.messages[0] as {
+        role: string;
+        turnEvents: Array<{ data: { status: string } }>;
+      };
+      expect(flushedMsg.role).toBe('assistant');
+      expect(flushedMsg.turnEvents[0].data.status).toBe('running');
+
+      // Tool completes after the flush — follow-up row carries the result.
+      sub(toolEnd('bash', 'a.txt b.txt'));
+      expect(cache.push).toHaveBeenCalledTimes(2);
+      const followup = cache.messages[1] as {
+        role: string;
+        content: string;
+        turnEvents: Array<{
+          type: string;
+          data: { status: string; result: string; input: string };
+        }>;
+      };
+      expect(followup.role).toBe('assistant');
+      expect(followup.content).toBe('');
+      expect(followup.turnEvents).toHaveLength(1);
+      expect(followup.turnEvents[0].type).toBe('tool_call');
+      expect(followup.turnEvents[0].data.status).toBe('completed');
+      expect(followup.turnEvents[0].data.result).toBe('a.txt b.txt');
+      expect(followup.turnEvents[0].data.input).toBe('ls');
+    });
+
+    it('matches multiple concurrent flushed tools in FIFO order by name', () => {
+      const cache = mockCache();
+      const { subscriber: sub, flushPartial } = createHistoryCaptureSubscriber(
+        () => cache as unknown as MessageHistory
+      );
+
+      sub(toolStart('bash', 'ls'));
+      sub(toolStart('bash', 'pwd'));
+      flushPartial();
+      expect(cache.push).toHaveBeenCalledOnce();
+
+      sub(toolEnd('bash', 'a.txt'));
+      sub(toolEnd('bash', '/home'));
+
+      expect(cache.push).toHaveBeenCalledTimes(3);
+      const first = cache.messages[1] as {
+        turnEvents: Array<{ data: { input: string; result: string } }>;
+      };
+      const second = cache.messages[2] as {
+        turnEvents: Array<{ data: { input: string; result: string } }>;
+      };
+      // FIFO: first ls→a.txt, then pwd→/home.
+      expect(first.turnEvents[0].data.input).toBe('ls');
+      expect(first.turnEvents[0].data.result).toBe('a.txt');
+      expect(second.turnEvents[0].data.input).toBe('pwd');
+      expect(second.turnEvents[0].data.result).toBe('/home');
+    });
+
+    it('does NOT push a follow-up row when the tool completion matches the current in-flight turn', () => {
+      // Normal flow (no flush): tool_execution_end updates currentTurnEvents
+      // in place, message_end commits the whole turn. No follow-up.
+      const cache = mockCache();
+      const { subscriber: sub } = createHistoryCaptureSubscriber(
+        () => cache as unknown as MessageHistory
+      );
+
+      sub(toolStart('bash', 'ls'));
+      sub(toolEnd('bash', 'a.txt'));
+      sub(messageEnd());
+
+      expect(cache.push).toHaveBeenCalledOnce();
+      const msg = cache.messages[0] as {
+        turnEvents: Array<{ data: { status: string; result: string } }>;
+      };
+      expect(msg.turnEvents[0].data.status).toBe('completed');
+      expect(msg.turnEvents[0].data.result).toBe('a.txt');
+    });
   });
 });

--- a/src/server/chat/history-capture.test.ts
+++ b/src/server/chat/history-capture.test.ts
@@ -28,8 +28,11 @@ function thinkingDelta(delta: string): AgentSessionEvent {
   } as unknown as AgentSessionEvent;
 }
 
-function messageEnd(): AgentSessionEvent {
-  return { type: 'message_end' } as unknown as AgentSessionEvent;
+function messageEnd(opts?: { stopReason?: string; errorMessage?: string }): AgentSessionEvent {
+  const message = opts
+    ? { stopReason: opts.stopReason, errorMessage: opts.errorMessage }
+    : undefined;
+  return { type: 'message_end', message } as unknown as AgentSessionEvent;
 }
 
 function toolStart(toolName: string, args?: unknown): AgentSessionEvent {
@@ -48,7 +51,9 @@ function toolEnd(toolName: string, result?: string, isError = false): AgentSessi
 describe('createHistoryCaptureSubscriber', () => {
   it('captures text-only assistant turn', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+    const { subscriber: sub } = createHistoryCaptureSubscriber(
+      () => cache as unknown as MessageHistory
+    );
 
     sub(textDelta('Hello '));
     sub(textDelta('world'));
@@ -63,7 +68,9 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('captures tool-only turn (no text)', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+    const { subscriber: sub } = createHistoryCaptureSubscriber(
+      () => cache as unknown as MessageHistory
+    );
 
     sub(thinkingDelta('Let me think...'));
     sub(toolStart('read_file', { path: '/tmp/foo' }));
@@ -85,7 +92,9 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('does not push when message_end fires with no content or events', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+    const { subscriber: sub } = createHistoryCaptureSubscriber(
+      () => cache as unknown as MessageHistory
+    );
 
     sub(messageEnd());
 
@@ -94,7 +103,9 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('captures compaction_start as a clean system message', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+    const { subscriber: sub } = createHistoryCaptureSubscriber(
+      () => cache as unknown as MessageHistory
+    );
 
     sub({ type: 'compaction_start', reason: 'threshold' } as unknown as AgentSessionEvent);
 
@@ -106,7 +117,9 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('captures successful compaction_end as a clean system message', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+    const { subscriber: sub } = createHistoryCaptureSubscriber(
+      () => cache as unknown as MessageHistory
+    );
 
     sub({
       type: 'compaction_end',
@@ -124,7 +137,9 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('surfaces errorMessage on failed compaction_end', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+    const { subscriber: sub } = createHistoryCaptureSubscriber(
+      () => cache as unknown as MessageHistory
+    );
 
     sub({
       type: 'compaction_end',
@@ -143,7 +158,9 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('surfaces aborted compaction_end distinctly from failure', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+    const { subscriber: sub } = createHistoryCaptureSubscriber(
+      () => cache as unknown as MessageHistory
+    );
 
     sub({
       type: 'compaction_end',
@@ -159,7 +176,9 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('surfaces silent no-op (result undefined, no flags) as a failure', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+    const { subscriber: sub } = createHistoryCaptureSubscriber(
+      () => cache as unknown as MessageHistory
+    );
 
     sub({
       type: 'compaction_end',
@@ -176,7 +195,9 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('captures text + tool calls in the same turn', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+    const { subscriber: sub } = createHistoryCaptureSubscriber(
+      () => cache as unknown as MessageHistory
+    );
 
     sub(thinkingDelta('Thinking...'));
     sub(toolStart('bash', 'ls'));
@@ -200,7 +221,9 @@ describe('createHistoryCaptureSubscriber', () => {
 
   it('marks tool error results with Error prefix', () => {
     const cache = mockCache();
-    const sub = createHistoryCaptureSubscriber(() => cache as unknown as MessageHistory);
+    const { subscriber: sub } = createHistoryCaptureSubscriber(
+      () => cache as unknown as MessageHistory
+    );
 
     sub(toolStart('bash', 'bad-cmd'));
     sub(toolEnd('bash', 'command not found', true));
@@ -210,5 +233,112 @@ describe('createHistoryCaptureSubscriber', () => {
       turnEvents: Array<{ data: { result: string } }>;
     };
     expect(msg.turnEvents[0].data.result).toBe('Error: command not found');
+  });
+
+  describe('error turns', () => {
+    it('captures the partial assistant AND an LLM-error system row on stopReason=error', () => {
+      const cache = mockCache();
+      const { subscriber: sub } = createHistoryCaptureSubscriber(
+        () => cache as unknown as MessageHistory
+      );
+
+      sub(textDelta('I was almost done'));
+      sub(
+        messageEnd({ stopReason: 'error', errorMessage: '401 Invalid authentication credentials' })
+      );
+
+      // Two pushes: assistant partial first (chronological), then system error row.
+      expect(cache.push).toHaveBeenCalledTimes(2);
+      const assistant = cache.messages[0] as { role: string; content: string };
+      const system = cache.messages[1] as { role: string; content: string };
+      expect(assistant.role).toBe('assistant');
+      expect(assistant.content).toBe('I was almost done');
+      expect(system.role).toBe('system');
+      expect(system.content).toBe('LLM error\n\n401 Invalid authentication credentials');
+    });
+
+    it('still pushes the LLM-error row when the partial is empty', () => {
+      const cache = mockCache();
+      const { subscriber: sub } = createHistoryCaptureSubscriber(
+        () => cache as unknown as MessageHistory
+      );
+
+      sub(messageEnd({ stopReason: 'error', errorMessage: '503 service unavailable' }));
+
+      expect(cache.push).toHaveBeenCalledOnce();
+      const system = cache.messages[0] as { role: string; content: string };
+      expect(system.role).toBe('system');
+      expect(system.content).toBe('LLM error\n\n503 service unavailable');
+    });
+
+    it('does not push an LLM-error row when stopReason is not error', () => {
+      const cache = mockCache();
+      const { subscriber: sub } = createHistoryCaptureSubscriber(
+        () => cache as unknown as MessageHistory
+      );
+
+      sub(textDelta('done'));
+      sub(messageEnd({ stopReason: 'end_turn' }));
+
+      expect(cache.push).toHaveBeenCalledOnce();
+      const msg = cache.messages[0] as { role: string };
+      expect(msg.role).toBe('assistant');
+    });
+  });
+
+  describe('flushPartial (steering ordering fix)', () => {
+    it('commits the in-flight partial as an assistant message, then resets state', () => {
+      const cache = mockCache();
+      const { subscriber: sub, flushPartial } = createHistoryCaptureSubscriber(
+        () => cache as unknown as MessageHistory
+      );
+
+      sub(textDelta('half-finished response'));
+      flushPartial();
+
+      expect(cache.push).toHaveBeenCalledOnce();
+      const msg = cache.messages[0] as { role: string; content: string };
+      expect(msg.role).toBe('assistant');
+      expect(msg.content).toBe('half-finished response');
+
+      // A subsequent message_end for the interrupted turn must NOT double-push:
+      // the accumulator was reset by flushPartial.
+      sub(messageEnd());
+      expect(cache.push).toHaveBeenCalledOnce();
+    });
+
+    it('flushes accumulated thinking + tool calls as turn events', () => {
+      const cache = mockCache();
+      const { subscriber: sub, flushPartial } = createHistoryCaptureSubscriber(
+        () => cache as unknown as MessageHistory
+      );
+
+      sub(thinkingDelta('analyzing...'));
+      sub(toolStart('read_file', { path: '/tmp/foo' }));
+      sub(toolEnd('read_file', 'contents'));
+      sub(textDelta('here is my response so far'));
+      flushPartial();
+
+      const msg = cache.messages[0] as {
+        role: string;
+        content: string;
+        turnEvents: Array<{ type: string }>;
+      };
+      expect(msg.role).toBe('assistant');
+      expect(msg.content).toBe('here is my response so far');
+      expect(msg.turnEvents).toHaveLength(2);
+      expect(msg.turnEvents[0].type).toBe('thinking');
+      expect(msg.turnEvents[1].type).toBe('tool_call');
+    });
+
+    it('is a no-op when nothing is in flight', () => {
+      const cache = mockCache();
+      const { flushPartial } = createHistoryCaptureSubscriber(
+        () => cache as unknown as MessageHistory
+      );
+
+      flushPartial();
+      expect(cache.push).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/server/chat/history-capture.test.ts
+++ b/src/server/chat/history-capture.test.ts
@@ -341,6 +341,20 @@ describe('createHistoryCaptureSubscriber', () => {
       expect(cache.push).not.toHaveBeenCalled();
     });
 
+    it('marks the tool follow-up row with isFollowUp=true so UI does not clobber a streaming new turn', () => {
+      const cache = mockCache();
+      const { subscriber: sub, flushPartial } = createHistoryCaptureSubscriber(
+        () => cache as unknown as MessageHistory
+      );
+
+      sub(toolStart('bash', 'ls'));
+      flushPartial();
+      sub(toolEnd('bash', 'a.txt'));
+
+      const followup = cache.messages[1] as { isFollowUp?: boolean };
+      expect(followup.isFollowUp).toBe(true);
+    });
+
     it('records tool_execution_end as a follow-up row when the tool was flushed mid-run', () => {
       // Steering during tool use: flushPartial pushes the assistant message
       // with the tool_call still in 'running' state. When tool_execution_end

--- a/src/server/chat/history-capture.ts
+++ b/src/server/chat/history-capture.ts
@@ -68,7 +68,11 @@ export function createHistoryCaptureSubscriber(getChatCache: () => MessageHistor
     }
     if (currentAssistantText || currentTurnEvents.length > 0) {
       const assistantMsg: ChatMessage = {
-        id: `msg-${Date.now()}`,
+        // randomUUID rather than msg-${Date.now()}: dedup-by-id in the UI's
+        // appendMessage makes id uniqueness load-bearing, and millisecond
+        // resolution can collide when message_end + flushPartial fire close
+        // together (e.g. steering immediately after a fast turn).
+        id: `msg-${randomUUID()}`,
         role: 'assistant',
         content: currentAssistantText,
         timestamp: Date.now(),
@@ -102,7 +106,7 @@ export function createHistoryCaptureSubscriber(getChatCache: () => MessageHistor
         ).message;
         if (messageData?.stopReason === 'error' && messageData.errorMessage) {
           getChatCache().push({
-            id: `msg-llm-error-${randomUUID()}`,
+            id: `msg-${randomUUID()}`,
             role: 'system',
             content: `LLM error\n\n${messageData.errorMessage}`,
             timestamp: Date.now(),

--- a/src/server/chat/history-capture.ts
+++ b/src/server/chat/history-capture.ts
@@ -204,6 +204,8 @@ export function createHistoryCaptureSubscriber(getChatCache: () => MessageHistor
         // execution (steering during tool use). If so, push a follow-up
         // assistant row carrying just the completed tool_call so the result
         // is preserved and chronologically lands AFTER the steering user row.
+        // Marked `isFollowUp: true` so the UI appends it WITHOUT clobbering
+        // the now-streaming next turn's draft.
         if (!matched) {
           const idx = flushedRunningTools.findIndex((t) => t.name === event.toolName);
           if (idx >= 0) {
@@ -214,6 +216,7 @@ export function createHistoryCaptureSubscriber(getChatCache: () => MessageHistor
               role: 'assistant',
               content: '',
               timestamp: Date.now(),
+              isFollowUp: true,
               turnEvents: [
                 {
                   type: 'tool_call',

--- a/src/server/chat/history-capture.ts
+++ b/src/server/chat/history-capture.ts
@@ -49,6 +49,14 @@ export function createHistoryCaptureSubscriber(getChatCache: () => MessageHistor
   let currentAssistantText = '';
   let activeThinkingContent = '';
   let currentTurnEvents: ChatTurnEvent[] = [];
+  // FIFO queue of tools that were still running when commitAccumulatedTurn
+  // pushed them into chatCache. A later tool_execution_end whose toolName
+  // matches the head of this queue belongs to a flushed message — we push a
+  // follow-up assistant row carrying just the completed tool_call so the
+  // result isn't dropped. Tracks {name, input} so the follow-up row preserves
+  // the original invocation. FIFO match by name handles concurrent same-name
+  // tools (e.g. two bash calls in flight at flush time).
+  const flushedRunningTools: Array<{ name: string; input: string | undefined }> = [];
 
   // Shared helper: finalize active thinking into currentTurnEvents, then
   // push the accumulated turn (if any) and reset. Used by message_end AND
@@ -67,6 +75,13 @@ export function createHistoryCaptureSubscriber(getChatCache: () => MessageHistor
       activeThinkingContent = '';
     }
     if (currentAssistantText || currentTurnEvents.length > 0) {
+      // Remember any tool calls still running at commit time so a later
+      // tool_execution_end can be matched and recorded as a follow-up row.
+      for (const ev of currentTurnEvents) {
+        if (ev.type === 'tool_call' && ev.data.status === 'running') {
+          flushedRunningTools.push({ name: ev.data.name, input: ev.data.input });
+        }
+      }
       const assistantMsg: ChatMessage = {
         // randomUUID rather than msg-${Date.now()}: dedup-by-id in the UI's
         // appendMessage makes id uniqueness load-bearing, and millisecond
@@ -184,6 +199,37 @@ export function createHistoryCaptureSubscriber(getChatCache: () => MessageHistor
           }
           return e;
         });
+
+        // No match in currentTurnEvents: the tool may have been flushed mid-
+        // execution (steering during tool use). If so, push a follow-up
+        // assistant row carrying just the completed tool_call so the result
+        // is preserved and chronologically lands AFTER the steering user row.
+        if (!matched) {
+          const idx = flushedRunningTools.findIndex((t) => t.name === event.toolName);
+          if (idx >= 0) {
+            const orig = flushedRunningTools[idx];
+            flushedRunningTools.splice(idx, 1);
+            getChatCache().push({
+              id: `msg-${randomUUID()}`,
+              role: 'assistant',
+              content: '',
+              timestamp: Date.now(),
+              turnEvents: [
+                {
+                  type: 'tool_call',
+                  data: {
+                    id: `tool-${randomUUID()}`,
+                    name: event.toolName,
+                    status: 'completed' as const,
+                    input: orig.input,
+                    result: finalResult,
+                    timestamp: Date.now(),
+                  },
+                },
+              ],
+            });
+          }
+        }
         break;
       }
 

--- a/src/server/chat/history-capture.ts
+++ b/src/server/chat/history-capture.ts
@@ -4,6 +4,12 @@
  * Creates an event subscriber that captures agent session events into a
  * MessageHistory (chat cache). Extracted from Server so the logic is testable
  * independently.
+ *
+ * Everything visible as a chat row lives in chatCache — including the partial
+ * assistant turn that errored, the LLM-error system row, and compaction
+ * notices. The UI receives these live via the chatCache's push listener
+ * (WebSocketHandler forwards each push as chat_message_added), so there is no
+ * UI-side synthesis of these rows.
  */
 
 import { randomUUID } from 'node:crypto';
@@ -23,15 +29,58 @@ import type { MessageHistory } from './history.js';
  * the complete assistant message on message_end. Tool-only turns (thinking +
  * tool calls without text) are also persisted. Compaction events are recorded
  * as system messages.
+ *
+ * Returns `{ subscriber, flushPartial }`. The subscriber goes to AgentHost.
+ * `flushPartial` is a server-side hook used by WebSocketHandler during a
+ * steering message: it captures whatever the in-flight turn has accumulated
+ * so far and pushes it into chatCache BEFORE the user's steering row is
+ * pushed. Without this, the steer's interrupt and the user-message push race,
+ * leaving chatCache in [user_steering, partial_assistant] order — chronologically
+ * wrong. After flushPartial fires, the SDK's eventual message_end finds the
+ * internal buffers empty and is a no-op for the partial branch (the error /
+ * compaction branches still apply if relevant).
  */
-export function createHistoryCaptureSubscriber(
-  getChatCache: () => MessageHistory
-): (event: AgentSessionEvent) => void {
+export interface HistoryCapture {
+  subscriber: (event: AgentSessionEvent) => void;
+  flushPartial: () => void;
+}
+
+export function createHistoryCaptureSubscriber(getChatCache: () => MessageHistory): HistoryCapture {
   let currentAssistantText = '';
   let activeThinkingContent = '';
   let currentTurnEvents: ChatTurnEvent[] = [];
 
-  return (event: AgentSessionEvent) => {
+  // Shared helper: finalize active thinking into currentTurnEvents, then
+  // push the accumulated turn (if any) and reset. Used by message_end AND
+  // flushPartial so both honor the same "what counts as a turn" rule.
+  function commitAccumulatedTurn(): void {
+    if (activeThinkingContent) {
+      currentTurnEvents.push({
+        type: 'thinking',
+        data: {
+          id: `thinking-${Date.now()}`,
+          content: activeThinkingContent,
+          isStreaming: false,
+          timestamp: Date.now(),
+        },
+      });
+      activeThinkingContent = '';
+    }
+    if (currentAssistantText || currentTurnEvents.length > 0) {
+      const assistantMsg: ChatMessage = {
+        id: `msg-${Date.now()}`,
+        role: 'assistant',
+        content: currentAssistantText,
+        timestamp: Date.now(),
+        turnEvents: currentTurnEvents.length > 0 ? [...currentTurnEvents] : undefined,
+      };
+      getChatCache().push(assistantMsg);
+      currentAssistantText = '';
+      currentTurnEvents = [];
+    }
+  }
+
+  const subscriber = (event: AgentSessionEvent) => {
     switch (event.type) {
       case 'message_update':
         if (event.assistantMessageEvent.type === 'text_delta') {
@@ -42,33 +91,22 @@ export function createHistoryCaptureSubscriber(
         break;
 
       case 'message_end': {
-        // Finalize thinking if active
-        if (activeThinkingContent) {
-          currentTurnEvents.push({
-            type: 'thinking',
-            data: {
-              id: `thinking-${Date.now()}`,
-              content: activeThinkingContent,
-              isStreaming: false,
-              timestamp: Date.now(),
-            },
-          });
-          activeThinkingContent = '';
-        }
+        commitAccumulatedTurn();
 
-        // Capture completed assistant message in history.
-        // Push when there's text OR tool-only turns (thinking + tool calls without text).
-        if (currentAssistantText || currentTurnEvents.length > 0) {
-          const assistantMsg: ChatMessage = {
-            id: `msg-${Date.now()}`,
-            role: 'assistant',
-            content: currentAssistantText,
+        // Error turns surface as a system row right after the assistant's
+        // partial. The row carries the full errorMessage; failover system
+        // rows pushed by AgentHost.reinitializeWithProvider intentionally
+        // DON'T re-embed the same text, so the chat shows the error once.
+        const messageData = (
+          event as unknown as { message?: { stopReason?: string; errorMessage?: string } }
+        ).message;
+        if (messageData?.stopReason === 'error' && messageData.errorMessage) {
+          getChatCache().push({
+            id: `msg-llm-error-${randomUUID()}`,
+            role: 'system',
+            content: `LLM error\n\n${messageData.errorMessage}`,
             timestamp: Date.now(),
-            turnEvents: currentTurnEvents.length > 0 ? [...currentTurnEvents] : undefined,
-          };
-          getChatCache().push(assistantMsg);
-          currentAssistantText = '';
-          currentTurnEvents = [];
+          });
         }
         break;
       }
@@ -87,6 +125,9 @@ export function createHistoryCaptureSubscriber(
           });
           activeThinkingContent = '';
         }
+        // (No commitAccumulatedTurn here: tool calls are still part of the
+        // in-flight turn and should accumulate into currentTurnEvents until
+        // message_end commits the whole turn.)
 
         // Format tool input for display
         let inputText = '';
@@ -179,4 +220,6 @@ export function createHistoryCaptureSubscriber(
       }
     }
   };
+
+  return { subscriber, flushPartial: commitAccumulatedTurn };
 }

--- a/src/server/chat/history.test.ts
+++ b/src/server/chat/history.test.ts
@@ -93,4 +93,61 @@ describe('MessageHistory', () => {
     history.push(makeMessage('1', 'deep'));
     expect(history.getMessages()).toHaveLength(1);
   });
+
+  describe('subscribe (observable)', () => {
+    it('notifies listeners on every push', () => {
+      const dir = trackTmpDir(makeTmpDir());
+      const history = new MessageHistory(join(dir, 'history.json'));
+      const received: ChatMessage[] = [];
+      history.subscribe((msg) => received.push(msg));
+
+      history.push(makeMessage('1', 'a'));
+      history.push(makeMessage('2', 'b'));
+
+      expect(received).toHaveLength(2);
+      expect(received[0].id).toBe('1');
+      expect(received[1].id).toBe('2');
+    });
+
+    it('returns an unsubscribe handle', () => {
+      const dir = trackTmpDir(makeTmpDir());
+      const history = new MessageHistory(join(dir, 'history.json'));
+      const received: ChatMessage[] = [];
+      const unsub = history.subscribe((msg) => received.push(msg));
+
+      history.push(makeMessage('1', 'a'));
+      unsub();
+      history.push(makeMessage('2', 'b'));
+
+      expect(received).toHaveLength(1);
+      expect(received[0].id).toBe('1');
+    });
+
+    it('supports multiple independent subscribers', () => {
+      const dir = trackTmpDir(makeTmpDir());
+      const history = new MessageHistory(join(dir, 'history.json'));
+      const a: ChatMessage[] = [];
+      const b: ChatMessage[] = [];
+      history.subscribe((msg) => a.push(msg));
+      history.subscribe((msg) => b.push(msg));
+
+      history.push(makeMessage('1', 'x'));
+
+      expect(a).toHaveLength(1);
+      expect(b).toHaveLength(1);
+    });
+
+    it('fires the listener after persistence (file already has the message)', () => {
+      // Guarantee: a subscriber observing a push can synchronously trust that
+      // chatCache.getMessages() will include the message.
+      const dir = trackTmpDir(makeTmpDir());
+      const history = new MessageHistory(join(dir, 'history.json'));
+      let observedCount = -1;
+      history.subscribe(() => {
+        observedCount = history.getMessages().length;
+      });
+      history.push(makeMessage('1', 'x'));
+      expect(observedCount).toBe(1);
+    });
+  });
 });

--- a/src/server/chat/history.ts
+++ b/src/server/chat/history.ts
@@ -3,17 +3,24 @@
  *
  * Server-side ring buffer of recent chat messages displayed in the UI.
  * Persists to a JSON file so history survives server restarts.
- * The server is the single source of truth — the UI does not cache messages.
+ * The server is the single source of truth — the UI mirrors this store.
+ *
+ * Observable: subscribers are notified on every push. WebSocketHandler uses
+ * this to broadcast new messages live, so a freshly-pushed system/user/
+ * assistant message reaches connected clients without waiting for a reload.
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import type { ChatMessage } from '../../shared/index.js';
 
+export type MessageHistoryListener = (message: ChatMessage) => void;
+
 export class MessageHistory {
   private messages: ChatMessage[] = [];
   private filePath: string;
   private maxMessages: number;
+  private listeners: Set<MessageHistoryListener> = new Set();
 
   constructor(filePath: string, maxMessages = 100) {
     this.filePath = filePath;
@@ -26,13 +33,22 @@ export class MessageHistory {
     return [...this.messages];
   }
 
-  /** Add a message and persist. */
+  /** Add a message, persist, and notify subscribers. */
   push(message: ChatMessage): void {
     this.messages.push(message);
     if (this.messages.length > this.maxMessages) {
       this.messages = this.messages.slice(-this.maxMessages);
     }
     this.save();
+    for (const listener of this.listeners) {
+      listener(message);
+    }
+  }
+
+  /** Subscribe to push events. Returns an unsubscribe function. */
+  subscribe(listener: MessageHistoryListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
   }
 
   /** Load history from disk. */

--- a/src/server/chat/history.ts
+++ b/src/server/chat/history.ts
@@ -13,6 +13,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 import type { ChatMessage } from '../../shared/index.js';
+import { log } from '../utils/logger.js';
 
 export type MessageHistoryListener = (message: ChatMessage) => void;
 
@@ -40,8 +41,16 @@ export class MessageHistory {
       this.messages = this.messages.slice(-this.maxMessages);
     }
     this.save();
+    // Per-listener try/catch so a throwing subscriber (e.g. a WebSocket send
+    // racing a closed socket) cannot break persistence, prevent later
+    // subscribers from running, or bubble up into the caller. The message is
+    // already in memory + on disk by this point, so we just log and continue.
     for (const listener of this.listeners) {
-      listener(message);
+      try {
+        listener(message);
+      } catch (err) {
+        log.error('[MessageHistory] subscriber threw:', err);
+      }
     }
   }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -473,13 +473,7 @@ export class Server {
     // Handle WebSocket connections
     this.wss.on('connection', (ws) => {
       log.info('Client connected');
-      new WebSocketHandler(
-        ws,
-        this.agentRegistry,
-        this.guideAgentId,
-        this.wss,
-        this.conversationSummarizer
-      );
+      new WebSocketHandler(ws, this.agentRegistry, this.guideAgentId, this.conversationSummarizer);
     });
   }
 
@@ -578,7 +572,12 @@ export class Server {
    * then persists the complete assistant message on message_end.
    */
   private subscribeForHistoryCapture(agentHost: AgentHost): void {
-    agentHost.subscribe(createHistoryCaptureSubscriber(() => agentHost.chatCache));
+    const { subscriber, flushPartial } = createHistoryCaptureSubscriber(() => agentHost.chatCache);
+    agentHost.subscribe(subscriber);
+    // Expose flushPartial on the host so WebSocketHandler can commit the
+    // in-flight assistant draft into chatCache BEFORE pushing a steering
+    // user message — preserves chronological order in the persisted chat.
+    agentHost.setHistoryFlushHook(flushPartial);
   }
 
   async start(): Promise<void> {

--- a/src/server/websocket/handler.test.ts
+++ b/src/server/websocket/handler.test.ts
@@ -28,16 +28,28 @@ function makeMockHost(opts: {
   role?: string;
 }): AgentHost & {
   __subscribers: Array<(event: unknown) => void>;
+  __cacheSubscribers: Array<(message: unknown) => void>;
   __setBusy: (b: boolean) => void;
   __setContext: (p: number | null) => void;
 } {
   let busy = opts.busy ?? false;
   let contextPercent: number | null = opts.contextPercent ?? null;
   const subscribers: Array<(event: unknown) => void> = [];
+  const cacheSubscribers: Array<(message: unknown) => void> = [];
 
   const host = {
     role: opts.role ?? 'guide',
-    chatCache: { getMessages: () => [], push: vi.fn() },
+    chatCache: {
+      getMessages: () => [],
+      push: vi.fn(),
+      subscribe: (cb: (message: unknown) => void) => {
+        cacheSubscribers.push(cb);
+        return () => {
+          const i = cacheSubscribers.indexOf(cb);
+          if (i >= 0) cacheSubscribers.splice(i, 1);
+        };
+      },
+    },
     getProvider: () => opts.provider ?? 'anthropic',
     isBusy: () => busy,
     getContextUsage: () =>
@@ -54,7 +66,9 @@ function makeMockHost(opts: {
     prompt: vi.fn(),
     abort: vi.fn(),
     state: { stopReason: 'end_turn' },
+    flushPartialTurn: vi.fn(),
     __subscribers: subscribers,
+    __cacheSubscribers: cacheSubscribers,
     __setBusy: (b: boolean) => {
       busy = b;
     },
@@ -65,6 +79,7 @@ function makeMockHost(opts: {
 
   return host as unknown as AgentHost & {
     __subscribers: Array<(event: unknown) => void>;
+    __cacheSubscribers: Array<(message: unknown) => void>;
     __setBusy: (b: boolean) => void;
     __setContext: (p: number | null) => void;
   };
@@ -93,10 +108,6 @@ function makeMockWs(): MockWs {
   };
 }
 
-function makeMockWss() {
-  return { clients: new Set<MockWs>() };
-}
-
 function sentMessages(ws: MockWs): ServerMessage[] {
   return ws.send.mock.calls.map((call) => JSON.parse(call[0] as string) as ServerMessage);
 }
@@ -106,7 +117,6 @@ describe('WebSocketHandler agent_busy_state delivery', () => {
   let conductorHost: ReturnType<typeof makeMockHost>;
   let registry: AgentRegistry;
   let ws: MockWs;
-  let wss: ReturnType<typeof makeMockWss>;
 
   beforeEach(() => {
     guideHost = makeMockHost({
@@ -127,15 +137,13 @@ describe('WebSocketHandler agent_busy_state delivery', () => {
     ]);
     registry = { get: (id: number) => hosts.get(id) } as unknown as AgentRegistry;
     ws = makeMockWs();
-    wss = makeMockWss();
   });
 
   it('sends Guide agent_busy_state snapshot on connect', () => {
     new WebSocketHandler(
       ws as unknown as ConstructorParameters<typeof WebSocketHandler>[0],
       registry,
-      1,
-      wss as unknown as ConstructorParameters<typeof WebSocketHandler>[3]
+      1
     );
 
     const msgs = sentMessages(ws);
@@ -153,8 +161,7 @@ describe('WebSocketHandler agent_busy_state delivery', () => {
     new WebSocketHandler(
       ws as unknown as ConstructorParameters<typeof WebSocketHandler>[0],
       registry,
-      1,
-      wss as unknown as ConstructorParameters<typeof WebSocketHandler>[3]
+      1
     );
 
     const snapshot = sentMessages(ws).find((m) => m.type === 'agent_busy_state');
@@ -165,8 +172,7 @@ describe('WebSocketHandler agent_busy_state delivery', () => {
     new WebSocketHandler(
       ws as unknown as ConstructorParameters<typeof WebSocketHandler>[0],
       registry,
-      1,
-      wss as unknown as ConstructorParameters<typeof WebSocketHandler>[3]
+      1
     );
 
     // Reset to ignore constructor-time sends; only inspect what switch_agent emits.
@@ -195,8 +201,7 @@ describe('WebSocketHandler agent_busy_state delivery', () => {
     new WebSocketHandler(
       ws as unknown as ConstructorParameters<typeof WebSocketHandler>[0],
       registry,
-      1,
-      wss as unknown as ConstructorParameters<typeof WebSocketHandler>[3]
+      1
     );
 
     ws.send.mockClear();
@@ -216,8 +221,7 @@ describe('WebSocketHandler agent_busy_state delivery', () => {
     new WebSocketHandler(
       ws as unknown as ConstructorParameters<typeof WebSocketHandler>[0],
       registry,
-      1,
-      wss as unknown as ConstructorParameters<typeof WebSocketHandler>[3]
+      1
     );
 
     ws.send.mockClear();
@@ -226,5 +230,189 @@ describe('WebSocketHandler agent_busy_state delivery', () => {
     const msgs = sentMessages(ws);
     expect(msgs.find((m) => m.type === 'error')).toBeTruthy();
     expect(msgs.find((m) => m.type === 'agent_busy_state')).toBeUndefined();
+  });
+});
+
+describe('WebSocketHandler chat_message_added forwarding', () => {
+  let guideHost: ReturnType<typeof makeMockHost>;
+  let conductorHost: ReturnType<typeof makeMockHost>;
+  let registry: AgentRegistry;
+  let ws: MockWs;
+
+  beforeEach(() => {
+    guideHost = makeMockHost({ role: 'guide' });
+    conductorHost = makeMockHost({ role: 'conductor' });
+    const hosts = new Map<number, AgentHost>([
+      [1, guideHost as unknown as AgentHost],
+      [5, conductorHost as unknown as AgentHost],
+    ]);
+    registry = { get: (id: number) => hosts.get(id) } as unknown as AgentRegistry;
+    ws = makeMockWs();
+  });
+
+  it('forwards a chatCache push as chat_message_added for the source agent', () => {
+    new WebSocketHandler(
+      ws as unknown as ConstructorParameters<typeof WebSocketHandler>[0],
+      registry,
+      1
+    );
+    ws.send.mockClear();
+
+    const message = {
+      id: 'sys-1',
+      role: 'system' as const,
+      content:
+        '401 auth error, switched to google\n\non anthropic, switching to google\n\n401 {}\n\nRun `system2 config` to refresh anthropic authentication and restart the server.',
+      timestamp: 100,
+    };
+    // Simulate a server-side push into the guide's chatCache.
+    for (const cb of guideHost.__cacheSubscribers) cb(message);
+
+    const sent = sentMessages(ws).filter((m) => m.type === 'chat_message_added');
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({ type: 'chat_message_added', message, agentId: 1 });
+  });
+
+  it('forwards pushes for the second agent only after switch_agent subscribes to it', () => {
+    new WebSocketHandler(
+      ws as unknown as ConstructorParameters<typeof WebSocketHandler>[0],
+      registry,
+      1
+    );
+
+    // Before subscribe: a push to the conductor must NOT reach this client.
+    for (const cb of conductorHost.__cacheSubscribers) {
+      cb({ id: 'a', role: 'system', content: 'noise', timestamp: 1 });
+    }
+    expect(sentMessages(ws).some((m) => m.type === 'chat_message_added')).toBe(false);
+
+    // Switch (subscribes to conductor's chatCache), then push: it should arrive.
+    ws.__listeners.message?.(Buffer.from(JSON.stringify({ type: 'switch_agent', agentId: 5 })));
+    ws.send.mockClear();
+
+    const message = {
+      id: 'b',
+      role: 'assistant' as const,
+      content: 'hello',
+      timestamp: 2,
+    };
+    for (const cb of conductorHost.__cacheSubscribers) cb(message);
+
+    const sent = sentMessages(ws).filter((m) => m.type === 'chat_message_added');
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({ type: 'chat_message_added', message, agentId: 5 });
+  });
+
+  it('reuses the client-provided id when echoing a user_message via chat_message_added', () => {
+    // Two clients on the same agent — when client A sends with id "client-id-1",
+    // client B should receive a chat_message_added with the same id so its
+    // dedup-by-id works against any local optimistic insert.
+    new WebSocketHandler(
+      ws as unknown as ConstructorParameters<typeof WebSocketHandler>[0],
+      registry,
+      1
+    );
+    ws.send.mockClear();
+
+    ws.__listeners.message?.(
+      Buffer.from(
+        JSON.stringify({
+          type: 'user_message',
+          content: 'hi',
+          agentId: 1,
+          id: 'client-id-1',
+        })
+      )
+    );
+
+    const pushed = (guideHost.chatCache.push as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(pushed).toMatchObject({ id: 'client-id-1', role: 'user', content: 'hi' });
+  });
+
+  it('provider_change carries no reason (chat row arrives via chat_message_added)', () => {
+    new WebSocketHandler(
+      ws as unknown as ConstructorParameters<typeof WebSocketHandler>[0],
+      registry,
+      1
+    );
+    ws.send.mockClear();
+
+    // Synthetic status event from reinitializeWithProvider.
+    guideHost.__subscribers[0]({
+      type: 'status',
+      provider: 'google',
+      reason: 'should-be-stripped',
+    });
+
+    const sent = sentMessages(ws).find((m) => m.type === 'provider_change');
+    expect(sent).toEqual({ type: 'provider_change', provider: 'google', agentId: 1 });
+    expect((sent as Record<string, unknown> | undefined)?.reason).toBeUndefined();
+  });
+
+  it('cleans up the chatCache subscription on disconnect', () => {
+    new WebSocketHandler(
+      ws as unknown as ConstructorParameters<typeof WebSocketHandler>[0],
+      registry,
+      1
+    );
+    expect(guideHost.__cacheSubscribers).toHaveLength(1);
+
+    ws.__listeners.close?.(Buffer.alloc(0));
+    expect(guideHost.__cacheSubscribers).toHaveLength(0);
+  });
+
+  it('steering_message flushes the in-flight partial BEFORE pushing the user row', () => {
+    // Preserves chronological order in chatCache: assistant_partial then
+    // user_steering. Without the flush, the user row gets pushed first and
+    // the SDK's eventual message_end pushes the partial after, giving the
+    // reverse (wrong) order on persisted history.
+    new WebSocketHandler(
+      ws as unknown as ConstructorParameters<typeof WebSocketHandler>[0],
+      registry,
+      1
+    );
+
+    const callOrder: string[] = [];
+    (guideHost.flushPartialTurn as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      callOrder.push('flushPartialTurn');
+    });
+    (guideHost.chatCache.push as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      callOrder.push('chatCache.push');
+    });
+
+    ws.__listeners.message?.(
+      Buffer.from(
+        JSON.stringify({
+          type: 'steering_message',
+          content: 'change direction',
+          agentId: 1,
+          id: 'steer-1',
+        })
+      )
+    );
+
+    expect(callOrder).toEqual(['flushPartialTurn', 'chatCache.push']);
+  });
+
+  it('user_message does NOT flush partial (no in-flight turn to commit)', () => {
+    new WebSocketHandler(
+      ws as unknown as ConstructorParameters<typeof WebSocketHandler>[0],
+      registry,
+      1
+    );
+    (guideHost.flushPartialTurn as ReturnType<typeof vi.fn>).mockClear();
+
+    ws.__listeners.message?.(
+      Buffer.from(
+        JSON.stringify({
+          type: 'user_message',
+          content: 'hi',
+          agentId: 1,
+          id: 'u-1',
+        })
+      )
+    );
+
+    expect(guideHost.flushPartialTurn).not.toHaveBeenCalled();
   });
 });

--- a/src/server/websocket/handler.test.ts
+++ b/src/server/websocket/handler.test.ts
@@ -329,6 +329,35 @@ describe('WebSocketHandler chat_message_added forwarding', () => {
     expect(pushed).toMatchObject({ id: 'client-id-1', role: 'user', content: 'hi' });
   });
 
+  it('replaces invalid client-provided ids with a server-generated UUID', () => {
+    // A buggy/malicious client could send a multi-megabyte id, control chars,
+    // or deliberately collide ids to trigger silent drops via dedup-by-id.
+    // Validation: <=128 chars, charset [A-Za-z0-9_-].
+    new WebSocketHandler(
+      ws as unknown as ConstructorParameters<typeof WebSocketHandler>[0],
+      registry,
+      1
+    );
+
+    const cases: Array<{ label: string; id: unknown }> = [
+      { label: 'empty string', id: '' },
+      { label: 'too long', id: 'x'.repeat(200) },
+      { label: 'control char', id: 'msg-\n-evil' },
+      { label: 'unicode', id: 'msg-évil' },
+      { label: 'non-string', id: 12345 },
+    ];
+
+    for (const { id } of cases) {
+      (guideHost.chatCache.push as ReturnType<typeof vi.fn>).mockClear();
+      ws.__listeners.message?.(
+        Buffer.from(JSON.stringify({ type: 'user_message', content: 'hi', agentId: 1, id }))
+      );
+      const pushed = (guideHost.chatCache.push as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(pushed.id).not.toBe(id);
+      expect(pushed.id).toMatch(/^msg-[0-9a-f-]{36}$/);
+    }
+  });
+
   it('provider_change carries no reason (chat row arrives via chat_message_added)', () => {
     new WebSocketHandler(
       ws as unknown as ConstructorParameters<typeof WebSocketHandler>[0],

--- a/src/server/websocket/handler.ts
+++ b/src/server/websocket/handler.ts
@@ -21,6 +21,25 @@ import type { AgentRegistry } from '../agents/registry.js';
 import type { ConversationSummarizer } from '../chat/summarizer.js';
 import { log } from '../utils/logger.js';
 
+/**
+ * Validate a client-provided ChatMessage id before persisting + rebroadcasting.
+ * Caps length and restricts to a safe charset so a malicious or buggy client
+ * can't (a) bloat chatCache with multi-MB ids, (b) inject control chars into
+ * persisted JSON or log lines, or (c) deliberately collide ids and trigger
+ * silent drops via the UI's dedup-by-id. Anything that fails this check is
+ * replaced with a server-generated UUID.
+ */
+const MAX_CLIENT_ID_LENGTH = 128;
+const CLIENT_ID_PATTERN = /^[A-Za-z0-9_-]+$/;
+function isValidClientMessageId(id: unknown): id is string {
+  return (
+    typeof id === 'string' &&
+    id.length > 0 &&
+    id.length <= MAX_CLIENT_ID_LENGTH &&
+    CLIENT_ID_PATTERN.test(id)
+  );
+}
+
 export class WebSocketHandler {
   private ws: WebSocket;
   private agentRegistry: AgentRegistry;
@@ -140,10 +159,12 @@ export class WebSocketHandler {
         // Capture user message in agent's chat cache. The push fires
         // chat_message_added to every subscribed client (including this one),
         // so the originating tab's optimistic insert dedups against the same id.
-        // Fall back to randomUUID() (not msg-${Date.now()}) so two rapid pushes
-        // within the same millisecond can't collide and silently drop a row.
+        // Validate the client-provided id: a too-long or off-charset id would
+        // persist as-is and rebroadcast to every other tab. Fall back to a
+        // server-generated UUID on anything invalid.
+        const id = isValidClientMessageId(message.id) ? message.id : `msg-${randomUUID()}`;
         host.chatCache.push({
-          id: message.id ?? `msg-${randomUUID()}`,
+          id,
           role: 'user',
           content: message.content,
           timestamp: Date.now(),

--- a/src/server/websocket/handler.ts
+++ b/src/server/websocket/handler.ts
@@ -3,12 +3,17 @@
  *
  * Bridges Pi Agent events to WebSocket clients for real-time chat UI updates.
  * Supports multi-agent routing: the user can switch the active chat to any agent.
- * User messages are captured in the agent's chat cache and broadcast to other tabs.
- * Assistant message history capture is handled centrally by Server.
+ *
+ * Chat row delivery is unified via `chat_message_added`: any push to the agent's
+ * chatCache (user input, history-capture's finalized assistant turns, LLM-error
+ * system rows, failover system rows, compaction system rows) is forwarded live
+ * to all subscribed clients. The UI mirrors chatCache exactly. Streaming events
+ * (assistant_chunk, tool_call_*) drive the transient draft above the committed
+ * messages list; they don't represent committed rows.
  */
 
 import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
-import type { WebSocket, WebSocketServer } from 'ws';
+import type { WebSocket } from 'ws';
 import type { ClientMessage, ServerMessage } from '../../shared/index.js';
 import type { AgentHost } from '../agents/host.js';
 import type { AgentRegistry } from '../agents/registry.js';
@@ -19,7 +24,6 @@ export class WebSocketHandler {
   private ws: WebSocket;
   private agentRegistry: AgentRegistry;
   private guideAgentId: number;
-  private wss: WebSocketServer;
   private activeAgentId: number;
   private subscriptions = new Map<number, () => void>();
   private thinkingAgents = new Set<number>();
@@ -29,13 +33,11 @@ export class WebSocketHandler {
     ws: WebSocket,
     agentRegistry: AgentRegistry,
     guideAgentId: number,
-    wss: WebSocketServer,
     summarizer?: ConversationSummarizer
   ) {
     this.ws = ws;
     this.agentRegistry = agentRegistry;
     this.guideAgentId = guideAgentId;
-    this.wss = wss;
     this.activeAgentId = guideAgentId;
     this.summarizer = summarizer;
 
@@ -85,20 +87,25 @@ export class WebSocketHandler {
   }
 
   /**
-   * Subscribe to an agent's events for streaming to this WebSocket client.
-   * Subscriptions are kept alive across agent switches so events continue
-   * flowing for background agents (preserving in-progress tool calls, etc.).
+   * Subscribe to an agent's events AND chatCache pushes for streaming to this
+   * WebSocket client. Subscriptions are kept alive across agent switches so
+   * events continue flowing for background agents (preserving in-progress tool
+   * calls, etc.) and committed rows reach the UI without waiting for a reload.
    */
   private subscribeToAgent(agentId: number, host: AgentHost): void {
     // Already subscribed to this agent
     if (this.subscriptions.has(agentId)) return;
 
-    this.subscriptions.set(
-      agentId,
-      host.subscribe((event) => {
-        this.handleAgentEvent(event, agentId, host);
-      })
-    );
+    const unsubEvents = host.subscribe((event) => {
+      this.handleAgentEvent(event, agentId, host);
+    });
+    const unsubCache = host.chatCache.subscribe((message) => {
+      this.send({ type: 'chat_message_added', message, agentId });
+    });
+    this.subscriptions.set(agentId, () => {
+      unsubEvents();
+      unsubCache();
+    });
   }
 
   private handleClientMessage(message: ClientMessage): void {
@@ -113,22 +120,25 @@ export class WebSocketHandler {
           return;
         }
 
-        // Capture user message in agent's chat cache
-        const userMsg = {
-          id: `msg-${Date.now()}`,
-          role: 'user' as const,
+        const isSteering = message.type === 'steering_message';
+
+        // Steering interrupts an in-flight assistant turn. Commit whatever
+        // the SDK has accumulated so far into chatCache FIRST, so the
+        // persisted order is [assistant_partial, user_steering] rather than
+        // racing the SDK's eventual message_end against this user push.
+        // No-op when nothing is in flight.
+        if (isSteering) {
+          host.flushPartialTurn();
+        }
+
+        // Capture user message in agent's chat cache. The push fires
+        // chat_message_added to every subscribed client (including this one),
+        // so the originating tab's optimistic insert dedups against the same id.
+        host.chatCache.push({
+          id: message.id ?? `msg-${Date.now()}`,
+          role: 'user',
           content: message.content,
           timestamp: Date.now(),
-        };
-        host.chatCache.push(userMsg);
-
-        // Broadcast to other tabs
-        this.broadcast({
-          type: 'user_message_broadcast',
-          id: userMsg.id,
-          content: userMsg.content,
-          timestamp: userMsg.timestamp,
-          agentId: targetId,
         });
 
         // Record for summarization (non-Guide agents only)
@@ -137,7 +147,6 @@ export class WebSocketHandler {
         }
 
         // Send to agent
-        const isSteering = message.type === 'steering_message';
         host
           .prompt(message.content, isSteering ? { isSteering: true } : undefined)
           .catch((error) => {
@@ -199,12 +208,14 @@ export class WebSocketHandler {
     // Handle synthetic events (not part of AgentSessionEvent type)
     const eventType = event.type as string;
     if (eventType === 'status') {
-      const statusEvent = event as unknown as { provider?: string; reason?: string };
+      const statusEvent = event as unknown as { provider?: string };
       if (statusEvent.provider) {
+        // The chat row describing the switch is delivered separately via the
+        // chat_message_added stream (pushed by reinitializeWithProvider). This
+        // event exists solely to refresh the UI's provider indicator.
         this.send({
           type: 'provider_change',
           provider: statusEvent.provider,
-          reason: statusEvent.reason,
           agentId,
         });
       }
@@ -241,13 +252,10 @@ export class WebSocketHandler {
           this.send({ type: 'thinking_end', agentId });
           this.thinkingAgents.delete(agentId);
         }
-        // Forward error info so the UI can render it in the chat timeline
-        const messageData = (
-          event as unknown as { message?: { stopReason?: string; errorMessage?: string } }
-        ).message;
-        const errorMessage =
-          messageData?.stopReason === 'error' ? messageData.errorMessage : undefined;
-        this.send({ type: 'assistant_end', agentId, errorMessage });
+        // Stream-over signal for the UI's draft state. LLM error rows are
+        // pushed into chatCache by history-capture and arrive via
+        // chat_message_added — they don't ride along on assistant_end.
+        this.send({ type: 'assistant_end', agentId });
         break;
       }
 
@@ -364,16 +372,6 @@ export class WebSocketHandler {
   private send(message: ServerMessage): void {
     if (this.ws.readyState === this.ws.OPEN) {
       this.ws.send(JSON.stringify(message));
-    }
-  }
-
-  /** Send a message to all other connected clients (excluding this one). */
-  private broadcast(message: ServerMessage): void {
-    const data = JSON.stringify(message);
-    for (const client of this.wss.clients) {
-      if (client !== this.ws && client.readyState === this.ws.OPEN) {
-        client.send(data);
-      }
     }
   }
 

--- a/src/server/websocket/handler.ts
+++ b/src/server/websocket/handler.ts
@@ -12,6 +12,7 @@
  * messages list; they don't represent committed rows.
  */
 
+import { randomUUID } from 'node:crypto';
 import type { AgentSessionEvent } from '@mariozechner/pi-coding-agent';
 import type { WebSocket } from 'ws';
 import type { ClientMessage, ServerMessage } from '../../shared/index.js';
@@ -49,6 +50,14 @@ export class WebSocketHandler {
       return;
     }
 
+    // Subscribe BEFORE sending the snapshot so the chatCache listener is
+    // installed first. This matches the switch_agent ordering and guarantees
+    // we never miss a push that lands after the snapshot is taken but before
+    // the subscription is wired up. The dedup-by-id in the UI's appendMessage
+    // handles any row that appears both in the snapshot and in a live
+    // chat_message_added event during the overlap window.
+    this.subscribeToAgent(guideAgentId, guideHost);
+
     // Send Guide's chat cache and provider info on connect
     this.send({
       type: 'chat_history',
@@ -60,9 +69,6 @@ export class WebSocketHandler {
     // Seed Guide's busy/context state into the client's push store so
     // MessageInput's contextPercent is populated before the first turn ends.
     this.sendAgentBusySnapshot(guideAgentId, guideHost);
-
-    // Subscribe to Guide's events for streaming to this client
-    this.subscribeToAgent(guideAgentId, guideHost);
 
     // Handle incoming messages from client
     ws.on('message', (data) => {
@@ -134,8 +140,10 @@ export class WebSocketHandler {
         // Capture user message in agent's chat cache. The push fires
         // chat_message_added to every subscribed client (including this one),
         // so the originating tab's optimistic insert dedups against the same id.
+        // Fall back to randomUUID() (not msg-${Date.now()}) so two rapid pushes
+        // within the same millisecond can't collide and silently drop a row.
         host.chatCache.push({
-          id: message.id ?? `msg-${Date.now()}`,
+          id: message.id ?? `msg-${randomUUID()}`,
           role: 'user',
           content: message.content,
           timestamp: Date.now(),

--- a/src/shared/types/chat.ts
+++ b/src/shared/types/chat.ts
@@ -32,4 +32,14 @@ export interface ChatMessage {
   content: string;
   timestamp: number;
   turnEvents?: ChatTurnEvent[];
+  /**
+   * True for assistant rows that did NOT finalize a streaming turn. Currently
+   * set by `history-capture` on the tool-completion follow-up row pushed when
+   * a tool that was running at `flushPartial` time fires its
+   * `tool_execution_end` later. By the time that row arrives in the UI, the
+   * next (steered) turn may already be streaming; the UI uses this flag to
+   * append the row WITHOUT clearing the in-flight streaming draft. Real
+   * turn-end rows leave this undefined/false so the draft is cleared as usual.
+   */
+  isFollowUp?: boolean;
 }

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -8,9 +8,12 @@ import type { ChatMessage } from './chat.js';
 
 // Client -> Server messages
 // agentId is optional on user/steering/abort: when absent, defaults to the Guide agent.
+// id is an optional client-generated id for user/steering messages; when present the
+// server reuses it as the ChatMessage id, so the chat_message_added round-trip dedups
+// against the originating client's optimistic insert.
 export type ClientMessage =
-  | { type: 'user_message'; content: string; agentId?: number }
-  | { type: 'steering_message'; content: string; agentId?: number } // Steering messages are inserted ASAP into the agent loop
+  | { type: 'user_message'; content: string; agentId?: number; id?: string }
+  | { type: 'steering_message'; content: string; agentId?: number; id?: string } // Steering messages are inserted ASAP into the agent loop
   | { type: 'abort'; agentId?: number }
   | { type: 'switch_agent'; agentId: number }; // Switch the active chat to a different agent
 
@@ -18,7 +21,7 @@ export type ClientMessage =
 // agentId is optional on streaming messages: when absent, implies the Guide agent.
 export type ServerMessage =
   | { type: 'assistant_chunk'; content: string; agentId?: number }
-  | { type: 'assistant_end'; agentId?: number; errorMessage?: string }
+  | { type: 'assistant_end'; agentId?: number }
   | { type: 'thinking_chunk'; content: string; agentId?: number }
   | { type: 'thinking_end'; agentId?: number }
   | { type: 'tool_call_start'; name: string; input?: string; agentId?: number }
@@ -28,15 +31,9 @@ export type ServerMessage =
   | { type: 'error'; message: string; agentId?: number }
   | { type: 'ready_for_input'; agentId?: number } // Signals that the agent is ready for the next message
   | { type: 'chat_history'; messages: ChatMessage[]; agentId: number } // Sent on connect and agent switch
-  | {
-      type: 'user_message_broadcast';
-      id: string;
-      content: string;
-      timestamp: number;
-      agentId?: number;
-    }
+  | { type: 'chat_message_added'; message: ChatMessage; agentId: number } // Fired on every chatCache push (mirrors the server's source of truth)
   | { type: 'provider_info'; provider: string; agentId: number } // Sent on connect/switch — current LLM provider for an agent
-  | { type: 'provider_change'; provider: string; reason?: string; agentId: number } // Sent on failover — provider switched
+  | { type: 'provider_change'; provider: string; agentId: number } // Sent on failover — provider switched (chat row arrives via chat_message_added)
   | { type: 'compaction_start'; agentId?: number } // Sent when auto-compaction begins
   | { type: 'compaction_end'; agentId?: number } // Sent when auto-compaction completes
   // Push notifications: tell UI panels to refetch data

--- a/src/shared/types/messages.ts
+++ b/src/shared/types/messages.ts
@@ -7,7 +7,8 @@
 import type { ChatMessage } from './chat.js';
 
 // Client -> Server messages
-// agentId is optional on user/steering/abort: when absent, defaults to the Guide agent.
+// agentId is optional on user/steering/abort: when absent, defaults to the
+// connection's active agent (initially the Guide, updated by switch_agent).
 // id is an optional client-generated id for user/steering messages; when present the
 // server reuses it as the ChatMessage id, so the chat_message_added round-trip dedups
 // against the originating client's optimistic insert.

--- a/src/ui/components/Chat.tsx
+++ b/src/ui/components/Chat.tsx
@@ -17,14 +17,16 @@ export function Chat() {
   const addUserMessage = useChatStore((s) => s.addUserMessage);
   const activeAgentLabel = useChatStore((s) => s.activeAgentLabel);
 
+  // The optimistic insert and the WS send share an id; the server reuses it
+  // when pushing to chatCache, so the echoed chat_message_added dedups.
   const handleSend = (content: string) => {
-    addUserMessage(content);
-    sendMessage(content);
+    const id = addUserMessage(content);
+    sendMessage(content, id);
   };
 
   const handleSteer = (content: string) => {
-    addUserMessage(content);
-    sendSteeringMessage(content);
+    const id = addUserMessage(content);
+    sendSteeringMessage(content, id);
   };
 
   return (

--- a/src/ui/hooks/useWebSocket.ts
+++ b/src/ui/hooks/useWebSocket.ts
@@ -139,11 +139,10 @@ export function useWebSocket() {
             const aid = message.agentId ?? state.guideAgentId;
             if (aid !== null) {
               state.finishThinking(aid);
-              state.finishAssistantMessage(aid);
-              // Show LLM errors in the chat timeline as collapsible system messages
-              if (message.errorMessage) {
-                state.addSystemMessage(`LLM error\n\n${message.errorMessage}`, aid);
-              }
+              // Stream is over; the canonical assistant row (and any LLM-error
+              // system row) arrives via chat_message_added. Clear the draft as
+              // a safety net in case the turn produced no committed message.
+              state.clearAssistantDraft(aid);
             }
             break;
           }
@@ -198,11 +197,11 @@ export function useWebSocket() {
             break;
           }
 
-          case 'user_message_broadcast': {
-            const aid = message.agentId ?? state.guideAgentId;
-            if (aid !== null) {
-              state.addUserMessage(message.content, message.id, message.timestamp, aid);
-            }
+          case 'chat_message_added': {
+            // Canonical committed row from the server's chatCache. Idempotent
+            // by id so the originating tab's optimistic addUserMessage dedups
+            // against the server's echo.
+            state.appendMessage(message.message, message.agentId);
             break;
           }
 
@@ -230,11 +229,9 @@ export function useWebSocket() {
             break;
 
           case 'provider_change':
+            // Indicator-only: the chat row describing the switch arrives via
+            // chat_message_added (pushed by reinitializeWithProvider).
             state.setProvider(message.provider, message.agentId);
-            state.addSystemMessage(
-              message.reason ?? `Switched to ${message.provider}`,
-              message.agentId
-            );
             break;
 
           case 'compaction_start': {
@@ -345,25 +342,27 @@ export function useWebSocket() {
     };
   }, []);
 
-  const sendMessage = useCallback((content: string) => {
+  const sendMessage = useCallback((content: string, id?: string) => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       const agentId = useChatStore.getState().activeAgentId;
       const msg: ClientMessage = {
         type: 'user_message',
         content,
         agentId: agentId ?? undefined,
+        id,
       };
       wsRef.current.send(JSON.stringify(msg));
     }
   }, []);
 
-  const sendSteeringMessage = useCallback((content: string) => {
+  const sendSteeringMessage = useCallback((content: string, id?: string) => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
       const agentId = useChatStore.getState().activeAgentId;
       const msg: ClientMessage = {
         type: 'steering_message',
         content,
         agentId: agentId ?? undefined,
+        id,
       };
       wsRef.current.send(JSON.stringify(msg));
     }

--- a/src/ui/stores/chat.test.ts
+++ b/src/ui/stores/chat.test.ts
@@ -130,149 +130,125 @@ describe('useChatStore', () => {
     });
   });
 
-  describe('addUserMessage during steering', () => {
-    it('snapshots in-progress turn events into a partial assistant message', () => {
+  describe('addUserMessage (optimistic local insert)', () => {
+    it('inserts the user message and returns its id', () => {
       useChatStore.setState({ activeAgentId: 1 });
       useChatStore.getState().loadHistory([], 1);
 
-      // Simulate agent mid-stream with a tool call
-      useChatStore.getState().startToolCall('bash', '{"command":"ls"}', 1);
-      useChatStore.getState().setStreaming(true, 1);
-
-      // Steer: send a user message while streaming
-      useChatStore.getState().addUserMessage('change direction', undefined, undefined, 1);
-
-      const state = useChatStore.getState().agentStates.get(1);
-      // Should have 2 messages: the snapshot (partial assistant) + user message
-      expect(state?.messages).toHaveLength(2);
-      expect(state?.messages[0].role).toBe('assistant');
-      expect(state?.messages[0].turnEvents).toHaveLength(1);
-      expect(state?.messages[0].turnEvents?.[0].type).toBe('tool_call');
-      expect(state?.messages[1].role).toBe('user');
-      expect(state?.messages[1].content).toBe('change direction');
-      // Streaming state should be cleared, and isWaitingForResponse stays false
-      expect(state?.currentTurnEvents).toHaveLength(0);
-      expect(state?.currentAssistantMessage).toBeNull();
-      expect(state?.isWaitingForResponse).toBe(false);
-    });
-
-    it('does not snapshot when agent is idle (normal send)', () => {
-      useChatStore.setState({ activeAgentId: 1 });
-      useChatStore.getState().loadHistory([], 1);
-
-      // Agent is idle (not streaming)
-      useChatStore.getState().addUserMessage('hello', undefined, undefined, 1);
+      const id = useChatStore.getState().addUserMessage('hello', 1);
 
       const state = useChatStore.getState().agentStates.get(1);
       expect(state?.messages).toHaveLength(1);
-      expect(state?.messages[0].role).toBe('user');
+      expect(state?.messages[0]).toMatchObject({ role: 'user', content: 'hello', id });
       expect(state?.isWaitingForResponse).toBe(true);
     });
 
-    it('snapshots partial assistant text along with turn events', () => {
+    it('skips the waiting indicator when steering mid-stream', () => {
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore.getState().loadHistory([], 1);
+      useChatStore.getState().setStreaming(true, 1);
+
+      useChatStore.getState().addUserMessage('change direction', 1);
+
+      const state = useChatStore.getState().agentStates.get(1);
+      // Local commit is just the user row; the partial assistant arrives via
+      // chat_message_added → appendMessage when the server's history-capture
+      // pushes it. We don't snapshot client-side any more.
+      expect(state?.messages).toHaveLength(1);
+      expect(state?.messages[0].role).toBe('user');
+      expect(state?.isWaitingForResponse).toBe(false);
+    });
+
+    it('returns an id even when no agent is selected', () => {
+      // Ensures Chat.tsx can pass an id to the WS send regardless of target state.
+      useChatStore.setState({ activeAgentId: null });
+      const id = useChatStore.getState().addUserMessage('hi');
+      expect(typeof id).toBe('string');
+      expect(id.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('appendMessage (server-driven canonical insert)', () => {
+    it('appends a system message from chat_message_added', () => {
+      useChatStore.getState().loadHistory([], 1);
+      useChatStore.setState({ activeAgentId: 1 });
+
+      const fullContent =
+        '401 auth error, switched to google\n\non anthropic, switching to google\n\n401 {...}\n\nRun `system2 config` to refresh anthropic authentication and restart the server.';
+      useChatStore
+        .getState()
+        .appendMessage({ id: 'sys-1', role: 'system', content: fullContent, timestamp: 1 }, 1);
+
+      const state = useChatStore.getState().agentStates.get(1);
+      expect(state?.messages).toHaveLength(1);
+      expect(state?.messages[0].content).toBe(fullContent);
+      // Tag/body split (rendered by SystemMessageBlock) lives below the first
+      // double-newline — the hint must be reachable that way.
+      expect(state?.messages[0].content).toContain('Run `system2 config`');
+    });
+
+    it('dedups by id (originating-tab echo)', () => {
       useChatStore.setState({ activeAgentId: 1 });
       useChatStore.getState().loadHistory([], 1);
 
-      // Simulate agent mid-stream with thinking + partial text
+      const id = useChatStore.getState().addUserMessage('hello', 1);
+      // Server echoes the user message back with the same id.
+      useChatStore
+        .getState()
+        .appendMessage({ id, role: 'user', content: 'hello', timestamp: 1 }, 1);
+
+      const state = useChatStore.getState().agentStates.get(1);
+      expect(state?.messages).toHaveLength(1);
+    });
+
+    it('clears the streaming draft when a canonical assistant row arrives', () => {
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore.getState().loadHistory([], 1);
+
       useChatStore.getState().startThinking(1);
       useChatStore.getState().appendThinkingChunk('analyzing...', 1);
       useChatStore.getState().finishThinking(1);
       useChatStore.getState().startAssistantMessage(1);
-      useChatStore.getState().appendAssistantChunk('Here is my partial', 1);
+      useChatStore.getState().appendAssistantChunk('Here is the answer', 1);
 
-      useChatStore.getState().addUserMessage('actually do X', undefined, undefined, 1);
-
-      const state = useChatStore.getState().agentStates.get(1);
-      expect(state?.messages).toHaveLength(2);
-      expect(state?.messages[0].role).toBe('assistant');
-      expect(state?.messages[0].content).toBe('Here is my partial');
-      expect(state?.messages[0].turnEvents).toHaveLength(1);
-      expect(state?.messages[0].turnEvents?.[0].type).toBe('thinking');
-      expect(state?.messages[1].role).toBe('user');
-    });
-  });
-
-  describe('addSystemMessage', () => {
-    it('routes to specified agentId instead of activeAgentId', () => {
-      useChatStore.getState().loadHistory([], 1);
-      useChatStore.getState().loadHistory([], 2);
-      useChatStore.setState({ activeAgentId: 1 });
-
-      // System message targets agent 2 (background agent failover)
-      useChatStore
-        .getState()
-        .addSystemMessage('429 rate_limit on google, switching to anthropic', 2);
-
-      // Agent 2 should have the message
-      const state2 = useChatStore.getState().agentStates.get(2);
-      expect(state2?.messages).toHaveLength(1);
-      expect(state2?.messages[0].role).toBe('system');
-      expect(state2?.messages[0].content).toContain('rate_limit');
-
-      // Agent 1 (active) should not
-      const state1 = useChatStore.getState().agentStates.get(1);
-      expect(state1?.messages).toHaveLength(0);
-    });
-
-    it('defaults to activeAgentId when agentId is omitted', () => {
-      useChatStore.getState().loadHistory([], 1);
-      useChatStore.setState({ activeAgentId: 1 });
-
-      useChatStore.getState().addSystemMessage('something happened');
+      useChatStore.getState().appendMessage(
+        {
+          id: 'asst-1',
+          role: 'assistant',
+          content: 'Here is the answer',
+          timestamp: 1,
+          turnEvents: [
+            {
+              type: 'thinking',
+              data: { id: 't', content: 'analyzing...', isStreaming: false, timestamp: 1 },
+            },
+          ],
+        },
+        1
+      );
 
       const state = useChatStore.getState().agentStates.get(1);
       expect(state?.messages).toHaveLength(1);
-      expect(state?.messages[0].role).toBe('system');
-    });
-  });
-
-  describe('finishAssistantMessage', () => {
-    it('preserves orphaned turn events when content is empty', () => {
-      useChatStore.setState({ activeAgentId: 1 });
-      useChatStore.getState().loadHistory([], 1);
-
-      // Simulate a tool call with no follow-up text (model returned empty content)
-      useChatStore.getState().startToolCall('read_system2_db', '{"sql":"SELECT 1"}', 1);
-      useChatStore.getState().finishToolCall('read_system2_db', '[{"id":1}]', 1);
-
-      // Finish with no assistant text
-      useChatStore.getState().finishAssistantMessage(1);
-
-      const state = useChatStore.getState().agentStates.get(1);
-      // Should have committed a message with turn events even though content is empty
-      expect(state?.messages).toHaveLength(1);
       expect(state?.messages[0].role).toBe('assistant');
-      expect(state?.messages[0].content).toBe('');
-      expect(state?.messages[0].turnEvents).toHaveLength(1);
-      expect(state?.messages[0].turnEvents?.[0].type).toBe('tool_call');
-      // Turn events should be cleared from current state
+      expect(state?.currentAssistantMessage).toBeNull();
       expect(state?.currentTurnEvents).toHaveLength(0);
+      expect(state?.activeThinkingId).toBeNull();
     });
+  });
 
-    it('does nothing when both content and turn events are empty', () => {
-      useChatStore.setState({ activeAgentId: 1 });
-      useChatStore.getState().loadHistory([], 1);
-
-      useChatStore.getState().finishAssistantMessage(1);
-
-      const state = useChatStore.getState().agentStates.get(1);
-      expect(state?.messages).toHaveLength(0);
-    });
-
-    it('commits normally when content exists', () => {
+  describe('clearAssistantDraft', () => {
+    it('clears a no-content turn safely', () => {
       useChatStore.setState({ activeAgentId: 1 });
       useChatStore.getState().loadHistory([], 1);
 
       useChatStore.getState().startAssistantMessage(1);
-      useChatStore.getState().appendAssistantChunk('Hello', 1);
-      useChatStore.getState().startToolCall('bash', '{}', 1);
-      useChatStore.getState().finishToolCall('bash', 'ok', 1);
-      useChatStore.getState().finishAssistantMessage(1);
+      useChatStore.getState().appendAssistantChunk('partial', 1);
+      useChatStore.getState().clearAssistantDraft(1);
 
       const state = useChatStore.getState().agentStates.get(1);
-      expect(state?.messages).toHaveLength(1);
-      expect(state?.messages[0].content).toBe('Hello');
-      expect(state?.messages[0].turnEvents).toHaveLength(1);
+      expect(state?.messages).toHaveLength(0);
+      expect(state?.currentAssistantMessage).toBeNull();
+      expect(state?.currentTurnEvents).toHaveLength(0);
     });
   });
 

--- a/src/ui/stores/chat.test.ts
+++ b/src/ui/stores/chat.test.ts
@@ -281,18 +281,45 @@ describe('useChatStore', () => {
       expect(state?.isWaitingForResponse).toBe(false);
     });
 
-    it('dedups by id (originating-tab echo)', () => {
+    it('replaces in place on id match (originating-tab echo adopts server canonical fields)', () => {
+      // Local optimistic insert stamps timestamp with the browser clock; the
+      // server's chat_message_added carries the server clock. Other tabs see
+      // the server version. To keep all tabs identical, the originating tab
+      // must overwrite its local row with the server's canonical version on
+      // id match — not just dedup and keep the local copy.
       useChatStore.setState({ activeAgentId: 1 });
       useChatStore.getState().loadHistory([], 1);
 
       const id = useChatStore.getState().addUserMessage('hello', 1);
-      // Server echoes the user message back with the same id.
+      const before = useChatStore.getState().agentStates.get(1);
+      const localTimestamp = before?.messages[0].timestamp;
+      // Force a different server timestamp by passing an explicit one.
+      const serverTimestamp = (localTimestamp ?? 0) + 50;
       useChatStore
         .getState()
-        .appendMessage({ id, role: 'user', content: 'hello', timestamp: 1 }, 1);
+        .appendMessage({ id, role: 'user', content: 'hello', timestamp: serverTimestamp }, 1);
 
       const state = useChatStore.getState().agentStates.get(1);
       expect(state?.messages).toHaveLength(1);
+      expect(state?.messages[0].timestamp).toBe(serverTimestamp);
+    });
+
+    it('does not flip isWaitingForResponse when the same id is echoed back', () => {
+      // The originating tab's addUserMessage already set the indicator;
+      // appendMessage replacing the row should not re-touch it. Otherwise a
+      // ready_for_input arriving in the (very small) window between the
+      // local insert and the server echo would be re-clobbered.
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore.getState().loadHistory([], 1);
+
+      const id = useChatStore.getState().addUserMessage('hi', 1);
+      // Pretend the turn already ended (ready_for_input cleared the flag).
+      useChatStore.getState().setWaitingForResponse(false, 1);
+
+      useChatStore.getState().appendMessage({ id, role: 'user', content: 'hi', timestamp: 1 }, 1);
+
+      const state = useChatStore.getState().agentStates.get(1);
+      expect(state?.isWaitingForResponse).toBe(false);
     });
 
     it('clears the streaming draft when a canonical assistant row arrives', () => {

--- a/src/ui/stores/chat.test.ts
+++ b/src/ui/stores/chat.test.ts
@@ -182,19 +182,25 @@ describe('useChatStore', () => {
       expect(state?.isWaitingForResponse).toBe(true);
     });
 
-    it('skips the waiting indicator when steering mid-stream', () => {
+    it('skips the optimistic insert when steering mid-stream', () => {
+      // Server flushPartialTurn() pushes the assistant partial to chatCache
+      // BEFORE the steering user row, so the persisted order is
+      // [assistant_partial, user_steering]. If we inserted the user row
+      // locally first, chat_message_added's tail-append would put the
+      // assistant partial AFTER the user row in the UI — disagreeing with the
+      // persisted view. Skipping the optimistic insert lets both rows arrive
+      // via chat_message_added in correct order.
       useChatStore.setState({ activeAgentId: 1 });
       useChatStore.getState().loadHistory([], 1);
       useChatStore.getState().setStreaming(true, 1);
 
-      useChatStore.getState().addUserMessage('change direction', 1);
+      const id = useChatStore.getState().addUserMessage('change direction', 1);
 
       const state = useChatStore.getState().agentStates.get(1);
-      // Local commit is just the user row; the partial assistant arrives via
-      // chat_message_added → appendMessage when the server's history-capture
-      // pushes it. We don't snapshot client-side any more.
-      expect(state?.messages).toHaveLength(1);
-      expect(state?.messages[0].role).toBe('user');
+      expect(state?.messages).toHaveLength(0);
+      // The id is still returned so Chat.tsx can pass it to the server.
+      expect(typeof id).toBe('string');
+      expect(id.length).toBeGreaterThan(0);
       expect(state?.isWaitingForResponse).toBe(false);
     });
 
@@ -224,6 +230,36 @@ describe('useChatStore', () => {
       // Tag/body split (rendered by SystemMessageBlock) lives below the first
       // double-newline — the hint must be reachable that way.
       expect(state?.messages[0].content).toContain('Run `system2 config`');
+    });
+
+    it('sets isWaitingForResponse when a user row arrives from the wire and the agent is idle', () => {
+      // Covers (a) the steering case on the originating tab — local insert
+      // skipped, the user row arrives via chat_message_added — and (b) other
+      // tabs receiving a user message sent from a sibling tab.
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore.getState().loadHistory([], 1);
+
+      useChatStore
+        .getState()
+        .appendMessage({ id: 'u-1', role: 'user', content: 'hi', timestamp: 1 }, 1);
+
+      const state = useChatStore.getState().agentStates.get(1);
+      expect(state?.messages).toHaveLength(1);
+      expect(state?.isWaitingForResponse).toBe(true);
+    });
+
+    it('does NOT flip isWaitingForResponse when a user row arrives while already streaming (steering case)', () => {
+      // Mid-stream the spinner is driven by isStreaming, not isWaitingForResponse.
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore.getState().loadHistory([], 1);
+      useChatStore.getState().setStreaming(true, 1);
+
+      useChatStore
+        .getState()
+        .appendMessage({ id: 'u-1', role: 'user', content: 'steer', timestamp: 1 }, 1);
+
+      const state = useChatStore.getState().agentStates.get(1);
+      expect(state?.isWaitingForResponse).toBe(false);
     });
 
     it('dedups by id (originating-tab echo)', () => {

--- a/src/ui/stores/chat.test.ts
+++ b/src/ui/stores/chat.test.ts
@@ -128,6 +128,25 @@ describe('useChatStore', () => {
       expect(state?.messages[1].id).toBe('live-1');
     });
 
+    it('preserves isWaitingForResponse on snapshot reload (pre-stream waiting state)', () => {
+      // Scenario: user just sent a message (isWaitingForResponse=true), but
+      // the agent hasn't started streaming yet. A new chat_history snapshot
+      // arrives (e.g. tab switches agents and back). If we cleared the flag
+      // here, the next submit would be classified as a fresh user_message
+      // instead of a steering_message, and the spinner would disappear.
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore.getState().loadHistory([], 1);
+      useChatStore.getState().setWaitingForResponse(true, 1);
+
+      useChatStore
+        .getState()
+        .loadHistory([{ id: 'snap-1', role: 'user', content: 'hi', timestamp: 1 }], 1);
+
+      const state = useChatStore.getState().agentStates.get(1);
+      expect(state?.isWaitingForResponse).toBe(true);
+      expect(state?.messages).toHaveLength(1);
+    });
+
     it('snapshot dedups against existing rows that ARE present in it', () => {
       // The same push can land in BOTH the live event and the subsequent
       // snapshot (id is the same). loadHistory must not duplicate.

--- a/src/ui/stores/chat.test.ts
+++ b/src/ui/stores/chat.test.ts
@@ -322,6 +322,47 @@ describe('useChatStore', () => {
       expect(state?.isWaitingForResponse).toBe(false);
     });
 
+    it('does NOT clear the streaming draft when a follow-up assistant row arrives', () => {
+      // Steering during tool use: turn 1 was flushed with a running tool;
+      // turn 2 is now streaming. When the flushed tool finishes,
+      // history-capture pushes a follow-up assistant row. Clearing the draft
+      // here would drop turn 2's in-flight chunks/turnEvents.
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore.getState().loadHistory([], 1);
+      useChatStore.getState().startAssistantMessage(1);
+      useChatStore.getState().appendAssistantChunk('turn 2 streaming...', 1);
+
+      useChatStore.getState().appendMessage(
+        {
+          id: 'follow-up-1',
+          role: 'assistant',
+          content: '',
+          timestamp: 1,
+          isFollowUp: true,
+          turnEvents: [
+            {
+              type: 'tool_call',
+              data: {
+                id: 't',
+                name: 'bash',
+                status: 'completed' as const,
+                input: 'ls',
+                result: 'a.txt',
+                timestamp: 1,
+              },
+            },
+          ],
+        },
+        1
+      );
+
+      const state = useChatStore.getState().agentStates.get(1);
+      // Row appended, but the turn 2 draft is intact.
+      expect(state?.messages).toHaveLength(1);
+      expect(state?.messages[0].id).toBe('follow-up-1');
+      expect(state?.currentAssistantMessage).toBe('turn 2 streaming...');
+    });
+
     it('clears the streaming draft when a canonical assistant row arrives', () => {
       useChatStore.setState({ activeAgentId: 1 });
       useChatStore.getState().loadHistory([], 1);

--- a/src/ui/stores/chat.test.ts
+++ b/src/ui/stores/chat.test.ts
@@ -105,6 +105,45 @@ describe('useChatStore', () => {
       expect(state?.currentTurnEvents).toHaveLength(1);
       expect(state?.currentTurnEvents[0].type).toBe('tool_call');
     });
+
+    it('merges existing rows that arrived before the snapshot (no drop on subscribe-then-snapshot race)', () => {
+      // On switch_agent the server subscribes to chatCache BEFORE sending the
+      // snapshot; if a push lands in between, the UI sees chat_message_added
+      // first and then chat_history. Without a merge, loadHistory would
+      // overwrite messages and drop the row delivered via appendMessage.
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore
+        .getState()
+        .appendMessage({ id: 'live-1', role: 'system', content: 'arrived live', timestamp: 2 }, 1);
+
+      useChatStore
+        .getState()
+        .loadHistory([{ id: 'snap-1', role: 'user', content: 'in snapshot', timestamp: 1 }], 1);
+
+      const state = useChatStore.getState().agentStates.get(1);
+      expect(state?.messages).toHaveLength(2);
+      // Snapshot stays at the head (preserves persisted order); the live row
+      // that wasn't in the snapshot is appended at the tail.
+      expect(state?.messages[0].id).toBe('snap-1');
+      expect(state?.messages[1].id).toBe('live-1');
+    });
+
+    it('snapshot dedups against existing rows that ARE present in it', () => {
+      // The same push can land in BOTH the live event and the subsequent
+      // snapshot (id is the same). loadHistory must not duplicate.
+      useChatStore.setState({ activeAgentId: 1 });
+      useChatStore
+        .getState()
+        .appendMessage({ id: 'm1', role: 'user', content: 'hello', timestamp: 1 }, 1);
+
+      useChatStore
+        .getState()
+        .loadHistory([{ id: 'm1', role: 'user', content: 'hello', timestamp: 1 }], 1);
+
+      const state = useChatStore.getState().agentStates.get(1);
+      expect(state?.messages).toHaveLength(1);
+      expect(state?.messages[0].id).toBe('m1');
+    });
   });
 
   describe('clearAllStreamingState', () => {

--- a/src/ui/stores/chat.ts
+++ b/src/ui/stores/chat.ts
@@ -226,19 +226,30 @@ export const useChatStore = create<ChatState>()(
               existing.currentTurnEvents.length > 0 ||
               existing.currentAssistantMessage);
 
+          // Merge the snapshot with any rows that already arrived via
+          // appendMessage (chat_message_added). Snapshot is the canonical
+          // base (preserves the persisted order); anything in current that
+          // isn't in the snapshot — by id — is appended at the tail. This
+          // makes the listener-then-snapshot window of the constructor /
+          // switch_agent flow robust: a push that lands between subscribe
+          // and snapshot won't be dropped by loadHistory overwriting messages.
+          const snapshotIds = new Set(messages.map((m) => m.id));
+          const tail = existing?.messages.filter((m) => !snapshotIds.has(m.id)) ?? [];
+          const merged = tail.length > 0 ? [...messages, ...tail] : messages;
+
           // If agent has in-progress work (e.g., switching back to a busy agent),
           // only update committed messages and preserve streaming state.
           if (hasInProgress) {
             return {
               agentStates: updateAgentState(state.agentStates, agentId, () => ({
-                messages,
+                messages: merged,
               })),
             };
           }
 
           return {
             agentStates: updateAgentState(state.agentStates, agentId, () => ({
-              messages,
+              messages: merged,
               currentAssistantMessage: null,
               currentTurnEvents: [],
               activeThinkingId: null,

--- a/src/ui/stores/chat.ts
+++ b/src/ui/stores/chat.ts
@@ -196,24 +196,30 @@ export const useChatStore = create<ChatState>()(
 
         set((state) => {
           const current = state.agentStates.get(targetId) ?? createDefaultAgentState();
-          // Dedup-by-id: covers (a) the originating tab's optimistic insert
+          // Match-by-id covers (a) the originating tab's optimistic insert
           // echoed back by chat_message_added, and (b) any race between the
-          // initial chat_history snapshot and live pushes that arrived during
-          // the subscribe-then-snapshot window.
-          if (current.messages.some((m) => m.id === message.id)) {
-            return state;
-          }
+          // initial chat_history snapshot and live pushes during the
+          // subscribe-then-snapshot window. On match we REPLACE in place
+          // rather than ignore: the server is the source of truth for
+          // canonical fields (notably `timestamp`, which the local optimistic
+          // insert stamped with the browser clock), so all tabs end up
+          // rendering the same row. Order is preserved by index-based replace.
+          const existingIdx = current.messages.findIndex((m) => m.id === message.id);
+          const isUpdate = existingIdx >= 0;
+          const newMessages = isUpdate
+            ? current.messages.map((m, i) => (i === existingIdx ? message : m))
+            : [...current.messages, message];
+
           const isCanonicalAssistant = message.role === 'assistant';
           // A user row arriving via the wire (steering on the originating tab,
           // or any user message from another tab) means the agent is about to
           // start a turn — flip the indicator on, unless we're already
-          // streaming (steering during an in-flight turn keeps the existing
-          // streaming spinner). Mirrors the non-steering branch of
-          // addUserMessage so behavior is identical across tabs.
-          const startsTurn = message.role === 'user' && !current.isStreaming;
+          // streaming or this is the echo of a row the originating tab already
+          // inserted (its addUserMessage call already set the indicator).
+          const startsTurn = !isUpdate && message.role === 'user' && !current.isStreaming;
           return {
             agentStates: updateAgentState(state.agentStates, targetId, () => ({
-              messages: [...current.messages, message],
+              messages: newMessages,
               // The canonical assistant row arrives with text + turnEvents
               // baked in; the streaming draft becomes redundant.
               ...(isCanonicalAssistant

--- a/src/ui/stores/chat.ts
+++ b/src/ui/stores/chat.ts
@@ -232,9 +232,15 @@ export const useChatStore = create<ChatState>()(
       loadHistory: (messages: Message[], agentId: number) => {
         set((state) => {
           const existing = state.agentStates.get(agentId);
+          // isWaitingForResponse is set when a user row arrives without an
+          // assistant turn yet having started; if we cleared it here a
+          // snapshot landing mid-wait would make the UI look idle and a
+          // subsequent submit would be classified as a fresh user_message
+          // instead of a steering_message.
           const hasInProgress =
             existing &&
             (existing.isStreaming ||
+              existing.isWaitingForResponse ||
               existing.currentTurnEvents.length > 0 ||
               existing.currentAssistantMessage);
 

--- a/src/ui/stores/chat.ts
+++ b/src/ui/stores/chat.ts
@@ -169,21 +169,24 @@ export const useChatStore = create<ChatState>()(
         const agentState = get().agentStates.get(targetId);
         const isSteering = agentState?.isStreaming ?? false;
 
-        const message: Message = {
-          id,
-          role: 'user',
-          content,
-          timestamp: Date.now(),
-        };
-        set((state) => ({
-          agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
-            messages: [...s.messages, message],
-            // Steering: leave the draft alone; the server's history-capture
-            // will push the partial assistant row via chat_message_added.
-            // Non-steering: a brand-new turn — set waiting indicator.
-            isWaitingForResponse: !isSteering,
-          })),
-        }));
+        // Steering: skip the optimistic local insert. The server runs
+        // flushPartialTurn() BEFORE pushing the user row, so the canonical
+        // chatCache order is [assistant_partial, user_steering]. If we
+        // inserted the user row locally first, chat_message_added's append
+        // (which only ever appends at the tail) would land the assistant
+        // partial AFTER the user row, contradicting the persisted view.
+        // Letting both rows arrive via chat_message_added preserves order.
+        // Cost: a single WS round-trip before the user's text appears in the
+        // chat (~tens of ms on localhost) — acceptable for the rare steer.
+        if (!isSteering) {
+          const message: Message = { id, role: 'user', content, timestamp: Date.now() };
+          set((state) => ({
+            agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
+              messages: [...s.messages, message],
+              isWaitingForResponse: true,
+            })),
+          }));
+        }
         return id;
       },
 
@@ -201,6 +204,13 @@ export const useChatStore = create<ChatState>()(
             return state;
           }
           const isCanonicalAssistant = message.role === 'assistant';
+          // A user row arriving via the wire (steering on the originating tab,
+          // or any user message from another tab) means the agent is about to
+          // start a turn — flip the indicator on, unless we're already
+          // streaming (steering during an in-flight turn keeps the existing
+          // streaming spinner). Mirrors the non-steering branch of
+          // addUserMessage so behavior is identical across tabs.
+          const startsTurn = message.role === 'user' && !current.isStreaming;
           return {
             agentStates: updateAgentState(state.agentStates, targetId, () => ({
               messages: [...current.messages, message],
@@ -213,6 +223,7 @@ export const useChatStore = create<ChatState>()(
                     activeThinkingId: null,
                   }
                 : {}),
+              ...(startsTurn ? { isWaitingForResponse: true } : {}),
             })),
           };
         });

--- a/src/ui/stores/chat.ts
+++ b/src/ui/stores/chat.ts
@@ -3,11 +3,21 @@
  *
  * Zustand store for managing chat messages and connection state.
  * Supports per-agent state: each agent has its own message history
- * and streaming state. The active agent determines
- * which state is displayed in the UI.
+ * and streaming state. The active agent determines which state is displayed.
  *
- * The server is the source of truth for message history.
- * On WebSocket connect, the server sends chat_history with recent messages.
+ * The server's chatCache is the single source of truth for committed messages.
+ * Two paths populate `messages[]`:
+ *   - `loadHistory(...)`: full snapshot on connect / agent switch.
+ *   - `appendMessage(msg, agentId)`: incremental row from `chat_message_added`.
+ * Both are dedup-by-id. Streaming events (assistant chunks, tool calls) build a
+ * TRANSIENT draft (`currentAssistantMessage`, `currentTurnEvents`) above the
+ * committed list; when the canonical assistant message arrives via
+ * `appendMessage`, the draft is cleared atomically with the append.
+ *
+ * `addUserMessage` is an optimistic insert used by the originating tab for
+ * instant feedback; the server reuses the client-provided id so the echoed
+ * `chat_message_added` dedups cleanly.
+ *
  * Active agent selection is persisted to localStorage so it survives refreshes.
  */
 
@@ -77,12 +87,12 @@ interface ChatState {
   getActiveState: () => PerAgentState;
 
   // Actions (agentId optional, defaults to active agent)
-  addUserMessage: (content: string, id?: string, timestamp?: number, agentId?: number) => void;
-  addSystemMessage: (content: string, agentId?: number) => void;
+  addUserMessage: (content: string, agentId?: number) => string; // Returns the generated id (for server reuse)
+  appendMessage: (message: Message, agentId?: number) => void; // Server-driven canonical insert
   loadHistory: (messages: Message[], agentId: number) => void;
   startAssistantMessage: (agentId?: number) => void;
   appendAssistantChunk: (chunk: string, agentId?: number) => void;
-  finishAssistantMessage: (agentId?: number) => void;
+  clearAssistantDraft: (agentId?: number) => void; // Called on assistant_end; canonical row arrives via appendMessage
   startThinking: (agentId?: number) => void;
   appendThinkingChunk: (chunk: string, agentId?: number) => void;
   finishThinking: (agentId?: number) => void;
@@ -147,62 +157,64 @@ export const useChatStore = create<ChatState>()(
         return agentStates.get(activeAgentId) ?? EMPTY_AGENT_STATE;
       },
 
-      addUserMessage: (content: string, id?: string, timestamp?: number, agentId?: number) => {
+      addUserMessage: (content: string, agentId?: number) => {
         const targetId = agentId ?? get().activeAgentId;
-        if (targetId === null) return;
+        // Generate a stable id even when no target exists so the caller can pass
+        // it to the server; the server will use it as the ChatMessage.id, so the
+        // echoed chat_message_added dedups against this optimistic insert.
+        const id = `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        if (targetId === null) return id;
 
         const agentState = get().agentStates.get(targetId);
         const isSteering = agentState?.isStreaming ?? false;
 
-        // When steering mid-stream, commit any in-progress content so the
-        // existing thinking/tool blocks stay visible above the user's message
-        const partialMessages: Message[] = [];
-        if (isSteering && agentState) {
-          const hasTurnEvents = agentState.currentTurnEvents.length > 0;
-          const hasPartialText = !!agentState.currentAssistantMessage;
-          if (hasTurnEvents || hasPartialText) {
-            partialMessages.push({
-              id: `msg-${Date.now()}-partial`,
-              role: 'assistant',
-              content: agentState.currentAssistantMessage ?? '',
-              timestamp: Date.now(),
-              turnEvents: hasTurnEvents ? [...agentState.currentTurnEvents] : undefined,
-            });
-          }
-        }
-
         const message: Message = {
-          id: id ?? `msg-${Date.now()}`,
+          id,
           role: 'user',
-          content,
-          timestamp: timestamp ?? Date.now(),
-        };
-        set((state) => ({
-          agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
-            messages: [...s.messages, ...partialMessages, message],
-            currentAssistantMessage: null,
-            currentTurnEvents: [],
-            activeThinkingId: null,
-            isWaitingForResponse: !isSteering,
-          })),
-        }));
-      },
-
-      addSystemMessage: (content: string, agentId?: number) => {
-        const targetId = agentId ?? get().activeAgentId;
-        if (targetId === null) return;
-
-        const message: Message = {
-          id: `msg-${Date.now()}`,
-          role: 'system',
           content,
           timestamp: Date.now(),
         };
         set((state) => ({
           agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
             messages: [...s.messages, message],
+            // Steering: leave the draft alone; the server's history-capture
+            // will push the partial assistant row via chat_message_added.
+            // Non-steering: a brand-new turn — set waiting indicator.
+            isWaitingForResponse: !isSteering,
           })),
         }));
+        return id;
+      },
+
+      appendMessage: (message: Message, agentId?: number) => {
+        const targetId = agentId ?? get().activeAgentId;
+        if (targetId === null) return;
+
+        set((state) => {
+          const current = state.agentStates.get(targetId) ?? createDefaultAgentState();
+          // Dedup-by-id: covers (a) the originating tab's optimistic insert
+          // echoed back by chat_message_added, and (b) any race between the
+          // initial chat_history snapshot and live pushes that arrived during
+          // the subscribe-then-snapshot window.
+          if (current.messages.some((m) => m.id === message.id)) {
+            return state;
+          }
+          const isCanonicalAssistant = message.role === 'assistant';
+          return {
+            agentStates: updateAgentState(state.agentStates, targetId, () => ({
+              messages: [...current.messages, message],
+              // The canonical assistant row arrives with text + turnEvents
+              // baked in; the streaming draft becomes redundant.
+              ...(isCanonicalAssistant
+                ? {
+                    currentAssistantMessage: null,
+                    currentTurnEvents: [],
+                    activeThinkingId: null,
+                  }
+                : {}),
+            })),
+          };
+        });
       },
 
       loadHistory: (messages: Message[], agentId: number) => {
@@ -259,36 +271,19 @@ export const useChatStore = create<ChatState>()(
         }));
       },
 
-      finishAssistantMessage: (agentId?: number) => {
+      clearAssistantDraft: (agentId?: number) => {
         const targetId = agentId ?? get().activeAgentId;
         if (targetId === null) return;
-
-        const agentState = get().agentStates.get(targetId);
-        if (!agentState) return;
-
-        const content = agentState.currentAssistantMessage;
-        const hasTurnEvents = agentState.currentTurnEvents.length > 0;
-
-        // Commit a message when there is text content OR orphaned turn events
-        // (e.g. model returned empty content after a tool call). Without this,
-        // turn events would be silently dropped on the next user message.
-        if (content || hasTurnEvents) {
-          const message: Message = {
-            id: `msg-${Date.now()}`,
-            role: 'assistant',
-            content: content ?? '',
-            timestamp: Date.now(),
-            turnEvents: hasTurnEvents ? [...agentState.currentTurnEvents] : undefined,
-          };
-          set((state) => ({
-            agentStates: updateAgentState(state.agentStates, targetId, (s) => ({
-              messages: [...s.messages, message],
-              currentAssistantMessage: null,
-              currentTurnEvents: [],
-              activeThinkingId: null,
-            })),
-          }));
-        }
+        // Safety net for turns that produced no committed message (e.g. an
+        // immediately-aborted stream): if appendMessage already cleared the
+        // draft via the canonical assistant row, this is a no-op.
+        set((state) => ({
+          agentStates: updateAgentState(state.agentStates, targetId, () => ({
+            currentAssistantMessage: null,
+            currentTurnEvents: [],
+            activeThinkingId: null,
+          })),
+        }));
       },
 
       startThinking: (agentId?: number) => {

--- a/src/ui/stores/chat.ts
+++ b/src/ui/stores/chat.ts
@@ -210,7 +210,13 @@ export const useChatStore = create<ChatState>()(
             ? current.messages.map((m, i) => (i === existingIdx ? message : m))
             : [...current.messages, message];
 
-          const isCanonicalAssistant = message.role === 'assistant';
+          // Clear the streaming draft only on assistant rows that finalize an
+          // in-flight turn. The follow-up rows pushed by history-capture for
+          // post-flush tool completions are marked isFollowUp because by the
+          // time they arrive, the user has steered and the next turn may
+          // already be streaming — clearing the draft would drop chunks /
+          // turnEvents that belong to that new turn.
+          const isCanonicalAssistant = message.role === 'assistant' && !message.isFollowUp;
           // A user row arriving via the wire (steering on the originating tab,
           // or any user message from another tab) means the agent is about to
           // start a turn — flip the indicator on, unless we're already

--- a/src/ui/stores/chat.ts
+++ b/src/ui/stores/chat.ts
@@ -159,10 +159,11 @@ export const useChatStore = create<ChatState>()(
 
       addUserMessage: (content: string, agentId?: number) => {
         const targetId = agentId ?? get().activeAgentId;
-        // Generate a stable id even when no target exists so the caller can pass
-        // it to the server; the server will use it as the ChatMessage.id, so the
-        // echoed chat_message_added dedups against this optimistic insert.
-        const id = `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        // crypto.randomUUID(): dedup-by-id makes id uniqueness load-bearing
+        // (collisions silently drop rows). Available in every browser since
+        // ~2021 and in Node test environments. The `msg-` prefix is purely
+        // cosmetic for log-grepping.
+        const id = `msg-${crypto.randomUUID()}`;
         if (targetId === null) return id;
 
         const agentState = get().agentStates.get(targetId);


### PR DESCRIPTION
## Summary

- `MessageHistory` is now observable; `WebSocketHandler` forwards each `chatCache.push` as `chat_message_added` carrying the full `ChatMessage`. The UI mirrors `chatCache` exactly — every committed chat row (user / assistant / system / failover / LLM-error / compaction) reaches the UI through this single event.
- Steering ordering fix: history-capture exposes `flushPartial`; `WebSocketHandler.handleClientMessage` calls `host.flushPartialTurn()` before pushing the user row on `steering_message`, so the persisted order is `[assistant_partial, user_steering]` instead of racing the SDK's eventual `message_end`.
- Duplicate-error-text fix: the `"LLM error\n\n<errorMessage>"` system row (pushed by history-capture on `stopReason='error'`) is now the sole carrier of the raw error text. All five failover detail strings in `host.ts` no longer embed `errorMessage` — they carry only the routing description and the re-auth hint when applicable.

Closes #197

## Why the symptom appeared

The user-reported bug was that the `Run \`system2 config\`` hint never appeared in the chat after an OAuth 401. The hint *was* in the persisted `chatCache` (inside the failover row's collapsible body), but the live wire path was `provider_change → addSystemMessage(reason)` — which dropped the `detail` field. The live state and the persisted state had drifted because they were built by two parallel systems.

## What changed (protocol)

The server+UI ship together, so these are not breaking for any external consumer:

- **Added** `chat_message_added` server event (full `ChatMessage` payload).
- **Added** optional `id` on `user_message` / `steering_message` client events; server reuses it as `ChatMessage.id`, so the originating tab's optimistic insert dedups against its own echo.
- **Removed** `user_message_broadcast` (folded into `chat_message_added`).
- **Removed** `provider_change.reason` (chat row arrives via `chat_message_added`; event is now indicator-only).
- **Removed** `assistant_end.errorMessage` (LLM-error row arrives via `chat_message_added` from history-capture).

## What changed (UI store)

- `appendMessage(message, agentId)` is the canonical insertion path — dedup-by-id, clears the streaming draft when the row is an assistant.
- `addUserMessage` now returns the generated id so `Chat.tsx` can pass it to the WS send for echo dedup.
- `finishAssistantMessage` removed (server-driven now); replaced with `clearAssistantDraft` as a safety net on `assistant_end`.
- `addSystemMessage` external API removed (server pushes; UI receives).

## Invariant after this PR

> Anything visible as a row in the chat lives in `MessageHistory`. The UI's committed-message list mirrors it exactly. Streaming events drive a transient draft above the committed list; the canonical row arrives via `chat_message_added`.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm check` — clean (one pre-existing warning on `bash.test.ts`, unrelated)
- [x] `pnpm test` — 1118/1118 pass (5 new tests cover `flushPartial` and the steering flush call order)
- [x] `pnpm build` — clean
- [ ] Manual: trigger a 401 from Anthropic OAuth in dev; confirm the failover row's body contains the `system2 config` hint live (no reload needed) and that the LLM-error row + failover row each appear once with the error text in only the former.
- [ ] Manual: steer mid-stream; confirm the persisted chat shows `[assistant_partial, user_steering]` after reload.
- [ ] Manual: two tabs open on the same agent; send from tab A; confirm tab B sees the message via `chat_message_added` (not a doubled row in tab A).