### PR TITLE
feat(ui): render Markdown frontmatter as a blockquote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Markdown frontmatter now renders as a blockquote of its raw `key: value` lines instead of being mangled. A leading `---` block was previously parsed as a setext-heading underline, so a skill or artifact's `name`/`description` frontmatter rendered as one giant heading at the top of the document. The shared `Markdown` component now runs `remark-frontmatter` (which parses the block into a `yaml` node) plus a small `remarkFrontmatterBlockquote` transform that renders that node as a blockquote, mirroring how the frontmatter is written in the source.
+
 ## [0.5.0] - 2026-06-05
 
 ### Added

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -4,7 +4,7 @@ React web interface providing a real-time chat experience with artifact display.
 
 **Source:** `src/ui/`
 **Build:** [Vite](https://vite.dev/) (part of `pnpm build`)
-**Dependencies:** [React 18](https://react.dev/), [Zustand](https://github.com/pmndrs/zustand), [Primer React](https://primer.style/react), [react-markdown](https://github.com/remarkjs/react-markdown). The shared `Markdown` wrapper always applies [remark-gfm](https://github.com/remarkjs/remark-gfm) (GFM tables, strikethrough, autolinks, task lists) and [remark-math](https://github.com/remarkjs/remark-math) + [rehype-katex](https://katex.org/) for LaTeX. Math uses `$$…$$` delimiters (single `$` is disabled so currency like `$5` stays literal); `$$…$$` renders inline within text, or as a display block on its own lines. Heading `id`s ([rehype-slug](https://github.com/rehypejs/rehype-slug)) are opt-in via the `enableHeadingIds` prop, enabled only in the artifact viewer so in-page `#anchor` links resolve there (off elsewhere to avoid duplicate ids across the many `Markdown` instances on a page).
+**Dependencies:** [React 18](https://react.dev/), [Zustand](https://github.com/pmndrs/zustand), [Primer React](https://primer.style/react), [react-markdown](https://github.com/remarkjs/react-markdown). The shared `Markdown` wrapper always applies [remark-gfm](https://github.com/remarkjs/remark-gfm) (GFM tables, strikethrough, autolinks, task lists), [remark-frontmatter](https://github.com/remarkjs/remark-frontmatter) plus a `remarkFrontmatterBlockquote` transform (a leading `---` block renders as a blockquote of its raw `key: value` lines rather than being mis-parsed as a giant setext heading), and [remark-math](https://github.com/remarkjs/remark-math) + [rehype-katex](https://katex.org/) for LaTeX. Math uses `$$…$$` delimiters (single `$` is disabled so currency like `$5` stays literal); `$$…$$` renders inline within text, or as a display block on its own lines. Heading `id`s ([rehype-slug](https://github.com/rehypejs/rehype-slug)) are opt-in via the `enableHeadingIds` prop, enabled only in the artifact viewer so in-page `#anchor` links resolve there (off elsewhere to avoid duplicate ids across the many `Markdown` instances on a page).
 
 ## Source Structure
 
@@ -26,7 +26,7 @@ src/
 │   ├── TaskDetailModal.tsx # Task detail overlay (comments, links, markdown)
 │   ├── ProjectDetailModal.tsx # Project detail overlay (status, labels, dates)
 │   ├── MultiSelectDropdown.tsx # Reusable multiselect dropdown with checkboxes
-│   ├── Markdown.tsx        # Shared wrapper: remark-gfm + remark-math/rehype-katex always on; rehype-slug heading ids opt-in (artifact viewer)
+│   ├── Markdown.tsx        # Shared wrapper: remark-gfm + remark-frontmatter (→ blockquote) + remark-math/rehype-katex always on; rehype-slug heading ids opt-in (artifact viewer)
 │   └── ParticlesBackground.tsx # Animated particle background (tsparticles)
 ├── hooks/
 │   ├── useWebSocket.ts    # WebSocket connection and message handling

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "react-markdown": "^10.1.0",
     "rehype-katex": "^7.0.1",
     "rehype-slug": "^6.0.0",
+    "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
     "ws": "^8.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ dependencies:
   rehype-slug:
     specifier: ^6.0.0
     version: 6.0.0
+  remark-frontmatter:
+    specifier: ^5.0.0
+    version: 5.0.0
   remark-gfm:
     specifier: ^4.0.1
     version: 4.0.1
@@ -1821,7 +1824,7 @@ packages:
       typebox: 1.1.37
       undici: 7.25.0
       uuid: 14.0.0
-      yaml: 2.8.3
+      yaml: 2.9.0
     optionalDependencies:
       '@mariozechner/clipboard': 0.3.5
     transitivePeerDependencies:
@@ -4432,6 +4435,12 @@ packages:
       strnum: 2.2.3
     dev: false
 
+  /fault@2.0.1:
+    resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
+    dependencies:
+      format: 0.2.2
+    dev: false
+
   /fd-slicer@1.1.0:
     resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
     dependencies:
@@ -4499,6 +4508,11 @@ packages:
 
   /focus-visible@5.2.1:
     resolution: {integrity: sha512-8Bx950VD1bWTQJEH/AM6SpEk+SU55aVnp4Ujhuuxy3eMEBCRwBnTBnVXr9YAPvZL3/CNjCa8u4IWfNmEO53whA==}
+    dev: false
+
+  /format@0.2.2:
+    resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
+    engines: {node: '>=0.4.x'}
     dev: false
 
   /formdata-polyfill@4.0.10:
@@ -5338,6 +5352,19 @@ packages:
       - supports-color
     dev: false
 
+  /mdast-util-frontmatter@2.0.1:
+    resolution: {integrity: sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      escape-string-regexp: 5.0.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-extension-frontmatter: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /mdast-util-gfm-autolink-literal@2.0.1:
     resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
     dependencies:
@@ -5586,6 +5613,15 @@ packages:
       micromark-util-normalize-identifier: 2.0.1
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    dev: false
+
+  /micromark-extension-frontmatter@2.0.0:
+    resolution: {integrity: sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg==}
+    dependencies:
+      fault: 2.0.1
+      micromark-util-character: 2.1.1
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
     dev: false
@@ -6670,6 +6706,17 @@ packages:
       hast-util-heading-rank: 3.0.0
       hast-util-to-string: 3.0.1
       unist-util-visit: 5.1.0
+    dev: false
+
+  /remark-frontmatter@5.0.0:
+    resolution: {integrity: sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ==}
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-frontmatter: 2.0.1
+      micromark-extension-frontmatter: 2.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /remark-gfm@4.0.1:
@@ -7884,8 +7931,8 @@ packages:
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  /yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+  /yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
     dev: false

--- a/src/ui/components/Markdown.test.tsx
+++ b/src/ui/components/Markdown.test.tsx
@@ -58,4 +58,24 @@ describe('Markdown', () => {
     expect(container.textContent).toContain('$5');
     expect(container.textContent).toContain('$10');
   });
+
+  it('renders leading frontmatter as a blockquote of its raw lines, not a heading', () => {
+    const md = '---\nname: my-skill\ndescription: Does a thing\n---\n\n# Body';
+    const { container } = render(<Markdown>{md}</Markdown>);
+
+    const quote = container.querySelector('blockquote');
+    expect(quote).not.toBeNull();
+    expect(quote?.textContent).toContain('name: my-skill');
+    expect(quote?.textContent).toContain('description: Does a thing');
+    // Lines are hard-broken so each `key: value` sits on its own line, mirroring the source.
+    expect(quote?.querySelector('br')).not.toBeNull();
+    // The fence must not become a setext heading: the only heading is the body's.
+    const headings = [...container.querySelectorAll('h1, h2')].map((h) => h.textContent);
+    expect(headings).toEqual(['Body']);
+  });
+
+  it('does not add a blockquote when there is no frontmatter', () => {
+    const { container } = render(<Markdown>{'# Title\n\nJust body text.'}</Markdown>);
+    expect(container.querySelector('blockquote')).toBeNull();
+  });
 });

--- a/src/ui/components/Markdown.tsx
+++ b/src/ui/components/Markdown.tsx
@@ -2,12 +2,19 @@ import 'katex/dist/katex.min.css';
 import ReactMarkdown, { type Options } from 'react-markdown';
 import rehypeKatex from 'rehype-katex';
 import rehypeSlug from 'rehype-slug';
+import remarkFrontmatter from 'remark-frontmatter';
 import remarkGfm from 'remark-gfm';
 import remarkMath from 'remark-math';
+import { remarkFrontmatterBlockquote } from './remarkFrontmatterBlockquote';
 
+// `remark-frontmatter` parses a leading `---` block into a `yaml` node — otherwise the fence
+// is mis-parsed as a setext heading and the metadata renders as a giant title.
+// `remarkFrontmatterBlockquote` then renders that node as a blockquote of its raw lines.
 // Disable single-`$` inline math: `$5 and $10` is currency, not an equation.
 // Math uses `$$…$$` (inline within text, or on its own lines for a display block).
 const REMARK_PLUGINS: Options['remarkPlugins'] = [
+  remarkFrontmatter,
+  remarkFrontmatterBlockquote,
   remarkGfm,
   [remarkMath, { singleDollarTextMath: false }],
 ];

--- a/src/ui/components/remarkFrontmatterBlockquote.ts
+++ b/src/ui/components/remarkFrontmatterBlockquote.ts
@@ -32,10 +32,12 @@ export function remarkFrontmatterBlockquote() {
     const node = tree.children[0];
     if (!node || node.type !== 'yaml' || typeof node.value !== 'string') return;
 
-    // `node.value` is the frontmatter body without the `---` fences. Trim trailing
-    // whitespace so a trailing newline doesn't produce a blank final line.
-    const lines = node.value.replace(/\s+$/, '').split('\n');
-    if (lines.length === 0 || (lines.length === 1 && lines[0] === '')) return;
+    // `node.value` is the frontmatter body without the `---` fences. Split on LF or CRLF so
+    // Windows line endings don't leave a stray `\r` on each line, then drop trailing blank
+    // lines (the block usually ends with a newline) so there's no empty final line.
+    const lines = node.value.split(/\r?\n/);
+    while (lines.length > 0 && lines[lines.length - 1].trim() === '') lines.pop();
+    if (lines.length === 0) return;
 
     // Plain text + hard breaks: render each line literally (no markdown interpretation of
     // values) on its own line, matching the single-spaced source layout.

--- a/src/ui/components/remarkFrontmatterBlockquote.ts
+++ b/src/ui/components/remarkFrontmatterBlockquote.ts
@@ -1,0 +1,50 @@
+/**
+ * Render document frontmatter as a blockquote of its raw lines, mirroring how the
+ * frontmatter is written in the source.
+ *
+ * `remark-frontmatter` parses the leading `---` block into a `yaml` mdast node (always the
+ * first child of the root). Two things go wrong without this transform:
+ *   - With `remark-frontmatter` alone, rehype has no handler for `yaml` nodes, so the
+ *     frontmatter silently disappears.
+ *   - Without `remark-frontmatter` at all, the `---` fence is parsed as a setext heading
+ *     underline and the whole `name:`/`description:` block renders as one giant heading.
+ *
+ * This transform replaces the leading `yaml` node with a `blockquote` whose paragraph holds
+ * the original frontmatter lines (plain text, hard-broken between lines) so it reads like the
+ * source `key: value` block. Must run after `remark-frontmatter` (which produces the node).
+ *
+ * Typed structurally to avoid pulling `mdast`/`unified` (pnpm transitive, not direct deps)
+ * into this file; the emitted shape is a valid mdast `blockquote`.
+ */
+interface MdNode {
+  type: string;
+  value?: string;
+  children?: MdNode[];
+  [key: string]: unknown;
+}
+interface MdRoot {
+  type: 'root';
+  children: MdNode[];
+}
+
+export function remarkFrontmatterBlockquote() {
+  return (tree: MdRoot): void => {
+    const node = tree.children[0];
+    if (!node || node.type !== 'yaml' || typeof node.value !== 'string') return;
+
+    // `node.value` is the frontmatter body without the `---` fences. Trim trailing
+    // whitespace so a trailing newline doesn't produce a blank final line.
+    const lines = node.value.replace(/\s+$/, '').split('\n');
+    if (lines.length === 0 || (lines.length === 1 && lines[0] === '')) return;
+
+    // Plain text + hard breaks: render each line literally (no markdown interpretation of
+    // values) on its own line, matching the single-spaced source layout.
+    const paragraph: MdNode = { type: 'paragraph', children: [] };
+    lines.forEach((line, i) => {
+      if (i > 0) paragraph.children?.push({ type: 'break' });
+      paragraph.children?.push({ type: 'text', value: line });
+    });
+
+    tree.children[0] = { type: 'blockquote', children: [paragraph] };
+  };
+}


### PR DESCRIPTION
## What

A leading `---` frontmatter block was parsed by markdown as a **setext-heading underline**, so a skill/artifact's `name`/`description` rendered as one giant heading at the top of the document (see the skill viewer).

This adds [`remark-frontmatter`](https://github.com/remarkjs/remark-frontmatter) — which parses the leading `---` block into a `yaml` node instead — plus a small `remarkFrontmatterBlockquote` transform that renders that node as a **blockquote of its raw `key: value` lines**, mirroring how the frontmatter is written in the source.

## Notes

- Applies wherever the shared `Markdown` component renders (not gated like `enableHeadingIds`). Documents without frontmatter are unaffected; body `---` thematic breaks and setext headings are unaffected (remark-frontmatter only matches a leading fenced block). One edge: a message that *starts* with a `---…---` block now renders as a blockquote — rare in chat, intended in the viewer. Happy to gate it behind a prop if you'd prefer viewer-only.
- No YAML parsing needed (the raw lines are rendered verbatim), so no extra runtime dep beyond `remark-frontmatter`.

## Tests

`Markdown.test.tsx`: frontmatter renders as a blockquote (not a heading); no blockquote added when there's no frontmatter. Full suite green (1150), `pnpm check`/`build` clean.